### PR TITLE
Implement SUB instruction with TDD approach

### DIFF
--- a/src/cpu/instructions/instructions.rs
+++ b/src/cpu/instructions/instructions.rs
@@ -1,6 +1,7 @@
 use std::fmt;
 use super::add::opcode::{Add16, Add8, AddSP16};
 use super::adc::opcode::Adc;
+use super::sub::opcode::Sub8;
 
 #[derive(Debug, PartialEq)]
 pub enum Error {
@@ -26,6 +27,7 @@ pub trait Instructions {
     fn add16(&mut self, opcode: &Add16) -> Result<u8, Error>;
     fn add_sp16(&mut self, opcode: &AddSP16) -> Result<u8, Error>;
     fn adc(&mut self, opcode: &Adc) -> Result<u8, Error>;
+    fn sub8(&mut self, opcode: &Sub8) -> Result<u8, Error>;
 }
 
 #[cfg(test)]

--- a/src/cpu/instructions/mod.rs
+++ b/src/cpu/instructions/mod.rs
@@ -1,5 +1,6 @@
 pub mod adc;
 pub mod add;
+pub mod sub;
 pub mod decoder;
 pub mod opcodes;
 pub mod operand;

--- a/src/cpu/instructions/opcodes.rs
+++ b/src/cpu/instructions/opcodes.rs
@@ -1,5 +1,6 @@
 use super::adc::decoder::AdcDecoder;
 use super::add::decoder::{Add16Decoder, Add8Decoder, AddSP16Decoder};
+use super::sub::decoder::Sub8Decoder;
 use super::opcode::OpCode;
 use super::decoder::{Decoder, Error};
 
@@ -15,6 +16,7 @@ impl OpCodeDecoder {
                 Box::new(Add16Decoder {}),
                 Box::new(AddSP16Decoder {}),
                 Box::new(AdcDecoder{} ),
+                Box::new(Sub8Decoder {}),
             ],
         }
     }
@@ -82,6 +84,15 @@ mod tests {
         let opcode = 0x8F;
         let expected_cycles = 4;
         let expected_operand = Operand::Register8(Register8::A);
+
+        FakeCpu::new().test_decode_operand(opcode, &OpCodeDecoder::new(), expected_cycles, expected_operand);
+    }
+
+    #[test]
+    fn test_from_sub8_b() {
+        let opcode = 0x90;
+        let expected_cycles = 4;
+        let expected_operand = Operand::Register8(Register8::B);
 
         FakeCpu::new().test_decode_operand(opcode, &OpCodeDecoder::new(), expected_cycles, expected_operand);
     }

--- a/src/cpu/instructions/sub/decoder.rs
+++ b/src/cpu/instructions/sub/decoder.rs
@@ -1,0 +1,117 @@
+use crate::cpu::instructions::decoder::{Decoder, Error};
+use crate::cpu::instructions::opcode::OpCode;
+use crate::cpu::instructions::operand::*;
+
+use super::opcode::Sub8;
+
+pub struct Sub8Decoder;
+impl Decoder for Sub8Decoder {
+    fn decode(&self, opcode: u8) -> Result<Box<dyn OpCode>, Error> {
+        match opcode {
+            0x90 => Ok(Box::new(Sub8 { operand: Operand::Register8(Register8::B), cycles: 4 })),
+            0x91 => Ok(Box::new(Sub8 { operand: Operand::Register8(Register8::C), cycles: 4 })),
+            0x92 => Ok(Box::new(Sub8 { operand: Operand::Register8(Register8::D), cycles: 4 })),
+            0x93 => Ok(Box::new(Sub8 { operand: Operand::Register8(Register8::E), cycles: 4 })),
+            0x94 => Ok(Box::new(Sub8 { operand: Operand::Register8(Register8::H), cycles: 4 })),
+            0x95 => Ok(Box::new(Sub8 { operand: Operand::Register8(Register8::L), cycles: 4 })),
+            0x96 => Ok(Box::new(Sub8 { operand: Operand::Memory(Memory::HL), cycles: 8 })),
+            0x97 => Ok(Box::new(Sub8 { operand: Operand::Register8(Register8::A), cycles: 4 })),
+            0xD6 => Ok(Box::new(Sub8 { operand: Operand::Imm8, cycles: 8 })),
+            _ => Err(Error::InvalidOpcode(opcode)),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use crate::cpu::instructions::test::util::FakeCpu;
+
+    #[test]
+    fn test_decode_sub8_b() {
+        let opcode = 0x90;
+        let expected_cycles = 4;
+        let expected_operand = Operand::Register8(Register8::B);
+
+        FakeCpu::new().test_decode_operand(opcode, &Sub8Decoder, expected_cycles, expected_operand);
+    }
+
+    #[test]
+    fn test_decode_sub8_c() {
+        let opcode = 0x91;
+        let expected_cycles = 4;
+        let expected_operand = Operand::Register8(Register8::C);
+
+        FakeCpu::new().test_decode_operand(opcode, &Sub8Decoder, expected_cycles, expected_operand);
+    }
+
+    #[test]
+    fn test_decode_sub8_d() {
+        let opcode = 0x92;
+        let expected_cycles = 4;
+        let expected_operand = Operand::Register8(Register8::D);
+
+        FakeCpu::new().test_decode_operand(opcode, &Sub8Decoder, expected_cycles, expected_operand);
+    }
+
+    #[test]
+    fn test_decode_sub8_e() {
+        let opcode = 0x93;
+        let expected_cycles = 4;
+        let expected_operand = Operand::Register8(Register8::E);
+
+        FakeCpu::new().test_decode_operand(opcode, &Sub8Decoder, expected_cycles, expected_operand);
+    }
+
+    #[test]
+    fn test_decode_sub8_h() {
+        let opcode = 0x94;
+        let expected_cycles = 4;
+        let expected_operand = Operand::Register8(Register8::H);
+
+        FakeCpu::new().test_decode_operand(opcode, &Sub8Decoder, expected_cycles, expected_operand);
+    }
+
+    #[test]
+    fn test_decode_sub8_l() {
+        let opcode = 0x95;
+        let expected_cycles = 4;
+        let expected_operand = Operand::Register8(Register8::L);
+
+        FakeCpu::new().test_decode_operand(opcode, &Sub8Decoder, expected_cycles, expected_operand);
+    }
+
+    #[test]
+    fn test_decode_sub8_hl() {
+        let opcode = 0x96;
+        let expected_cycles = 8;
+        let expected_operand = Operand::Memory(Memory::HL);
+
+        FakeCpu::new().test_decode_operand(opcode, &Sub8Decoder, expected_cycles, expected_operand);
+    }
+
+    #[test]
+    fn test_decode_sub8_a() {
+        let opcode = 0x97;
+        let expected_cycles = 4;
+        let expected_operand = Operand::Register8(Register8::A);
+
+        FakeCpu::new().test_decode_operand(opcode, &Sub8Decoder, expected_cycles, expected_operand);
+    }
+
+    #[test]
+    fn test_decode_sub8_imm8() {
+        let opcode = 0xD6;
+        let expected_cycles = 8;
+        let expected_operand = Operand::Imm8;
+
+        FakeCpu::new().test_decode_operand(opcode, &Sub8Decoder, expected_cycles, expected_operand);
+    }
+
+    #[test]
+    fn test_invalid_opcode_sub8() {
+        let opcode = 0xFF; // Example invalid opcode for Sub8
+        assert!(Sub8Decoder{}.decode(opcode).is_err());
+    }
+}

--- a/src/cpu/instructions/sub/mod.rs
+++ b/src/cpu/instructions/sub/mod.rs
@@ -1,0 +1,2 @@
+pub mod decoder;
+pub mod opcode;

--- a/src/cpu/instructions/sub/opcode.rs
+++ b/src/cpu/instructions/sub/opcode.rs
@@ -1,0 +1,103 @@
+use crate::cpu::instructions::opcode::OpCode;
+use crate::cpu::instructions::operand::*;
+use crate::cpu::instructions::instructions::{Error, Instructions};
+
+/// Subtracts the value of the operand from the accumulator register (A).
+pub struct Sub8 {
+    pub operand: Operand,
+    pub cycles: u8,
+}
+
+impl OpCode for Sub8 {
+    fn execute(&self, cpu: &mut dyn Instructions) -> Result<u8, Error> {
+        cpu.sub8(&self)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use crate::cpu::instructions::test::util::FakeCpu;
+
+    #[test]
+    fn test_execute_sub8_b() {
+        let expected_cycles = 4;
+        let expected_operand = Operand::Register8(Register8::B);
+        let opcode = Sub8{operand: expected_operand, cycles: expected_cycles};
+
+        FakeCpu::new().test_execute_opcode(&opcode, expected_cycles, expected_operand);
+    }
+
+    #[test]
+    fn test_execute_sub8_c() {
+        let expected_cycles = 4;
+        let expected_operand = Operand::Register8(Register8::C);
+        let opcode = Sub8{operand: expected_operand, cycles: expected_cycles};
+
+        FakeCpu::new().test_execute_opcode(&opcode, expected_cycles, expected_operand);
+    }
+
+    #[test]
+    fn test_execute_sub8_d() {
+        let expected_cycles = 4;
+        let expected_operand = Operand::Register8(Register8::D);
+        let opcode = Sub8{operand: expected_operand, cycles: expected_cycles};
+
+        FakeCpu::new().test_execute_opcode(&opcode, expected_cycles, expected_operand);
+    }
+
+    #[test]
+    fn test_execute_sub8_e() {
+        let expected_cycles = 4;
+        let expected_operand = Operand::Register8(Register8::E);
+        let opcode = Sub8{operand: expected_operand, cycles: expected_cycles};
+
+        FakeCpu::new().test_execute_opcode(&opcode, expected_cycles, expected_operand);
+    }
+
+    #[test]
+    fn test_execute_sub8_h() {
+        let expected_cycles = 4;
+        let expected_operand = Operand::Register8(Register8::H);
+        let opcode = Sub8{operand: expected_operand, cycles: expected_cycles};
+
+        FakeCpu::new().test_execute_opcode(&opcode, expected_cycles, expected_operand);
+    }
+
+    #[test]
+    fn test_execute_sub8_l() {
+        let expected_cycles = 4;
+        let expected_operand = Operand::Register8(Register8::L);
+        let opcode = Sub8{operand: expected_operand, cycles: expected_cycles};
+
+        FakeCpu::new().test_execute_opcode(&opcode, expected_cycles, expected_operand);
+    }
+
+    #[test]
+    fn test_execute_sub8_hl() {
+        let expected_cycles = 8;
+        let expected_operand = Operand::Memory(Memory::HL);
+        let opcode = Sub8{operand: expected_operand, cycles: expected_cycles};
+
+        FakeCpu::new().test_execute_opcode(&opcode, expected_cycles, expected_operand);
+    }
+
+    #[test]
+    fn test_execute_sub8_a() {
+        let expected_cycles = 4;
+        let expected_operand = Operand::Register8(Register8::A);
+        let opcode = Sub8{operand: expected_operand, cycles: expected_cycles};
+
+        FakeCpu::new().test_execute_opcode(&opcode, expected_cycles, expected_operand);
+    }
+
+    #[test]
+    fn test_execute_sub8_imm8() {
+        let expected_cycles = 8;
+        let expected_operand = Operand::Imm8;
+        let opcode = Sub8{operand: expected_operand, cycles: expected_cycles};
+
+        FakeCpu::new().test_execute_opcode(&opcode, expected_cycles, expected_operand);
+    }
+}

--- a/src/cpu/instructions/test/mod.rs
+++ b/src/cpu/instructions/test/mod.rs
@@ -2,6 +2,7 @@
 pub mod util {
     use crate::cpu::instructions::adc::opcode::Adc;
     use crate::cpu::instructions::add::opcode::{Add8, Add16, AddSP16};
+    use crate::cpu::instructions::sub::opcode::Sub8;
     use crate::cpu::instructions::decoder::Decoder;
     use crate::cpu::instructions::instructions::{Error, Instructions};
     use crate::cpu::instructions::opcode::OpCode;
@@ -47,6 +48,11 @@ pub mod util {
         }
 
         fn adc(&mut self, opcode: &Adc) -> Result<u8, Error> {
+            self.operand = Some(opcode.operand);
+            Ok(opcode.cycles)
+        }
+
+        fn sub8(&mut self, opcode: &Sub8) -> Result<u8, Error> {
             self.operand = Some(opcode.operand);
             Ok(opcode.cycles)
         }

--- a/src/cpu/operations/mod.rs
+++ b/src/cpu/operations/mod.rs
@@ -1,1 +1,2 @@
 pub mod add;
+pub mod sub;

--- a/src/cpu/operations/sub.rs
+++ b/src/cpu/operations/sub.rs
@@ -1,0 +1,65 @@
+use crate::cpu::registers::Flags;
+
+/// Subtracts b from a and returns the result and the flags.
+/// Possible Flag values:
+/// - Z: When the result is equal to 0.
+/// - N: true (always set for subtraction)
+/// - H: Set if borrow from bit 4.
+/// - C: Set if borrow (a < b).
+pub fn sub_u8(a: u8, b: u8) -> (u8, Flags) {
+    let (result, borrow) = a.overflowing_sub(b);
+    let nbits: usize = 8;
+    (result, Flags::from_sub(result.into(), borrow, sub_has_half_borrow(a.into(), b.into(), nbits)))
+}
+
+fn sub_has_half_borrow(a: usize, b: usize, nbits: usize) -> bool {
+    let half_mask = (1 << (nbits / 2)) - 1;
+    (a & half_mask) < (b & half_mask)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_sub_u8_zero_flag() {
+        let (result, flags) = sub_u8(5, 5);
+        assert_eq!(result, 0);
+        assert_eq!(flags, Flags::Z | Flags::N);
+    }
+
+    #[test]
+    fn test_sub_u8_no_flags() {
+        let (result, flags) = sub_u8(10, 3);
+        assert_eq!(result, 7);
+        assert_eq!(flags, Flags::N);
+    }
+
+    #[test]
+    fn test_sub_u8_half_borrow() {
+        let (result, flags) = sub_u8(16, 1);
+        assert_eq!(result, 15);
+        assert_eq!(flags, Flags::N | Flags::H);
+    }
+
+    #[test]
+    fn test_sub_u8_borrow() {
+        let (result, flags) = sub_u8(0, 1);
+        assert_eq!(result, 255);
+        assert_eq!(flags, Flags::N | Flags::C | Flags::H);
+    }
+
+    #[test]
+    fn test_sub_u8_borrow_and_half_borrow() {
+        let (result, flags) = sub_u8(0, 16);
+        assert_eq!(result, 240);
+        assert_eq!(flags, Flags::N | Flags::C);
+    }
+
+    #[test]
+    fn test_sub_u8_large_values() {
+        let (result, flags) = sub_u8(255, 1);
+        assert_eq!(result, 254);
+        assert_eq!(flags, Flags::N);
+    }
+}

--- a/src/cpu/registers.rs
+++ b/src/cpu/registers.rs
@@ -30,6 +30,16 @@ impl Flags {
         flags.set(Self::Z, sum == 0);
         flags
     }
+
+    /// Create a new set of flags from the result of a subtraction operation.
+    pub fn from_sub(result: usize, borrow: bool, half_borrow: bool) -> Self {
+        let mut flags = Self::empty();
+        flags.set(Self::C, borrow);
+        flags.set(Self::H, half_borrow);
+        flags.set(Self::N, true);
+        flags.set(Self::Z, result == 0);
+        flags
+    }
 }
 
 /// Registers for the Gameboy CPU


### PR DESCRIPTION
Add complete support for 8-bit subtraction instruction (SUB A, operand):
- Support for all 8-bit registers (B,C,D,E,H,L,A) and immediate values
- Correct flag handling (Z, N, H, C) according to Game Boy specifications
- Comprehensive test coverage including unit, decoder, and integration tests
- Opcodes: 0x90-0x97 (registers), 0xD6 (immediate)

🤖 Generated with [Claude Code](https://claude.ai/code)