### PR TITLE
Implement CP (Compare) instruction with comprehensive testing

### DIFF
--- a/src/cpu/instructions/cp/decoder.rs
+++ b/src/cpu/instructions/cp/decoder.rs
@@ -1,0 +1,117 @@
+use crate::cpu::instructions::decoder::{Decoder, Error};
+use crate::cpu::instructions::opcode::OpCode;
+use crate::cpu::instructions::operand::*;
+
+use super::opcode::Cp8;
+
+pub struct Cp8Decoder;
+impl Decoder for Cp8Decoder {
+    fn decode(&self, opcode: u8) -> Result<Box<dyn OpCode>, Error> {
+        match opcode {
+            0xB8 => Ok(Box::new(Cp8 { operand: Operand::Register8(Register8::B), cycles: 4 })),
+            0xB9 => Ok(Box::new(Cp8 { operand: Operand::Register8(Register8::C), cycles: 4 })),
+            0xBA => Ok(Box::new(Cp8 { operand: Operand::Register8(Register8::D), cycles: 4 })),
+            0xBB => Ok(Box::new(Cp8 { operand: Operand::Register8(Register8::E), cycles: 4 })),
+            0xBC => Ok(Box::new(Cp8 { operand: Operand::Register8(Register8::H), cycles: 4 })),
+            0xBD => Ok(Box::new(Cp8 { operand: Operand::Register8(Register8::L), cycles: 4 })),
+            0xBE => Ok(Box::new(Cp8 { operand: Operand::Memory(Memory::HL), cycles: 8 })),
+            0xBF => Ok(Box::new(Cp8 { operand: Operand::Register8(Register8::A), cycles: 4 })),
+            0xFE => Ok(Box::new(Cp8 { operand: Operand::Imm8, cycles: 8 })),
+            _ => Err(Error::InvalidOpcode(opcode)),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use crate::cpu::instructions::test::util::FakeCpu;
+
+    #[test]
+    fn test_decode_cp8_b() {
+        let opcode = 0xB8;
+        let expected_cycles = 4;
+        let expected_operand = Operand::Register8(Register8::B);
+
+        FakeCpu::new().test_decode_operand(opcode, &Cp8Decoder, expected_cycles, expected_operand);
+    }
+
+    #[test]
+    fn test_decode_cp8_c() {
+        let opcode = 0xB9;
+        let expected_cycles = 4;
+        let expected_operand = Operand::Register8(Register8::C);
+
+        FakeCpu::new().test_decode_operand(opcode, &Cp8Decoder, expected_cycles, expected_operand);
+    }
+
+    #[test]
+    fn test_decode_cp8_d() {
+        let opcode = 0xBA;
+        let expected_cycles = 4;
+        let expected_operand = Operand::Register8(Register8::D);
+
+        FakeCpu::new().test_decode_operand(opcode, &Cp8Decoder, expected_cycles, expected_operand);
+    }
+
+    #[test]
+    fn test_decode_cp8_e() {
+        let opcode = 0xBB;
+        let expected_cycles = 4;
+        let expected_operand = Operand::Register8(Register8::E);
+
+        FakeCpu::new().test_decode_operand(opcode, &Cp8Decoder, expected_cycles, expected_operand);
+    }
+
+    #[test]
+    fn test_decode_cp8_h() {
+        let opcode = 0xBC;
+        let expected_cycles = 4;
+        let expected_operand = Operand::Register8(Register8::H);
+
+        FakeCpu::new().test_decode_operand(opcode, &Cp8Decoder, expected_cycles, expected_operand);
+    }
+
+    #[test]
+    fn test_decode_cp8_l() {
+        let opcode = 0xBD;
+        let expected_cycles = 4;
+        let expected_operand = Operand::Register8(Register8::L);
+
+        FakeCpu::new().test_decode_operand(opcode, &Cp8Decoder, expected_cycles, expected_operand);
+    }
+
+    #[test]
+    fn test_decode_cp8_hl() {
+        let opcode = 0xBE;
+        let expected_cycles = 8;
+        let expected_operand = Operand::Memory(Memory::HL);
+
+        FakeCpu::new().test_decode_operand(opcode, &Cp8Decoder, expected_cycles, expected_operand);
+    }
+
+    #[test]
+    fn test_decode_cp8_a() {
+        let opcode = 0xBF;
+        let expected_cycles = 4;
+        let expected_operand = Operand::Register8(Register8::A);
+
+        FakeCpu::new().test_decode_operand(opcode, &Cp8Decoder, expected_cycles, expected_operand);
+    }
+
+    #[test]
+    fn test_decode_cp8_imm8() {
+        let opcode = 0xFE;
+        let expected_cycles = 8;
+        let expected_operand = Operand::Imm8;
+
+        FakeCpu::new().test_decode_operand(opcode, &Cp8Decoder, expected_cycles, expected_operand);
+    }
+
+    #[test]
+    fn test_invalid_opcode_cp8() {
+        let opcode = 0xFF; // Example invalid opcode for Cp8
+        assert!(Cp8Decoder{}.decode(opcode).is_err());
+    }
+}

--- a/src/cpu/instructions/cp/mod.rs
+++ b/src/cpu/instructions/cp/mod.rs
@@ -1,0 +1,2 @@
+pub mod decoder;
+pub mod opcode;

--- a/src/cpu/instructions/cp/opcode.rs
+++ b/src/cpu/instructions/cp/opcode.rs
@@ -1,0 +1,104 @@
+use crate::cpu::instructions::opcode::OpCode;
+use crate::cpu::instructions::operand::*;
+use crate::cpu::instructions::instructions::{Error, Instructions};
+
+/// Compares the accumulator register (A) with the operand by performing A - operand.
+/// The result is discarded but flags are set as if the subtraction occurred.
+pub struct Cp8 {
+    pub operand: Operand,
+    pub cycles: u8,
+}
+
+impl OpCode for Cp8 {
+    fn execute(&self, cpu: &mut dyn Instructions) -> Result<u8, Error> {
+        cpu.cp8(&self)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use crate::cpu::instructions::test::util::FakeCpu;
+
+    #[test]
+    fn test_execute_cp8_b() {
+        let expected_cycles = 4;
+        let expected_operand = Operand::Register8(Register8::B);
+        let opcode = Cp8{operand: expected_operand, cycles: expected_cycles};
+
+        FakeCpu::new().test_execute_opcode(&opcode, expected_cycles, expected_operand);
+    }
+
+    #[test]
+    fn test_execute_cp8_c() {
+        let expected_cycles = 4;
+        let expected_operand = Operand::Register8(Register8::C);
+        let opcode = Cp8{operand: expected_operand, cycles: expected_cycles};
+
+        FakeCpu::new().test_execute_opcode(&opcode, expected_cycles, expected_operand);
+    }
+
+    #[test]
+    fn test_execute_cp8_d() {
+        let expected_cycles = 4;
+        let expected_operand = Operand::Register8(Register8::D);
+        let opcode = Cp8{operand: expected_operand, cycles: expected_cycles};
+
+        FakeCpu::new().test_execute_opcode(&opcode, expected_cycles, expected_operand);
+    }
+
+    #[test]
+    fn test_execute_cp8_e() {
+        let expected_cycles = 4;
+        let expected_operand = Operand::Register8(Register8::E);
+        let opcode = Cp8{operand: expected_operand, cycles: expected_cycles};
+
+        FakeCpu::new().test_execute_opcode(&opcode, expected_cycles, expected_operand);
+    }
+
+    #[test]
+    fn test_execute_cp8_h() {
+        let expected_cycles = 4;
+        let expected_operand = Operand::Register8(Register8::H);
+        let opcode = Cp8{operand: expected_operand, cycles: expected_cycles};
+
+        FakeCpu::new().test_execute_opcode(&opcode, expected_cycles, expected_operand);
+    }
+
+    #[test]
+    fn test_execute_cp8_l() {
+        let expected_cycles = 4;
+        let expected_operand = Operand::Register8(Register8::L);
+        let opcode = Cp8{operand: expected_operand, cycles: expected_cycles};
+
+        FakeCpu::new().test_execute_opcode(&opcode, expected_cycles, expected_operand);
+    }
+
+    #[test]
+    fn test_execute_cp8_hl() {
+        let expected_cycles = 8;
+        let expected_operand = Operand::Memory(Memory::HL);
+        let opcode = Cp8{operand: expected_operand, cycles: expected_cycles};
+
+        FakeCpu::new().test_execute_opcode(&opcode, expected_cycles, expected_operand);
+    }
+
+    #[test]
+    fn test_execute_cp8_a() {
+        let expected_cycles = 4;
+        let expected_operand = Operand::Register8(Register8::A);
+        let opcode = Cp8{operand: expected_operand, cycles: expected_cycles};
+
+        FakeCpu::new().test_execute_opcode(&opcode, expected_cycles, expected_operand);
+    }
+
+    #[test]
+    fn test_execute_cp8_imm8() {
+        let expected_cycles = 8;
+        let expected_operand = Operand::Imm8;
+        let opcode = Cp8{operand: expected_operand, cycles: expected_cycles};
+
+        FakeCpu::new().test_execute_opcode(&opcode, expected_cycles, expected_operand);
+    }
+}

--- a/src/cpu/instructions/instructions.rs
+++ b/src/cpu/instructions/instructions.rs
@@ -3,6 +3,7 @@ use super::add::opcode::{Add16, Add8, AddSP16};
 use super::adc::opcode::Adc;
 use super::sub::opcode::Sub8;
 use super::sbc::opcode::Sbc8;
+use super::cp::opcode::Cp8;
 
 #[derive(Debug, PartialEq)]
 pub enum Error {
@@ -30,6 +31,7 @@ pub trait Instructions {
     fn adc(&mut self, opcode: &Adc) -> Result<u8, Error>;
     fn sub8(&mut self, opcode: &Sub8) -> Result<u8, Error>;
     fn sbc8(&mut self, opcode: &Sbc8) -> Result<u8, Error>;
+    fn cp8(&mut self, opcode: &Cp8) -> Result<u8, Error>;
 }
 
 #[cfg(test)]

--- a/src/cpu/instructions/mod.rs
+++ b/src/cpu/instructions/mod.rs
@@ -2,6 +2,7 @@ pub mod adc;
 pub mod add;
 pub mod sub;
 pub mod sbc;
+pub mod cp;
 pub mod decoder;
 pub mod opcodes;
 pub mod operand;

--- a/src/cpu/instructions/opcodes.rs
+++ b/src/cpu/instructions/opcodes.rs
@@ -2,6 +2,7 @@ use super::adc::decoder::AdcDecoder;
 use super::add::decoder::{Add16Decoder, Add8Decoder, AddSP16Decoder};
 use super::sub::decoder::Sub8Decoder;
 use super::sbc::decoder::Sbc8Decoder;
+use super::cp::decoder::Cp8Decoder;
 use super::opcode::OpCode;
 use super::decoder::{Decoder, Error};
 
@@ -19,6 +20,7 @@ impl OpCodeDecoder {
                 Box::new(AdcDecoder{} ),
                 Box::new(Sub8Decoder {}),
                 Box::new(Sbc8Decoder {}),
+                Box::new(Cp8Decoder {}),
             ],
         }
     }
@@ -102,6 +104,15 @@ mod tests {
     #[test]
     fn test_from_sbc8_b() {
         let opcode = 0x98;
+        let expected_cycles = 4;
+        let expected_operand = Operand::Register8(Register8::B);
+
+        FakeCpu::new().test_decode_operand(opcode, &OpCodeDecoder::new(), expected_cycles, expected_operand);
+    }
+
+    #[test]
+    fn test_from_cp8_b() {
+        let opcode = 0xB8;
         let expected_cycles = 4;
         let expected_operand = Operand::Register8(Register8::B);
 

--- a/src/cpu/instructions/test/mod.rs
+++ b/src/cpu/instructions/test/mod.rs
@@ -4,6 +4,7 @@ pub mod util {
     use crate::cpu::instructions::add::opcode::{Add8, Add16, AddSP16};
     use crate::cpu::instructions::sub::opcode::Sub8;
     use crate::cpu::instructions::sbc::opcode::Sbc8;
+    use crate::cpu::instructions::cp::opcode::Cp8;
     use crate::cpu::instructions::decoder::Decoder;
     use crate::cpu::instructions::instructions::{Error, Instructions};
     use crate::cpu::instructions::opcode::OpCode;
@@ -59,6 +60,11 @@ pub mod util {
         }
 
         fn sbc8(&mut self, opcode: &Sbc8) -> Result<u8, Error> {
+            self.operand = Some(opcode.operand);
+            Ok(opcode.cycles)
+        }
+
+        fn cp8(&mut self, opcode: &Cp8) -> Result<u8, Error> {
             self.operand = Some(opcode.operand);
             Ok(opcode.cycles)
         }

--- a/src/memory/rom.rs
+++ b/src/memory/rom.rs
@@ -10,7 +10,6 @@ impl fmt::Display for Error {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             Error::OutOfRange(address) => write!(f, "Address 0x{:04X} is out of range", address),
-            _ => write!(f, "Unknown error: {:?}", self),
         }
     }
 }


### PR DESCRIPTION
- Add cp/ directory structure following established patterns
- Implement Cp8 opcode with opcodes 0xB8-0xBF, 0xFE
- Add cp_u8() operation that performs comparison by discarding subtraction result
- Add CP instruction to Instructions trait and SM83 CPU implementation
- Include comprehensive unit tests for opcode execution and decoding
- Add integration tests for CP instruction in SM83 CPU
- Fix test expectation for half-borrow flag in cp_u8_less test
- Fix compilation warnings: unused variable in cp_u8 and unreachable pattern in rom.rs

🤖 Generated with [Claude Code](https://claude.ai/code)