### PR TITLE
Add adc opcode support

### DIFF
--- a/src/cpu/cpu.rs
+++ b/src/cpu/cpu.rs
@@ -1,5 +1,6 @@
 use std::fmt;
 use super::opcodes::add::{Add16, Add8, AddSP16};
+use super::opcodes::adc::Adc;
 
 #[derive(Debug, PartialEq)]
 pub enum Error {
@@ -21,17 +22,15 @@ impl fmt::Display for Error {
 }
 
 /// This trait includes all of the various instructions that a Gameboy CPU must implement.
-/// todo: Rename to Cpu.
 pub trait Cpu {
     fn add8(&mut self, opcode: &Add8) -> Result<u8, Error>;
     fn add16(&mut self, opcode: &Add16) -> Result<u8, Error>;
     fn add_sp16(&mut self, opcode: &AddSP16) -> Result<u8, Error>;
+    fn adc(&mut self, opcode: &Adc) -> Result<u8, Error>;
 }
 
 #[cfg(test)]
 mod tests {
-    use crate::cpu::opcodes::operand;
-
     use super::*;
 
     #[test]

--- a/src/cpu/opcodes/adc.rs
+++ b/src/cpu/opcodes/adc.rs
@@ -1,0 +1,104 @@
+use super::opcode::OpCode;
+use super::operand::*;
+
+use crate::cpu::cpu::{Cpu, Error};
+
+/// Adds the value of the operand and the carry flag to the accumulator register (A).
+pub struct Adc {
+    pub operand: Operand,
+    pub cycles: u8,
+}
+
+impl OpCode for Adc {
+    fn execute(&self, cpu: &mut dyn Cpu) -> Result<u8, Error> {
+        cpu.adc(&self)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use crate::cpu::opcodes::test_util::operand_test_util::FakeCpu;
+
+    #[test]
+    fn test_execute_adc_b() {
+        let expected_cycles = 4;
+        let expected_operand = Operand::Register8(Register8::B);
+        let opcode = Adc{operand: expected_operand, cycles: expected_cycles};
+
+        FakeCpu::new().test_execute_opcode(&opcode, expected_cycles, expected_operand);
+    }
+
+    #[test]
+    fn test_execute_adc_c() {
+        let expected_cycles = 4;
+        let expected_operand = Operand::Register8(Register8::C);
+        let opcode = Adc{operand: expected_operand, cycles: expected_cycles};
+
+        FakeCpu::new().test_execute_opcode(&opcode, expected_cycles, expected_operand);
+    }
+
+    #[test]
+    fn test_execute_adc_d() {
+        let expected_cycles = 4;
+        let expected_operand = Operand::Register8(Register8::D);
+        let opcode = Adc{operand: expected_operand, cycles: expected_cycles};
+
+        FakeCpu::new().test_execute_opcode(&opcode, expected_cycles, expected_operand);
+    }
+
+    #[test]
+    fn test_execute_adc_e() {
+        let expected_cycles = 4;
+        let expected_operand = Operand::Register8(Register8::E);
+        let opcode = Adc{operand: expected_operand, cycles: expected_cycles};
+
+        FakeCpu::new().test_execute_opcode(&opcode, expected_cycles, expected_operand);
+    }
+
+    #[test]
+    fn test_execute_adc_h() {
+        let expected_cycles = 4;
+        let expected_operand = Operand::Register8(Register8::H);
+        let opcode = Adc{operand: expected_operand, cycles: expected_cycles};
+
+        FakeCpu::new().test_execute_opcode(&opcode, expected_cycles, expected_operand);
+    }
+
+    #[test]
+    fn test_execute_adc_l() {
+        let expected_cycles = 4;
+        let expected_operand = Operand::Register8(Register8::L);
+        let opcode = Adc{operand: expected_operand, cycles: expected_cycles};
+
+        FakeCpu::new().test_execute_opcode(&opcode, expected_cycles, expected_operand);
+    }
+
+    #[test]
+    fn test_execute_adc_a() {
+        let expected_cycles = 4;
+        let expected_operand = Operand::Register8(Register8::A);
+        let opcode = Adc{operand: expected_operand, cycles: expected_cycles};
+
+        FakeCpu::new().test_execute_opcode(&opcode, expected_cycles, expected_operand);
+    }
+
+    #[test]
+    fn test_execute_adc_memhl() {
+        let expected_cycles = 8;
+        let expected_operand = Operand::Memory(Memory::HL);
+        let opcode = Adc{operand: expected_operand, cycles: expected_cycles};
+
+        FakeCpu::new().test_execute_opcode(&opcode, expected_cycles, expected_operand);
+    }
+
+    #[test]
+    fn test_execute_adc_imm8() {
+        let expected_cycles = 8;
+        let expected_operand = Operand::Imm8;
+        let opcode = Adc{operand: expected_operand, cycles: expected_cycles};
+
+        FakeCpu::new().test_execute_opcode(&opcode, expected_cycles, expected_operand);
+    }
+}

--- a/src/cpu/opcodes/decoders/adc.rs
+++ b/src/cpu/opcodes/decoders/adc.rs
@@ -1,0 +1,119 @@
+use super::decoder::{Decoder, Error};
+
+use crate::cpu::opcodes::adc::Adc;
+use crate::cpu::opcodes::opcode::OpCode;
+use crate::cpu::opcodes::operand::*;
+
+pub struct AdcDecoder;
+impl Decoder for AdcDecoder {
+    fn decode(&self, opcode: u8) -> Result<Box<dyn OpCode>, Error> {
+        match opcode {
+            0x88 => Ok(Box::new(Adc { operand: Operand::Register8(Register8::B), cycles: 4 })),
+            0x89 => Ok(Box::new(Adc { operand: Operand::Register8(Register8::C), cycles: 4 })),
+            0x8A => Ok(Box::new(Adc { operand: Operand::Register8(Register8::D), cycles: 4 })),
+            0x8B => Ok(Box::new(Adc { operand: Operand::Register8(Register8::E), cycles: 4 })),
+            0x8C => Ok(Box::new(Adc { operand: Operand::Register8(Register8::H), cycles: 4 })),
+            0x8D => Ok(Box::new(Adc { operand: Operand::Register8(Register8::L), cycles: 4 })),
+            0x8E => Ok(Box::new(Adc { operand: Operand::Memory(Memory::HL), cycles: 8 })),
+            0x8F => Ok(Box::new(Adc { operand: Operand::Register8(Register8::A), cycles: 4 })),
+            0xCE => Ok(Box::new(Adc { operand: Operand::Imm8, cycles: 8 })),
+            _ => Err(Error::InvalidOpcode(opcode)),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use crate::cpu::opcodes::test_util::operand_test_util::FakeCpu;
+
+    #[test]
+    fn test_decode_adc_opcode_regb() {
+        let opcode = 0x88;
+        let expected_cycles = 4;
+        let expected_operand = Operand::Register8(Register8::B);
+
+        FakeCpu::new().test_decode_operand(opcode, &AdcDecoder, expected_cycles, expected_operand);
+    }
+
+    #[test]
+    fn test_decode_adc_opcode_regc() {
+        let opcode = 0x89;
+        let expected_cycles = 4;
+        let expected_operand = Operand::Register8(Register8::C);
+
+        FakeCpu::new().test_decode_operand(opcode, &AdcDecoder, expected_cycles, expected_operand);
+    }
+
+    #[test]
+    fn test_decode_adc_opcode_regd() {
+        let opcode = 0x8A;
+        let expected_cycles = 4;
+        let expected_operand = Operand::Register8(Register8::D);
+
+        FakeCpu::new().test_decode_operand(opcode, &AdcDecoder, expected_cycles, expected_operand);
+    }
+
+    #[test]
+    fn test_decode_adc_opcode_rege() {
+        let opcode = 0x8B;
+        let expected_cycles = 4;
+        let expected_operand = Operand::Register8(Register8::E);
+
+        FakeCpu::new().test_decode_operand(opcode, &AdcDecoder, expected_cycles, expected_operand);
+    }
+
+    #[test]
+    fn test_decode_adc_opcode_regh() {
+        let opcode = 0x8C;
+        let expected_cycles = 4;
+        let expected_operand = Operand::Register8(Register8::H);
+
+        FakeCpu::new().test_decode_operand(opcode, &AdcDecoder, expected_cycles, expected_operand);
+    }
+
+    #[test]
+    fn test_decode_adc_opcode_regl() {
+        let opcode = 0x8D;
+        let expected_cycles = 4;
+        let expected_operand = Operand::Register8(Register8::L);
+
+        FakeCpu::new().test_decode_operand(opcode, &AdcDecoder, expected_cycles, expected_operand);
+    }
+
+    #[test]
+    fn test_decode_adc_opcode_memhl() {
+        let opcode = 0x8E;
+        let expected_cycles = 8;
+        let expected_operand = Operand::Memory(Memory::HL);
+
+        FakeCpu::new().test_decode_operand(opcode, &AdcDecoder, expected_cycles, expected_operand);
+    }
+
+    #[test]
+    fn test_decode_adc_opcode_rega() {
+        let opcode = 0x8F;
+        let expected_cycles = 4;
+        let expected_operand = Operand::Register8(Register8::A);
+
+        FakeCpu::new().test_decode_operand(opcode, &AdcDecoder, expected_cycles, expected_operand);
+    }
+
+    #[test]
+    fn test_decode_adc_opcode_imm8() {
+        let opcode = 0xCE;
+        let expected_cycles = 8;
+        let expected_operand = Operand::Imm8;
+
+        FakeCpu::new().test_decode_operand(opcode, &AdcDecoder, expected_cycles, expected_operand);
+    }
+
+    #[test]
+    fn test_decode_adc_opcode_invalid() {
+        let decoder = AdcDecoder {};
+        let result = decoder.decode(0xFF);
+        assert!(result.is_err());
+    }
+}
+

--- a/src/cpu/opcodes/decoders/mod.rs
+++ b/src/cpu/opcodes/decoders/mod.rs
@@ -1,4 +1,5 @@
 pub mod decoder;
 pub mod opcode;
 
+mod adc;
 mod add;

--- a/src/cpu/opcodes/decoders/opcode.rs
+++ b/src/cpu/opcodes/decoders/opcode.rs
@@ -1,6 +1,7 @@
 use crate::cpu::opcodes::opcode::OpCode;
 
 use super::add::{Add16Decoder, Add8Decoder, AddSP16Decoder};
+use super::adc::AdcDecoder;
 use super::decoder::{Decoder, Error};
 
 pub struct OpCodeDecoder {
@@ -13,7 +14,8 @@ impl OpCodeDecoder {
             opcodes: vec![
                 Box::new(Add8Decoder {}),
                 Box::new(Add16Decoder {}),
-                Box::new(AddSP16Decoder {})
+                Box::new(AddSP16Decoder {}),
+                Box::new(AdcDecoder{} ),
             ],
         }
     }
@@ -76,6 +78,15 @@ mod tests {
         FakeCpu::new().test_decode_operand(opcode, &OpCodeDecoder::new(), expected_cycles, expected_operand);
     }
 
+    #[test]
+    fn test_from_adc_a() {
+        let opcode = 0x8F;
+        let expected_cycles = 4;
+        let expected_operand = Operand::Register8(Register8::A);
+
+        FakeCpu::new().test_decode_operand(opcode, &OpCodeDecoder::new(), expected_cycles, expected_operand);
+    }
+    
     #[test]
     fn test_invalid_opcode() {
         let opcode = 0xFF; // Example invalid opcode

--- a/src/cpu/opcodes/mod.rs
+++ b/src/cpu/opcodes/mod.rs
@@ -1,4 +1,5 @@
 pub mod add;
+pub mod adc;
 pub mod decoders;
 pub mod operand;
 

--- a/src/cpu/opcodes/test_util.rs
+++ b/src/cpu/opcodes/test_util.rs
@@ -2,6 +2,7 @@
 pub mod operand_test_util {
     use crate::cpu::cpu::{Cpu, Error};
     use crate::cpu::opcodes::add::{Add8, Add16, AddSP16};
+    use crate::cpu::opcodes::adc::Adc;
     use crate::cpu::opcodes::decoders::decoder::Decoder;
     use crate::cpu::opcodes::operand::Operand;
     use crate::cpu::opcodes::opcode::OpCode;
@@ -41,6 +42,11 @@ pub mod operand_test_util {
         }
 
         fn add_sp16(&mut self, opcode: &AddSP16) -> Result<u8, Error> {
+            self.operand = Some(opcode.operand);
+            Ok(opcode.cycles)
+        }
+
+        fn adc(&mut self, opcode: &Adc) -> Result<u8, Error> {
             self.operand = Some(opcode.operand);
             Ok(opcode.cycles)
         }


### PR DESCRIPTION
Using the established paradigm, added ADC opcode support. Utilized Cursor to generate most of the implementation.