### PR TITLE
fix: include cart external RAM in save state blob

### DIFF
--- a/core/src/cpu/mod.rs
+++ b/core/src/cpu/mod.rs
@@ -3,4 +3,5 @@ pub mod instructions;
 mod operations;
 pub mod peripheral;
 pub mod registers;
+pub mod save_state;
 pub mod sm83;

--- a/core/src/cpu/peripheral/ppu.rs
+++ b/core/src/cpu/peripheral/ppu.rs
@@ -133,27 +133,12 @@ impl PpuPeripheral {
         out.push(self.window_line_counter);
     }
 
-    /// Deserialize PPU state from `data` at byte `offset`. Returns the number of bytes consumed.
-    pub fn load_state(&mut self, data: &[u8], offset: usize) -> usize {
-        let start = offset;
-        let mut cur = offset;
-        self.dot = u16::from_le_bytes([data[cur], data[cur + 1]]); cur += 2;
-        self.ly = data[cur]; cur += 1;
-        self.mode = match data[cur] {
-            0 => PpuMode::HBlank,
-            1 => PpuMode::VBlank,
-            2 => PpuMode::OamScan,
-            _ => PpuMode::PixelTransfer,
-        }; cur += 1;
-        self.window_line_counter = data[cur]; cur += 1;
-        cur - start
-    }
-
-    pub fn apply_fields(&mut self, dot: u16, ly: u8, mode: PpuMode, window_line_counter: u8) {
-        self.dot = dot;
-        self.ly = ly;
-        self.mode = mode;
-        self.window_line_counter = window_line_counter;
+    /// Apply PPU state from a parsed [`PpuState`].
+    pub fn load_state(&mut self, state: crate::cpu::save_state::PpuState) {
+        self.dot = state.dot;
+        self.ly = state.ly;
+        self.mode = state.mode;
+        self.window_line_counter = state.window_line_counter;
     }
 
     /// Advance the PPU by `cycles` T-cycles.

--- a/core/src/cpu/peripheral/ppu.rs
+++ b/core/src/cpu/peripheral/ppu.rs
@@ -125,12 +125,14 @@ impl PpuPeripheral {
         &self.framebuffer
     }
 
-    /// Serialize PPU state into `out`. 5 bytes: dot(LE u16) ly mode window_line_counter.
-    pub fn save_state(&self, out: &mut alloc::vec::Vec<u8>) {
-        out.extend_from_slice(&self.dot.to_le_bytes());
-        out.push(self.ly);
-        out.push(self.mode as u8);
-        out.push(self.window_line_counter);
+    /// Extract PPU state into a [`PpuState`] for serialization.
+    pub fn to_save_state(&self) -> crate::cpu::save_state::PpuState {
+        crate::cpu::save_state::PpuState {
+            dot: self.dot,
+            ly: self.ly,
+            mode: self.mode,
+            window_line_counter: self.window_line_counter,
+        }
     }
 
     /// Apply PPU state from a parsed [`PpuState`].

--- a/core/src/cpu/peripheral/ppu.rs
+++ b/core/src/cpu/peripheral/ppu.rs
@@ -149,6 +149,13 @@ impl PpuPeripheral {
         cur - start
     }
 
+    pub fn apply_fields(&mut self, dot: u16, ly: u8, mode: PpuMode, window_line_counter: u8) {
+        self.dot = dot;
+        self.ly = ly;
+        self.mode = mode;
+        self.window_line_counter = window_line_counter;
+    }
+
     /// Advance the PPU by `cycles` T-cycles.
     pub fn tick(&mut self, cycles: u16, input: PpuInput) -> PpuOutput {
         let lcdc = Lcdc(input.lcdc);

--- a/core/src/cpu/peripheral/timer.rs
+++ b/core/src/cpu/peripheral/timer.rs
@@ -67,6 +67,10 @@ impl TimerPeripheral {
         cur - start
     }
 
+    pub fn set_internal_counter(&mut self, value: u16) {
+        self.internal_counter = value;
+    }
+
     /// Advance the timer by `cycles` T-cycles.
     ///
     /// Pure transform: reads register state from `input`, returns new state

--- a/core/src/cpu/peripheral/timer.rs
+++ b/core/src/cpu/peripheral/timer.rs
@@ -54,9 +54,9 @@ impl TimerPeripheral {
         self.internal_counter = 0;
     }
 
-    /// Serialize timer state into `out`. 2 bytes: internal_counter LE.
-    pub fn save_state(&self, out: &mut alloc::vec::Vec<u8>) {
-        out.extend_from_slice(&self.internal_counter.to_le_bytes());
+    /// Extract timer state into a [`TimerState`] for serialization.
+    pub fn to_save_state(&self) -> crate::cpu::save_state::TimerState {
+        crate::cpu::save_state::TimerState { internal_counter: self.internal_counter }
     }
 
     /// Apply timer state from a parsed [`TimerState`].

--- a/core/src/cpu/peripheral/timer.rs
+++ b/core/src/cpu/peripheral/timer.rs
@@ -59,16 +59,9 @@ impl TimerPeripheral {
         out.extend_from_slice(&self.internal_counter.to_le_bytes());
     }
 
-    /// Deserialize timer state from `data` at byte `offset`. Returns the number of bytes consumed.
-    pub fn load_state(&mut self, data: &[u8], offset: usize) -> usize {
-        let start = offset;
-        let mut cur = offset;
-        self.internal_counter = u16::from_le_bytes([data[cur], data[cur + 1]]); cur += 2;
-        cur - start
-    }
-
-    pub fn set_internal_counter(&mut self, value: u16) {
-        self.internal_counter = value;
+    /// Apply timer state from a parsed [`TimerState`].
+    pub fn load_state(&mut self, state: crate::cpu::save_state::TimerState) {
+        self.internal_counter = state.internal_counter;
     }
 
     /// Advance the timer by `cycles` T-cycles.

--- a/core/src/cpu/registers.rs
+++ b/core/src/cpu/registers.rs
@@ -99,36 +99,6 @@ impl Registers {
         self.f = Flags::from_bits_truncate((af & 0xF0) as u8);
     }
 
-    /// Serialize registers into `out`. 10 bytes: A B C D E H L F SP(LE) PC(LE).
-    pub fn save_state(&self, out: &mut alloc::vec::Vec<u8>) {
-        out.push(self.a);
-        out.push(self.b);
-        out.push(self.c);
-        out.push(self.d);
-        out.push(self.e);
-        out.push(self.h);
-        out.push(self.l);
-        out.push(self.f.bits());
-        out.extend_from_slice(&self.sp.to_le_bytes());
-        out.extend_from_slice(&self.pc.to_le_bytes());
-    }
-
-    /// Deserialize registers from `data` at byte `offset`. Returns the number of bytes consumed.
-    pub fn load_state(&mut self, data: &[u8], offset: usize) -> usize {
-        let start = offset;
-        let mut cur = offset;
-        self.a  = data[cur]; cur += 1;
-        self.b  = data[cur]; cur += 1;
-        self.c  = data[cur]; cur += 1;
-        self.d  = data[cur]; cur += 1;
-        self.e  = data[cur]; cur += 1;
-        self.h  = data[cur]; cur += 1;
-        self.l  = data[cur]; cur += 1;
-        self.f  = Flags::from_bits_truncate(data[cur]); cur += 1;
-        self.sp = u16::from_le_bytes([data[cur], data[cur + 1]]); cur += 2;
-        self.pc = u16::from_le_bytes([data[cur], data[cur + 1]]); cur += 2;
-        cur - start
-    }
 
 }
 

--- a/core/src/cpu/registers.rs
+++ b/core/src/cpu/registers.rs
@@ -130,10 +130,6 @@ impl Registers {
         cur - start
     }
 
-    /// Apply register state from a parsed [`CpuState`].
-    pub fn apply_state(&mut self, state: crate::cpu::save_state::CpuState) {
-        *self = state.to_registers();
-    }
 }
 
 #[cfg(test)]

--- a/core/src/cpu/registers.rs
+++ b/core/src/cpu/registers.rs
@@ -129,6 +129,11 @@ impl Registers {
         self.pc = u16::from_le_bytes([data[cur], data[cur + 1]]); cur += 2;
         cur - start
     }
+
+    /// Apply register state from a parsed [`CpuState`].
+    pub fn apply_state(&mut self, state: crate::cpu::save_state::CpuState) {
+        *self = state.to_registers();
+    }
 }
 
 #[cfg(test)]

--- a/core/src/cpu/save_state.rs
+++ b/core/src/cpu/save_state.rs
@@ -1,0 +1,253 @@
+//! Typed save state representation for the RBSS v1 format.
+//!
+//! On the **save path**, `Sm83::save_state()` writes directly to a `Vec<u8>` —
+//! no `SaveState` instance is created.
+//!
+//! On the **load path**, `SaveState::from_blob(blob)` parses and validates the
+//! entire blob up front, returning `Err` if anything is wrong before any
+//! emulator state is touched. The struct owns the blob and exposes zero-copy
+//! slice accessors for large memory regions. Scalar fields are copied out at
+//! parse time. Call `Sm83::load_state(state)` to apply a parsed `SaveState`.
+
+use alloc::vec::Vec;
+use core::ops::Range;
+
+use crate::cpu::peripheral::ppu::PpuMode;
+use crate::cpu::registers::{Flags, Registers};
+use crate::cpu::sm83::ImeState;
+
+// ── Scalar field containers ───────────────────────────────────────────────────
+
+/// CPU register state copied out of the blob at parse time.
+#[derive(Debug, Clone, Copy)]
+pub struct CpuFields {
+    pub a: u8,
+    pub b: u8,
+    pub c: u8,
+    pub d: u8,
+    pub e: u8,
+    pub h: u8,
+    pub l: u8,
+    pub f: Flags,
+    pub sp: u16,
+    pub pc: u16,
+}
+
+impl CpuFields {
+    pub fn to_registers(self) -> Registers {
+        Registers {
+            a: self.a,
+            b: self.b,
+            c: self.c,
+            d: self.d,
+            e: self.e,
+            h: self.h,
+            l: self.l,
+            f: self.f,
+            sp: self.sp,
+            pc: self.pc,
+        }
+    }
+}
+
+/// PPU scalar state copied out of the blob at parse time.
+#[derive(Debug, Clone, Copy)]
+pub struct PpuFields {
+    pub dot: u16,
+    pub ly: u8,
+    pub mode: PpuMode,
+    pub window_line_counter: u8,
+}
+
+/// MBC register state copied out of the blob at parse time.
+#[derive(Debug, Clone, Copy)]
+pub struct MbcFields {
+    pub rom_bank_lo: u8,
+    pub upper_bits: u8,
+    pub ram_mode: bool,
+    pub ram_enabled: bool,
+}
+
+// ── SaveState ─────────────────────────────────────────────────────────────────
+
+/// A parsed, validated RBSS v1 save state blob.
+///
+/// The blob is owned by this struct. Large memory regions (WRAM, VRAM, etc.)
+/// are accessed as zero-copy slices via range indices into the blob. Scalar
+/// fields are copied out at parse time and accessible directly.
+pub struct SaveState {
+    blob: Vec<u8>,
+
+    // Scalar fields — cheap to copy, exposed directly.
+    cpu: CpuFields,
+    pub ime: ImeState,
+    pub halted: bool,
+    pub cycle_counter: u64,
+    pub timer_internal_counter: u16,
+    pub ppu: PpuFields,
+    mbc: Option<MbcFields>,
+
+    // Ranges into `blob` for the large memory regions.
+    io_range: Range<usize>,
+    ie_offset: usize,
+    wram_range: Range<usize>,
+    hram_range: Range<usize>,
+    vram_range: Range<usize>,
+    oam_range: Range<usize>,
+    cart_ram_range: Option<Range<usize>>,
+}
+
+impl SaveState {
+    /// Parse and validate a raw RBSS v1 blob.
+    ///
+    /// Returns `Err` if the blob is too short, has a bad magic, or has an
+    /// unsupported version. No emulator state is modified.
+    pub fn from_blob(blob: Vec<u8>) -> Result<Self, &'static str> {
+        if blob.len() < 16835 {
+            return Err("save state blob too short");
+        }
+        if &blob[0..4] != b"RBSS" {
+            return Err("invalid save state magic");
+        }
+        let version = u16::from_le_bytes([blob[4], blob[5]]);
+        if version != 1 {
+            return Err("unsupported save state version");
+        }
+
+        let mut cur = 6usize;
+
+        // CPU registers (10 bytes)
+        let cpu = CpuFields {
+            a:  blob[cur],     b: blob[cur + 1], c: blob[cur + 2],
+            d:  blob[cur + 3], e: blob[cur + 4], h: blob[cur + 5],
+            l:  blob[cur + 6],
+            f:  Flags::from_bits_truncate(blob[cur + 7]),
+            sp: u16::from_le_bytes([blob[cur + 8],  blob[cur + 9]]),
+            pc: u16::from_le_bytes([blob[cur + 10], blob[cur + 11]]),
+        };
+        cur += 12;
+
+        // IME + halted (2 bytes)
+        let ime = match blob[cur] {
+            1 => ImeState::Pending,
+            2 => ImeState::Enabled,
+            _ => ImeState::Disabled,
+        };
+        cur += 1;
+        let halted = blob[cur] != 0;
+        cur += 1;
+
+        // Cycle counter (8 bytes)
+        let cycle_counter = u64::from_le_bytes([
+            blob[cur],     blob[cur + 1], blob[cur + 2], blob[cur + 3],
+            blob[cur + 4], blob[cur + 5], blob[cur + 6], blob[cur + 7],
+        ]);
+        cur += 8;
+
+        // Timer (2 bytes)
+        let timer_internal_counter = u16::from_le_bytes([blob[cur], blob[cur + 1]]);
+        cur += 2;
+
+        // PPU (5 bytes)
+        let ppu = PpuFields {
+            dot: u16::from_le_bytes([blob[cur], blob[cur + 1]]),
+            ly:  blob[cur + 2],
+            mode: match blob[cur + 3] {
+                0 => PpuMode::HBlank,
+                1 => PpuMode::VBlank,
+                2 => PpuMode::OamScan,
+                _ => PpuMode::PixelTransfer,
+            },
+            window_line_counter: blob[cur + 4],
+        };
+        cur += 5;
+
+        // IO registers (0x80 bytes)
+        let io_range = cur..cur + 0x80;
+        cur += 0x80;
+
+        // IE register (1 byte)
+        let ie_offset = cur;
+        cur += 1;
+
+        // WRAM (0x2000 bytes)
+        let wram_range = cur..cur + 0x2000;
+        cur += 0x2000;
+
+        // HRAM (0x7F bytes)
+        let hram_range = cur..cur + 0x7F;
+        cur += 0x7F;
+
+        // VRAM (0x2000 bytes)
+        let vram_range = cur..cur + 0x2000;
+        cur += 0x2000;
+
+        // OAM (0xA0 bytes)
+        let oam_range = cur..cur + 0xA0;
+        cur += 0xA0;
+
+        // MBC state (optional, 4 bytes)
+        let mbc = if cur + 4 <= blob.len() {
+            let m = MbcFields {
+                rom_bank_lo: blob[cur].max(1),
+                upper_bits:  blob[cur + 1] & 0x03,
+                ram_mode:    blob[cur + 2] != 0,
+                ram_enabled: blob[cur + 3] != 0,
+            };
+            cur += 4;
+            Some(m)
+        } else {
+            None
+        };
+
+        // External cart RAM (optional, u16 LE length prefix)
+        let cart_ram_range = if cur + 2 <= blob.len() {
+            let ram_len = u16::from_le_bytes([blob[cur], blob[cur + 1]]) as usize;
+            cur += 2;
+            if ram_len > 0 && cur + ram_len <= blob.len() {
+                let range = cur..cur + ram_len;
+                Some(range)
+            } else {
+                None
+            }
+        } else {
+            None
+        };
+
+        Ok(SaveState {
+            blob,
+            cpu,
+            ime,
+            halted,
+            cycle_counter,
+            timer_internal_counter,
+            ppu,
+            mbc,
+            io_range,
+            ie_offset,
+            wram_range,
+            hram_range,
+            vram_range,
+            oam_range,
+            cart_ram_range,
+        })
+    }
+
+    // ── Scalar accessors ──────────────────────────────────────────────────────
+
+    pub fn cpu(&self) -> &CpuFields { &self.cpu }
+    pub fn mbc(&self) -> Option<&MbcFields> { self.mbc.as_ref() }
+    pub fn cycle_counter(&self) -> u64 { self.cycle_counter }
+
+    // ── Zero-copy slice accessors ─────────────────────────────────────────────
+
+    pub fn io_registers(&self) -> &[u8] { &self.blob[self.io_range.clone()] }
+    pub fn ie(&self) -> u8 { self.blob[self.ie_offset] }
+    pub fn wram(&self) -> &[u8] { &self.blob[self.wram_range.clone()] }
+    pub fn hram(&self) -> &[u8] { &self.blob[self.hram_range.clone()] }
+    pub fn vram(&self) -> &[u8] { &self.blob[self.vram_range.clone()] }
+    pub fn oam(&self) -> &[u8]  { &self.blob[self.oam_range.clone()] }
+    pub fn cart_ram(&self) -> Option<&[u8]> {
+        self.cart_ram_range.as_ref().map(|r| &self.blob[r.clone()])
+    }
+}

--- a/core/src/cpu/save_state.rs
+++ b/core/src/cpu/save_state.rs
@@ -10,15 +10,55 @@
 //! parse time. Call `Sm83::load_state(state)` to apply a parsed `SaveState`.
 
 use alloc::vec::Vec;
+use core::mem::size_of;
 use core::ops::Range;
 
 use crate::cpu::peripheral::ppu::PpuMode;
 use crate::cpu::registers::{Flags, Registers};
 use crate::cpu::sm83::ImeState;
 
+// ── Format constants ──────────────────────────────────────────────────────────
+
+pub const MAGIC: &[u8; 4]  = b"RBSS";
+pub const VERSION: u16      = 1;
+
+// Fixed-size regions in the blob (bytes).
+const MAGIC_SIZE:         usize = 4;
+const VERSION_SIZE:       usize = size_of::<u16>();
+const HEADER_SIZE:        usize = MAGIC_SIZE + VERSION_SIZE;
+
+const CPU_REGS_SIZE:      usize = 7 * size_of::<u8>()   // A B C D E H L
+                                + size_of::<u8>()        // F (flags)
+                                + size_of::<u16>()       // SP
+                                + size_of::<u16>();      // PC
+
+const IME_SIZE:           usize = size_of::<u8>();
+const HALTED_SIZE:        usize = size_of::<u8>();
+const CYCLE_COUNTER_SIZE: usize = size_of::<u64>();
+const TIMER_SIZE:         usize = size_of::<u16>();      // internal_counter
+const PPU_SIZE:           usize = size_of::<u16>()       // dot
+                                + size_of::<u8>()        // ly
+                                + size_of::<u8>()        // mode
+                                + size_of::<u8>();       // window_line_counter
+
+const IO_REGS_SIZE:       usize = 0x80;
+const IE_SIZE:            usize = size_of::<u8>();
+const WRAM_SIZE:          usize = 0x2000;
+const HRAM_SIZE:          usize = 0x7F;
+const VRAM_SIZE:          usize = 0x2000;
+const OAM_SIZE:           usize = 0xA0;
+const MBC_SIZE:           usize = 4 * size_of::<u8>();  // rom_bank_lo upper_bits ram_mode ram_enabled
+const CART_RAM_LEN_SIZE:  usize = size_of::<u16>();
+
+/// Minimum valid blob length: everything up through OAM, without optional MBC/cart RAM.
+pub const MIN_BLOB_SIZE: usize = HEADER_SIZE
+    + CPU_REGS_SIZE + IME_SIZE + HALTED_SIZE + CYCLE_COUNTER_SIZE
+    + TIMER_SIZE + PPU_SIZE
+    + IO_REGS_SIZE + IE_SIZE + WRAM_SIZE + HRAM_SIZE + VRAM_SIZE + OAM_SIZE;
+
 // ── Scalar field containers ───────────────────────────────────────────────────
 
-/// CPU register state copied out of the blob at parse time.
+/// CPU register state. Parsed from the blob; does not include IME or halted.
 #[derive(Debug, Clone, Copy)]
 pub struct CpuFields {
     pub a: u8,
@@ -34,23 +74,34 @@ pub struct CpuFields {
 }
 
 impl CpuFields {
+    /// Parse from `blob` at `offset`. Returns `(fields, bytes_consumed)`.
+    fn parse(blob: &[u8], offset: usize) -> (Self, usize) {
+        let b = &blob[offset..];
+        let fields = CpuFields {
+            a:  b[0],
+            b:  b[1],
+            c:  b[2],
+            d:  b[3],
+            e:  b[4],
+            h:  b[5],
+            l:  b[6],
+            f:  Flags::from_bits_truncate(b[7]),
+            sp: u16::from_le_bytes([b[8],  b[9]]),
+            pc: u16::from_le_bytes([b[10], b[11]]),
+        };
+        (fields, CPU_REGS_SIZE)
+    }
+
     pub fn to_registers(self) -> Registers {
         Registers {
-            a: self.a,
-            b: self.b,
-            c: self.c,
-            d: self.d,
-            e: self.e,
-            h: self.h,
-            l: self.l,
-            f: self.f,
-            sp: self.sp,
-            pc: self.pc,
+            a: self.a, b: self.b, c: self.c, d: self.d,
+            e: self.e, h: self.h, l: self.l, f: self.f,
+            sp: self.sp, pc: self.pc,
         }
     }
 }
 
-/// PPU scalar state copied out of the blob at parse time.
+/// PPU scalar state.
 #[derive(Debug, Clone, Copy)]
 pub struct PpuFields {
     pub dot: u16,
@@ -59,7 +110,26 @@ pub struct PpuFields {
     pub window_line_counter: u8,
 }
 
-/// MBC register state copied out of the blob at parse time.
+impl PpuFields {
+    /// Parse from `blob` at `offset`. Returns `(fields, bytes_consumed)`.
+    fn parse(blob: &[u8], offset: usize) -> (Self, usize) {
+        let b = &blob[offset..];
+        let fields = PpuFields {
+            dot:                  u16::from_le_bytes([b[0], b[1]]),
+            ly:                   b[2],
+            mode: match b[3] {
+                0 => PpuMode::HBlank,
+                1 => PpuMode::VBlank,
+                2 => PpuMode::OamScan,
+                _ => PpuMode::PixelTransfer,
+            },
+            window_line_counter:  b[4],
+        };
+        (fields, PPU_SIZE)
+    }
+}
+
+/// MBC register state.
 #[derive(Debug, Clone, Copy)]
 pub struct MbcFields {
     pub rom_bank_lo: u8,
@@ -68,13 +138,38 @@ pub struct MbcFields {
     pub ram_enabled: bool,
 }
 
+impl MbcFields {
+    /// Parse from `blob` at `offset`. Returns `(fields, bytes_consumed)`.
+    /// Applies the MBC1 bank-0 quirk (rom_bank_lo 0 → 1).
+    fn parse(blob: &[u8], offset: usize) -> (Self, usize) {
+        let b = &blob[offset..];
+        let fields = MbcFields {
+            rom_bank_lo: b[0].max(1),
+            upper_bits:  b[1] & 0x03,
+            ram_mode:    b[2] != 0,
+            ram_enabled: b[3] != 0,
+        };
+        (fields, MBC_SIZE)
+    }
+}
+
+/// Parse IME state from one byte. Returns `(ImeState, bytes_consumed)`.
+fn parse_ime(blob: &[u8], offset: usize) -> (ImeState, usize) {
+    let ime = match blob[offset] {
+        1 => ImeState::Pending,
+        2 => ImeState::Enabled,
+        _ => ImeState::Disabled,
+    };
+    (ime, IME_SIZE)
+}
+
 // ── SaveState ─────────────────────────────────────────────────────────────────
 
 /// A parsed, validated RBSS v1 save state blob.
 ///
 /// The blob is owned by this struct. Large memory regions (WRAM, VRAM, etc.)
-/// are accessed as zero-copy slices via range indices into the blob. Scalar
-/// fields are copied out at parse time and accessible directly.
+/// are zero-copy — accessed as slices via stored range indices. Scalar fields
+/// are copied out at parse time.
 pub struct SaveState {
     blob: Vec<u8>,
 
@@ -88,12 +183,12 @@ pub struct SaveState {
     mbc: Option<MbcFields>,
 
     // Ranges into `blob` for the large memory regions.
-    io_range: Range<usize>,
-    ie_offset: usize,
-    wram_range: Range<usize>,
-    hram_range: Range<usize>,
-    vram_range: Range<usize>,
-    oam_range: Range<usize>,
+    io_range:       Range<usize>,
+    ie_offset:      usize,
+    wram_range:     Range<usize>,
+    hram_range:     Range<usize>,
+    vram_range:     Range<usize>,
+    oam_range:      Range<usize>,
     cart_ram_range: Option<Range<usize>>,
 }
 
@@ -103,110 +198,52 @@ impl SaveState {
     /// Returns `Err` if the blob is too short, has a bad magic, or has an
     /// unsupported version. No emulator state is modified.
     pub fn from_blob(blob: Vec<u8>) -> Result<Self, &'static str> {
-        if blob.len() < 16835 {
+        if blob.len() < MIN_BLOB_SIZE {
             return Err("save state blob too short");
         }
-        if &blob[0..4] != b"RBSS" {
+        if &blob[0..MAGIC_SIZE] != MAGIC {
             return Err("invalid save state magic");
         }
-        let version = u16::from_le_bytes([blob[4], blob[5]]);
-        if version != 1 {
+        let version = u16::from_le_bytes([blob[MAGIC_SIZE], blob[MAGIC_SIZE + 1]]);
+        if version != VERSION {
             return Err("unsupported save state version");
         }
 
-        let mut cur = 6usize;
+        let mut cur = HEADER_SIZE;
 
-        // CPU registers (10 bytes)
-        let cpu = CpuFields {
-            a:  blob[cur],     b: blob[cur + 1], c: blob[cur + 2],
-            d:  blob[cur + 3], e: blob[cur + 4], h: blob[cur + 5],
-            l:  blob[cur + 6],
-            f:  Flags::from_bits_truncate(blob[cur + 7]),
-            sp: u16::from_le_bytes([blob[cur + 8],  blob[cur + 9]]),
-            pc: u16::from_le_bytes([blob[cur + 10], blob[cur + 11]]),
-        };
-        cur += 12;
+        let (cpu, n) = CpuFields::parse(&blob, cur);   cur += n;
 
-        // IME + halted (2 bytes)
-        let ime = match blob[cur] {
-            1 => ImeState::Pending,
-            2 => ImeState::Enabled,
-            _ => ImeState::Disabled,
-        };
-        cur += 1;
-        let halted = blob[cur] != 0;
-        cur += 1;
+        let (ime, n) = parse_ime(&blob, cur);           cur += n;
+        let halted = blob[cur] != 0;                    cur += HALTED_SIZE;
 
-        // Cycle counter (8 bytes)
-        let cycle_counter = u64::from_le_bytes([
-            blob[cur],     blob[cur + 1], blob[cur + 2], blob[cur + 3],
-            blob[cur + 4], blob[cur + 5], blob[cur + 6], blob[cur + 7],
-        ]);
-        cur += 8;
+        let cycle_counter = u64::from_le_bytes(
+            blob[cur..cur + CYCLE_COUNTER_SIZE].try_into().unwrap()
+        );                                              cur += CYCLE_COUNTER_SIZE;
 
-        // Timer (2 bytes)
         let timer_internal_counter = u16::from_le_bytes([blob[cur], blob[cur + 1]]);
-        cur += 2;
+                                                        cur += TIMER_SIZE;
 
-        // PPU (5 bytes)
-        let ppu = PpuFields {
-            dot: u16::from_le_bytes([blob[cur], blob[cur + 1]]),
-            ly:  blob[cur + 2],
-            mode: match blob[cur + 3] {
-                0 => PpuMode::HBlank,
-                1 => PpuMode::VBlank,
-                2 => PpuMode::OamScan,
-                _ => PpuMode::PixelTransfer,
-            },
-            window_line_counter: blob[cur + 4],
-        };
-        cur += 5;
+        let (ppu, n) = PpuFields::parse(&blob, cur);   cur += n;
 
-        // IO registers (0x80 bytes)
-        let io_range = cur..cur + 0x80;
-        cur += 0x80;
+        let io_range  = cur..cur + IO_REGS_SIZE;        cur += IO_REGS_SIZE;
+        let ie_offset = cur;                            cur += IE_SIZE;
+        let wram_range = cur..cur + WRAM_SIZE;          cur += WRAM_SIZE;
+        let hram_range = cur..cur + HRAM_SIZE;          cur += HRAM_SIZE;
+        let vram_range = cur..cur + VRAM_SIZE;          cur += VRAM_SIZE;
+        let oam_range  = cur..cur + OAM_SIZE;           cur += OAM_SIZE;
 
-        // IE register (1 byte)
-        let ie_offset = cur;
-        cur += 1;
-
-        // WRAM (0x2000 bytes)
-        let wram_range = cur..cur + 0x2000;
-        cur += 0x2000;
-
-        // HRAM (0x7F bytes)
-        let hram_range = cur..cur + 0x7F;
-        cur += 0x7F;
-
-        // VRAM (0x2000 bytes)
-        let vram_range = cur..cur + 0x2000;
-        cur += 0x2000;
-
-        // OAM (0xA0 bytes)
-        let oam_range = cur..cur + 0xA0;
-        cur += 0xA0;
-
-        // MBC state (optional, 4 bytes)
-        let mbc = if cur + 4 <= blob.len() {
-            let m = MbcFields {
-                rom_bank_lo: blob[cur].max(1),
-                upper_bits:  blob[cur + 1] & 0x03,
-                ram_mode:    blob[cur + 2] != 0,
-                ram_enabled: blob[cur + 3] != 0,
-            };
-            cur += 4;
+        let mbc = if cur + MBC_SIZE <= blob.len() {
+            let (m, n) = MbcFields::parse(&blob, cur); cur += n;
             Some(m)
         } else {
             None
         };
 
-        // External cart RAM (optional, u16 LE length prefix)
-        let cart_ram_range = if cur + 2 <= blob.len() {
+        let cart_ram_range = if cur + CART_RAM_LEN_SIZE <= blob.len() {
             let ram_len = u16::from_le_bytes([blob[cur], blob[cur + 1]]) as usize;
-            cur += 2;
+            cur += CART_RAM_LEN_SIZE;
             if ram_len > 0 && cur + ram_len <= blob.len() {
-                let range = cur..cur + ram_len;
-                Some(range)
+                Some(cur..cur + ram_len)
             } else {
                 None
             }
@@ -215,39 +252,27 @@ impl SaveState {
         };
 
         Ok(SaveState {
-            blob,
-            cpu,
-            ime,
-            halted,
-            cycle_counter,
-            timer_internal_counter,
-            ppu,
-            mbc,
-            io_range,
-            ie_offset,
-            wram_range,
-            hram_range,
-            vram_range,
-            oam_range,
-            cart_ram_range,
+            blob, cpu, ime, halted, cycle_counter, timer_internal_counter,
+            ppu, mbc, io_range, ie_offset, wram_range, hram_range, vram_range,
+            oam_range, cart_ram_range,
         })
     }
 
     // ── Scalar accessors ──────────────────────────────────────────────────────
 
-    pub fn cpu(&self) -> &CpuFields { &self.cpu }
-    pub fn mbc(&self) -> Option<&MbcFields> { self.mbc.as_ref() }
-    pub fn cycle_counter(&self) -> u64 { self.cycle_counter }
+    pub fn cpu(&self) -> &CpuFields          { &self.cpu }
+    pub fn mbc(&self) -> Option<&MbcFields>  { self.mbc.as_ref() }
+    pub fn cycle_counter(&self) -> u64       { self.cycle_counter }
 
     // ── Zero-copy slice accessors ─────────────────────────────────────────────
 
-    pub fn io_registers(&self) -> &[u8] { &self.blob[self.io_range.clone()] }
-    pub fn ie(&self) -> u8 { self.blob[self.ie_offset] }
-    pub fn wram(&self) -> &[u8] { &self.blob[self.wram_range.clone()] }
-    pub fn hram(&self) -> &[u8] { &self.blob[self.hram_range.clone()] }
-    pub fn vram(&self) -> &[u8] { &self.blob[self.vram_range.clone()] }
-    pub fn oam(&self) -> &[u8]  { &self.blob[self.oam_range.clone()] }
-    pub fn cart_ram(&self) -> Option<&[u8]> {
+    pub fn io_registers(&self) -> &[u8]      { &self.blob[self.io_range.clone()] }
+    pub fn ie(&self) -> u8                   { self.blob[self.ie_offset] }
+    pub fn wram(&self) -> &[u8]              { &self.blob[self.wram_range.clone()] }
+    pub fn hram(&self) -> &[u8]              { &self.blob[self.hram_range.clone()] }
+    pub fn vram(&self) -> &[u8]              { &self.blob[self.vram_range.clone()] }
+    pub fn oam(&self)  -> &[u8]              { &self.blob[self.oam_range.clone()] }
+    pub fn cart_ram(&self) -> Option<&[u8]>  {
         self.cart_ram_range.as_ref().map(|r| &self.blob[r.clone()])
     }
 }

--- a/core/src/cpu/save_state.rs
+++ b/core/src/cpu/save_state.rs
@@ -6,8 +6,8 @@
 //! On the **load path**, `SaveState::from_blob(blob)` parses and validates the
 //! entire blob up front, returning `Err` if anything is wrong before any
 //! emulator state is touched. The struct owns the blob and exposes zero-copy
-//! slice accessors for large memory regions. Scalar fields are copied out at
-//! parse time. Call `Sm83::load_state(state)` to apply a parsed `SaveState`.
+//! slice accessors for large memory regions. Each component's state struct is
+//! copied out at parse time and applied via that component's `load_state`.
 
 use alloc::vec::Vec;
 use core::mem::size_of;
@@ -19,27 +19,28 @@ use crate::cpu::sm83::ImeState;
 
 // ── Format constants ──────────────────────────────────────────────────────────
 
-pub const MAGIC: &[u8; 4]  = b"RBSS";
-pub const VERSION: u16      = 1;
+pub const MAGIC: &[u8; 4] = b"RBSS";
+pub const VERSION: u16     = 1;
 
-// Fixed-size regions in the blob (bytes).
 const MAGIC_SIZE:         usize = 4;
 const VERSION_SIZE:       usize = size_of::<u16>();
 const HEADER_SIZE:        usize = MAGIC_SIZE + VERSION_SIZE;
 
-const CPU_REGS_SIZE:      usize = 7 * size_of::<u8>()   // A B C D E H L
-                                + size_of::<u8>()        // F (flags)
-                                + size_of::<u16>()       // SP
-                                + size_of::<u16>();      // PC
-
+const CPU_REGS_SIZE:      usize = 7 * size_of::<u8>()  // A B C D E H L
+                                + size_of::<u8>()       // F (flags)
+                                + size_of::<u16>()      // SP
+                                + size_of::<u16>();     // PC
 const IME_SIZE:           usize = size_of::<u8>();
 const HALTED_SIZE:        usize = size_of::<u8>();
 const CYCLE_COUNTER_SIZE: usize = size_of::<u64>();
-const TIMER_SIZE:         usize = size_of::<u16>();      // internal_counter
-const PPU_SIZE:           usize = size_of::<u16>()       // dot
-                                + size_of::<u8>()        // ly
-                                + size_of::<u8>()        // mode
-                                + size_of::<u8>();       // window_line_counter
+const CPU_STATE_SIZE:     usize = CPU_REGS_SIZE + IME_SIZE + HALTED_SIZE + CYCLE_COUNTER_SIZE;
+
+const TIMER_STATE_SIZE:   usize = size_of::<u16>();     // internal_counter
+
+const PPU_STATE_SIZE:     usize = size_of::<u16>()      // dot
+                                + size_of::<u8>()       // ly
+                                + size_of::<u8>()       // mode
+                                + size_of::<u8>();      // window_line_counter
 
 const IO_REGS_SIZE:       usize = 0x80;
 const IE_SIZE:            usize = size_of::<u8>();
@@ -47,20 +48,18 @@ const WRAM_SIZE:          usize = 0x2000;
 const HRAM_SIZE:          usize = 0x7F;
 const VRAM_SIZE:          usize = 0x2000;
 const OAM_SIZE:           usize = 0xA0;
-const MBC_SIZE:           usize = 4 * size_of::<u8>();  // rom_bank_lo upper_bits ram_mode ram_enabled
+const MBC_SIZE:           usize = 4 * size_of::<u8>(); // rom_bank_lo upper_bits ram_mode ram_enabled
 const CART_RAM_LEN_SIZE:  usize = size_of::<u16>();
 
 /// Minimum valid blob length: everything up through OAM, without optional MBC/cart RAM.
-pub const MIN_BLOB_SIZE: usize = HEADER_SIZE
-    + CPU_REGS_SIZE + IME_SIZE + HALTED_SIZE + CYCLE_COUNTER_SIZE
-    + TIMER_SIZE + PPU_SIZE
-    + IO_REGS_SIZE + IE_SIZE + WRAM_SIZE + HRAM_SIZE + VRAM_SIZE + OAM_SIZE;
+pub const MIN_BLOB_SIZE: usize = HEADER_SIZE + CPU_STATE_SIZE + TIMER_STATE_SIZE
+    + PPU_STATE_SIZE + IO_REGS_SIZE + IE_SIZE + WRAM_SIZE + HRAM_SIZE + VRAM_SIZE + OAM_SIZE;
 
-// ── Scalar field containers ───────────────────────────────────────────────────
+// ── Component state structs ───────────────────────────────────────────────────
 
-/// CPU register state. Parsed from the blob; does not include IME or halted.
+/// Full CPU state: registers + IME + halted + cycle counter.
 #[derive(Debug, Clone, Copy)]
-pub struct CpuFields {
+pub struct CpuState {
     pub a: u8,
     pub b: u8,
     pub c: u8,
@@ -71,25 +70,34 @@ pub struct CpuFields {
     pub f: Flags,
     pub sp: u16,
     pub pc: u16,
+    pub ime: ImeState,
+    pub halted: bool,
+    pub cycle_counter: u64,
 }
 
-impl CpuFields {
-    /// Parse from `blob` at `offset`. Returns `(fields, bytes_consumed)`.
+impl CpuState {
     fn parse(blob: &[u8], offset: usize) -> (Self, usize) {
         let b = &blob[offset..];
-        let fields = CpuFields {
-            a:  b[0],
-            b:  b[1],
-            c:  b[2],
-            d:  b[3],
-            e:  b[4],
-            h:  b[5],
-            l:  b[6],
+        let ime = match b[CPU_REGS_SIZE] {
+            1 => ImeState::Pending,
+            2 => ImeState::Enabled,
+            _ => ImeState::Disabled,
+        };
+        let state = CpuState {
+            a:  b[0], b: b[1], c: b[2], d: b[3],
+            e:  b[4], h: b[5], l: b[6],
             f:  Flags::from_bits_truncate(b[7]),
             sp: u16::from_le_bytes([b[8],  b[9]]),
             pc: u16::from_le_bytes([b[10], b[11]]),
+            ime,
+            halted:        b[CPU_REGS_SIZE + IME_SIZE] != 0,
+            cycle_counter: u64::from_le_bytes(
+                b[CPU_REGS_SIZE + IME_SIZE + HALTED_SIZE
+                ..CPU_REGS_SIZE + IME_SIZE + HALTED_SIZE + CYCLE_COUNTER_SIZE]
+                    .try_into().unwrap()
+            ),
         };
-        (fields, CPU_REGS_SIZE)
+        (state, CPU_STATE_SIZE)
     }
 
     pub fn to_registers(self) -> Registers {
@@ -101,88 +109,85 @@ impl CpuFields {
     }
 }
 
-/// PPU scalar state.
+/// Timer peripheral state.
 #[derive(Debug, Clone, Copy)]
-pub struct PpuFields {
+pub struct TimerState {
+    pub internal_counter: u16,
+}
+
+impl TimerState {
+    fn parse(blob: &[u8], offset: usize) -> (Self, usize) {
+        let state = TimerState {
+            internal_counter: u16::from_le_bytes([blob[offset], blob[offset + 1]]),
+        };
+        (state, TIMER_STATE_SIZE)
+    }
+}
+
+/// PPU peripheral state.
+#[derive(Debug, Clone, Copy)]
+pub struct PpuState {
     pub dot: u16,
     pub ly: u8,
     pub mode: PpuMode,
     pub window_line_counter: u8,
 }
 
-impl PpuFields {
-    /// Parse from `blob` at `offset`. Returns `(fields, bytes_consumed)`.
+impl PpuState {
     fn parse(blob: &[u8], offset: usize) -> (Self, usize) {
         let b = &blob[offset..];
-        let fields = PpuFields {
-            dot:                  u16::from_le_bytes([b[0], b[1]]),
-            ly:                   b[2],
+        let state = PpuState {
+            dot:                 u16::from_le_bytes([b[0], b[1]]),
+            ly:                  b[2],
             mode: match b[3] {
                 0 => PpuMode::HBlank,
                 1 => PpuMode::VBlank,
                 2 => PpuMode::OamScan,
                 _ => PpuMode::PixelTransfer,
             },
-            window_line_counter:  b[4],
+            window_line_counter: b[4],
         };
-        (fields, PPU_SIZE)
+        (state, PPU_STATE_SIZE)
     }
 }
 
-/// MBC register state.
+/// MBC register state (covers MBC1 and MBC1Multicart layouts).
 #[derive(Debug, Clone, Copy)]
-pub struct MbcFields {
+pub struct MbcState {
     pub rom_bank_lo: u8,
     pub upper_bits: u8,
     pub ram_mode: bool,
     pub ram_enabled: bool,
 }
 
-impl MbcFields {
-    /// Parse from `blob` at `offset`. Returns `(fields, bytes_consumed)`.
-    /// Applies the MBC1 bank-0 quirk (rom_bank_lo 0 → 1).
+impl MbcState {
     fn parse(blob: &[u8], offset: usize) -> (Self, usize) {
         let b = &blob[offset..];
-        let fields = MbcFields {
+        let state = MbcState {
             rom_bank_lo: b[0].max(1),
             upper_bits:  b[1] & 0x03,
             ram_mode:    b[2] != 0,
             ram_enabled: b[3] != 0,
         };
-        (fields, MBC_SIZE)
+        (state, MBC_SIZE)
     }
-}
-
-/// Parse IME state from one byte. Returns `(ImeState, bytes_consumed)`.
-fn parse_ime(blob: &[u8], offset: usize) -> (ImeState, usize) {
-    let ime = match blob[offset] {
-        1 => ImeState::Pending,
-        2 => ImeState::Enabled,
-        _ => ImeState::Disabled,
-    };
-    (ime, IME_SIZE)
 }
 
 // ── SaveState ─────────────────────────────────────────────────────────────────
 
 /// A parsed, validated RBSS v1 save state blob.
 ///
-/// The blob is owned by this struct. Large memory regions (WRAM, VRAM, etc.)
-/// are zero-copy — accessed as slices via stored range indices. Scalar fields
-/// are copied out at parse time.
+/// Owns the blob. Large memory regions are zero-copy slices via range indices.
+/// Each component's state is a typed struct applied via that component's
+/// `load_state` method.
 pub struct SaveState {
     blob: Vec<u8>,
 
-    // Scalar fields — cheap to copy, exposed directly.
-    cpu: CpuFields,
-    pub ime: ImeState,
-    pub halted: bool,
-    pub cycle_counter: u64,
-    pub timer_internal_counter: u16,
-    pub ppu: PpuFields,
-    mbc: Option<MbcFields>,
+    pub cpu:   CpuState,
+    pub timer: TimerState,
+    pub ppu:   PpuState,
+    mbc:       Option<MbcState>,
 
-    // Ranges into `blob` for the large memory regions.
     io_range:       Range<usize>,
     ie_offset:      usize,
     wram_range:     Range<usize>,
@@ -211,29 +216,19 @@ impl SaveState {
 
         let mut cur = HEADER_SIZE;
 
-        let (cpu, n) = CpuFields::parse(&blob, cur);   cur += n;
+        let (cpu,   n) = CpuState::parse(&blob, cur);   cur += n;
+        let (timer, n) = TimerState::parse(&blob, cur);  cur += n;
+        let (ppu,   n) = PpuState::parse(&blob, cur);    cur += n;
 
-        let (ime, n) = parse_ime(&blob, cur);           cur += n;
-        let halted = blob[cur] != 0;                    cur += HALTED_SIZE;
-
-        let cycle_counter = u64::from_le_bytes(
-            blob[cur..cur + CYCLE_COUNTER_SIZE].try_into().unwrap()
-        );                                              cur += CYCLE_COUNTER_SIZE;
-
-        let timer_internal_counter = u16::from_le_bytes([blob[cur], blob[cur + 1]]);
-                                                        cur += TIMER_SIZE;
-
-        let (ppu, n) = PpuFields::parse(&blob, cur);   cur += n;
-
-        let io_range  = cur..cur + IO_REGS_SIZE;        cur += IO_REGS_SIZE;
-        let ie_offset = cur;                            cur += IE_SIZE;
-        let wram_range = cur..cur + WRAM_SIZE;          cur += WRAM_SIZE;
-        let hram_range = cur..cur + HRAM_SIZE;          cur += HRAM_SIZE;
-        let vram_range = cur..cur + VRAM_SIZE;          cur += VRAM_SIZE;
-        let oam_range  = cur..cur + OAM_SIZE;           cur += OAM_SIZE;
+        let io_range  = cur..cur + IO_REGS_SIZE;          cur += IO_REGS_SIZE;
+        let ie_offset = cur;                              cur += IE_SIZE;
+        let wram_range = cur..cur + WRAM_SIZE;            cur += WRAM_SIZE;
+        let hram_range = cur..cur + HRAM_SIZE;            cur += HRAM_SIZE;
+        let vram_range = cur..cur + VRAM_SIZE;            cur += VRAM_SIZE;
+        let oam_range  = cur..cur + OAM_SIZE;             cur += OAM_SIZE;
 
         let mbc = if cur + MBC_SIZE <= blob.len() {
-            let (m, n) = MbcFields::parse(&blob, cur); cur += n;
+            let (m, n) = MbcState::parse(&blob, cur);    cur += n;
             Some(m)
         } else {
             None
@@ -252,27 +247,23 @@ impl SaveState {
         };
 
         Ok(SaveState {
-            blob, cpu, ime, halted, cycle_counter, timer_internal_counter,
-            ppu, mbc, io_range, ie_offset, wram_range, hram_range, vram_range,
-            oam_range, cart_ram_range,
+            blob, cpu, timer, ppu, mbc,
+            io_range, ie_offset, wram_range, hram_range, vram_range, oam_range,
+            cart_ram_range,
         })
     }
 
-    // ── Scalar accessors ──────────────────────────────────────────────────────
+    // ── Accessors ─────────────────────────────────────────────────────────────
 
-    pub fn cpu(&self) -> &CpuFields          { &self.cpu }
-    pub fn mbc(&self) -> Option<&MbcFields>  { self.mbc.as_ref() }
-    pub fn cycle_counter(&self) -> u64       { self.cycle_counter }
+    pub fn mbc(&self) -> Option<&MbcState>  { self.mbc.as_ref() }
 
-    // ── Zero-copy slice accessors ─────────────────────────────────────────────
-
-    pub fn io_registers(&self) -> &[u8]      { &self.blob[self.io_range.clone()] }
-    pub fn ie(&self) -> u8                   { self.blob[self.ie_offset] }
-    pub fn wram(&self) -> &[u8]              { &self.blob[self.wram_range.clone()] }
-    pub fn hram(&self) -> &[u8]              { &self.blob[self.hram_range.clone()] }
-    pub fn vram(&self) -> &[u8]              { &self.blob[self.vram_range.clone()] }
-    pub fn oam(&self)  -> &[u8]              { &self.blob[self.oam_range.clone()] }
-    pub fn cart_ram(&self) -> Option<&[u8]>  {
+    pub fn io_registers(&self) -> &[u8]     { &self.blob[self.io_range.clone()] }
+    pub fn ie(&self) -> u8                  { self.blob[self.ie_offset] }
+    pub fn wram(&self) -> &[u8]             { &self.blob[self.wram_range.clone()] }
+    pub fn hram(&self) -> &[u8]             { &self.blob[self.hram_range.clone()] }
+    pub fn vram(&self) -> &[u8]             { &self.blob[self.vram_range.clone()] }
+    pub fn oam(&self)  -> &[u8]             { &self.blob[self.oam_range.clone()] }
+    pub fn cart_ram(&self) -> Option<&[u8]> {
         self.cart_ram_range.as_ref().map(|r| &self.blob[r.clone()])
     }
 }

--- a/core/src/cpu/save_state.rs
+++ b/core/src/cpu/save_state.rs
@@ -16,6 +16,7 @@ use core::ops::Range;
 use crate::cpu::peripheral::ppu::PpuMode;
 use crate::cpu::registers::{Flags, Registers};
 use crate::cpu::sm83::ImeState;
+use crate::memory::memory::GameBoyMemory;
 
 // ── Format constants ──────────────────────────────────────────────────────────
 
@@ -198,6 +199,41 @@ pub struct SaveState {
 }
 
 impl SaveState {
+    /// Serialize emulator state into an RBSS v1 blob.
+    ///
+    /// Called by `Sm83::save_state` which constructs the typed state structs
+    /// from its own fields and passes them here. This function owns the format.
+    pub fn serialize(cpu: CpuState, timer: TimerState, ppu: PpuState, memory: &GameBoyMemory) -> Vec<u8> {
+        let mut out = Vec::with_capacity(MIN_BLOB_SIZE);
+        // Header
+        out.extend_from_slice(MAGIC);
+        out.extend_from_slice(&VERSION.to_le_bytes());
+        // CPU registers
+        out.push(cpu.a); out.push(cpu.b); out.push(cpu.c); out.push(cpu.d);
+        out.push(cpu.e); out.push(cpu.h); out.push(cpu.l);
+        out.push(cpu.f.bits());
+        out.extend_from_slice(&cpu.sp.to_le_bytes());
+        out.extend_from_slice(&cpu.pc.to_le_bytes());
+        // IME + halted + cycle counter
+        out.push(match cpu.ime {
+            ImeState::Disabled => 0,
+            ImeState::Pending  => 1,
+            ImeState::Enabled  => 2,
+        });
+        out.push(cpu.halted as u8);
+        out.extend_from_slice(&cpu.cycle_counter.to_le_bytes());
+        // Timer
+        out.extend_from_slice(&timer.internal_counter.to_le_bytes());
+        // PPU
+        out.extend_from_slice(&ppu.dot.to_le_bytes());
+        out.push(ppu.ly);
+        out.push(ppu.mode as u8);
+        out.push(ppu.window_line_counter);
+        // Memory regions (IO regs, WRAM, HRAM, VRAM, OAM, MBC state, cart RAM)
+        memory.save_state(&mut out);
+        out
+    }
+
     /// Parse and validate a raw RBSS v1 blob.
     ///
     /// Returns `Err` if the blob is too short, has a bad magic, or has an

--- a/core/src/cpu/save_state.rs
+++ b/core/src/cpu/save_state.rs
@@ -77,6 +77,21 @@ pub struct CpuState {
 }
 
 impl CpuState {
+    pub fn serialize(&self, out: &mut Vec<u8>) {
+        out.push(self.a); out.push(self.b); out.push(self.c); out.push(self.d);
+        out.push(self.e); out.push(self.h); out.push(self.l);
+        out.push(self.f.bits());
+        out.extend_from_slice(&self.sp.to_le_bytes());
+        out.extend_from_slice(&self.pc.to_le_bytes());
+        out.push(match self.ime {
+            ImeState::Disabled => 0,
+            ImeState::Pending  => 1,
+            ImeState::Enabled  => 2,
+        });
+        out.push(self.halted as u8);
+        out.extend_from_slice(&self.cycle_counter.to_le_bytes());
+    }
+
     fn parse(blob: &[u8], offset: usize) -> (Self, usize) {
         let b = &blob[offset..];
         let ime = match b[CPU_REGS_SIZE] {
@@ -117,6 +132,10 @@ pub struct TimerState {
 }
 
 impl TimerState {
+    pub fn serialize(&self, out: &mut Vec<u8>) {
+        out.extend_from_slice(&self.internal_counter.to_le_bytes());
+    }
+
     fn parse(blob: &[u8], offset: usize) -> (Self, usize) {
         let state = TimerState {
             internal_counter: u16::from_le_bytes([blob[offset], blob[offset + 1]]),
@@ -135,6 +154,13 @@ pub struct PpuState {
 }
 
 impl PpuState {
+    pub fn serialize(&self, out: &mut Vec<u8>) {
+        out.extend_from_slice(&self.dot.to_le_bytes());
+        out.push(self.ly);
+        out.push(self.mode as u8);
+        out.push(self.window_line_counter);
+    }
+
     fn parse(blob: &[u8], offset: usize) -> (Self, usize) {
         let b = &blob[offset..];
         let state = PpuState {
@@ -205,31 +231,11 @@ impl SaveState {
     /// from its own fields and passes them here. This function owns the format.
     pub fn serialize(cpu: CpuState, timer: TimerState, ppu: PpuState, memory: &GameBoyMemory) -> Vec<u8> {
         let mut out = Vec::with_capacity(MIN_BLOB_SIZE);
-        // Header
         out.extend_from_slice(MAGIC);
         out.extend_from_slice(&VERSION.to_le_bytes());
-        // CPU registers
-        out.push(cpu.a); out.push(cpu.b); out.push(cpu.c); out.push(cpu.d);
-        out.push(cpu.e); out.push(cpu.h); out.push(cpu.l);
-        out.push(cpu.f.bits());
-        out.extend_from_slice(&cpu.sp.to_le_bytes());
-        out.extend_from_slice(&cpu.pc.to_le_bytes());
-        // IME + halted + cycle counter
-        out.push(match cpu.ime {
-            ImeState::Disabled => 0,
-            ImeState::Pending  => 1,
-            ImeState::Enabled  => 2,
-        });
-        out.push(cpu.halted as u8);
-        out.extend_from_slice(&cpu.cycle_counter.to_le_bytes());
-        // Timer
-        out.extend_from_slice(&timer.internal_counter.to_le_bytes());
-        // PPU
-        out.extend_from_slice(&ppu.dot.to_le_bytes());
-        out.push(ppu.ly);
-        out.push(ppu.mode as u8);
-        out.push(ppu.window_line_counter);
-        // Memory regions (IO regs, WRAM, HRAM, VRAM, OAM, MBC state, cart RAM)
+        cpu.serialize(&mut out);
+        timer.serialize(&mut out);
+        ppu.serialize(&mut out);
         memory.save_state(&mut out);
         out
     }

--- a/core/src/cpu/sm83.rs
+++ b/core/src/cpu/sm83.rs
@@ -284,17 +284,12 @@ impl Sm83 {
     /// well-formed `SaveState`. Returns `Ok(())` always; kept as `Result` for
     /// call-site symmetry and future extensibility.
     pub fn load_state(&mut self, state: SaveState) -> Result<(), &'static str> {
-        self.registers = state.cpu().to_registers();
-        self.ime = state.ime;
-        self.halted = state.halted;
-        self.cycle_counter = state.cycle_counter;
-        self.timer.set_internal_counter(state.timer_internal_counter);
-        self.ppu.apply_fields(
-            state.ppu.dot,
-            state.ppu.ly,
-            state.ppu.mode,
-            state.ppu.window_line_counter,
-        );
+        self.ime           = state.cpu.ime;
+        self.halted        = state.cpu.halted;
+        self.cycle_counter = state.cpu.cycle_counter;
+        self.registers.apply_state(state.cpu);
+        self.timer.load_state(state.timer);
+        self.ppu.load_state(state.ppu);
         self.memory.load_from_save_state(&state);
         Ok(())
     }

--- a/core/src/cpu/sm83.rs
+++ b/core/src/cpu/sm83.rs
@@ -284,13 +284,13 @@ impl Sm83 {
     /// well-formed `SaveState`. Returns `Ok(())` always; kept as `Result` for
     /// call-site symmetry and future extensibility.
     pub fn load_state(&mut self, state: SaveState) -> Result<(), &'static str> {
+        self.registers     = state.cpu.to_registers();
         self.ime           = state.cpu.ime;
         self.halted        = state.cpu.halted;
         self.cycle_counter = state.cpu.cycle_counter;
-        self.registers.apply_state(state.cpu);
         self.timer.load_state(state.timer);
         self.ppu.load_state(state.ppu);
-        self.memory.load_from_save_state(&state);
+        self.memory.load_state(&state);
         Ok(())
     }
 

--- a/core/src/cpu/sm83.rs
+++ b/core/src/cpu/sm83.rs
@@ -44,6 +44,7 @@ use super::peripheral::timer::{
     TimerInput, TimerPeripheral, DIV_ADDR, TIMA_ADDR, TIMER_INTERRUPT_BIT, TMA_ADDR, TAC_ADDR,
 };
 use super::registers::{Flags, Registers};
+use super::save_state::SaveState;
 
 use crate::memory::memory::{Error as MemoryError, GameBoyMemory, Memory as MemoryBus};
 
@@ -55,7 +56,7 @@ impl From<MemoryError> for InstructionError {
 
 /// Interrupt Master Enable state. EI has a 1-instruction delay before IME becomes active.
 #[derive(Debug, PartialEq, Clone, Copy)]
-enum ImeState {
+pub enum ImeState {
     Disabled,
     /// EI was just executed — IME activates after the next instruction.
     Pending,
@@ -276,39 +277,25 @@ impl Sm83 {
         out
     }
 
-    /// Restore emulator state from a blob produced by `save_state`.
-    /// Returns `Err` with a description if the blob is invalid.
-    pub fn load_state(&mut self, data: &[u8]) -> Result<(), &'static str> {
-        // Minimum size covers header + CPU + timer + PPU + memory (without MBC state).
-        // MBC state is appended after and may be absent in older saves.
-        if data.len() < 16835 {
-            return Err("save state blob too short");
-        }
-        if &data[0..4] != b"RBSS" {
-            return Err("invalid save state magic");
-        }
-        let version = u16::from_le_bytes([data[4], data[5]]);
-        if version != 1 {
-            return Err("unsupported save state version");
-        }
-        let mut offset = 6;
-        offset += self.registers.load_state(data, offset);
-        self.ime = match data[offset] {
-            1 => ImeState::Pending,
-            2 => ImeState::Enabled,
-            _ => ImeState::Disabled,
-        };
-        offset += 1;
-        self.halted = data[offset] != 0;
-        offset += 1;
-        self.cycle_counter = u64::from_le_bytes([
-            data[offset],     data[offset + 1], data[offset + 2], data[offset + 3],
-            data[offset + 4], data[offset + 5], data[offset + 6], data[offset + 7],
-        ]);
-        offset += 8;
-        offset += self.timer.load_state(data, offset);
-        offset += self.ppu.load_state(data, offset);
-        self.memory.load_state(data, offset);
+    /// Restore emulator state from a parsed [`SaveState`].
+    ///
+    /// The blob is fully validated before this is called (via
+    /// [`SaveState::from_blob`]), so applying here is infallible given a
+    /// well-formed `SaveState`. Returns `Ok(())` always; kept as `Result` for
+    /// call-site symmetry and future extensibility.
+    pub fn load_state(&mut self, state: SaveState) -> Result<(), &'static str> {
+        self.registers = state.cpu().to_registers();
+        self.ime = state.ime;
+        self.halted = state.halted;
+        self.cycle_counter = state.cycle_counter;
+        self.timer.set_internal_counter(state.timer_internal_counter);
+        self.ppu.apply_fields(
+            state.ppu.dot,
+            state.ppu.ly,
+            state.ppu.mode,
+            state.ppu.window_line_counter,
+        );
+        self.memory.load_from_save_state(&state);
         Ok(())
     }
 

--- a/core/src/cpu/sm83.rs
+++ b/core/src/cpu/sm83.rs
@@ -44,7 +44,7 @@ use super::peripheral::timer::{
     TimerInput, TimerPeripheral, DIV_ADDR, TIMA_ADDR, TIMER_INTERRUPT_BIT, TMA_ADDR, TAC_ADDR,
 };
 use super::registers::{Flags, Registers};
-use super::save_state::SaveState;
+use super::save_state::{CpuState, SaveState};
 
 use crate::memory::memory::{Error as MemoryError, GameBoyMemory, Memory as MemoryBus};
 
@@ -228,53 +228,16 @@ impl Sm83 {
         self.memory.set_external_ram(data);
     }
 
-    /// Serialize the full emulator state to a byte blob.
-    ///
-    /// Format:
-    ///   [0..4]   magic "RBSS"
-    ///   [4..6]   version u16 LE (= 1)
-    ///   [6]      A
-    ///   [7]      B
-    ///   [8]      C
-    ///   [9]      D
-    ///   [10]     E
-    ///   [11]     H
-    ///   [12]     L
-    ///   [13]     F (flags byte)
-    ///   [14..16] SP u16 LE
-    ///   [16..18] PC u16 LE
-    ///   [18]     IME (0=disabled, 1=pending, 2=enabled)
-    ///   [19]     halted (0/1)
-    ///   [20..28] cycle_counter u64 LE
-    ///   [28..30] timer internal_counter u16 LE
-    ///   [30..32] PPU dot u16 LE
-    ///   [32]     PPU ly
-    ///   [33]     PPU mode
-    ///   [34]     PPU window_line_counter
-    ///   [35..163]  IO registers (0xFF00–0xFF7F, 0x80 bytes)
-    ///   [163]    IE register
-    ///   [164..8356]   WRAM (0x2000 bytes)
-    ///   [8356..8483]  HRAM (0x7F bytes)
-    ///   [8483..16675] VRAM (0x2000 bytes)
-    ///   [16675..16835] OAM (0xA0 bytes)
+    /// Serialize the full emulator state to an RBSS v1 blob.
     pub fn save_state(&self) -> alloc::vec::Vec<u8> {
-        let mut out = alloc::vec::Vec::with_capacity(16835);
-        // Header
-        out.extend_from_slice(b"RBSS");
-        out.extend_from_slice(&1u16.to_le_bytes());
-        // Components
-        self.registers.save_state(&mut out);
-        out.push(match self.ime {
-            ImeState::Disabled => 0,
-            ImeState::Pending  => 1,
-            ImeState::Enabled  => 2,
-        });
-        out.push(self.halted as u8);
-        out.extend_from_slice(&self.cycle_counter.to_le_bytes());
-        self.timer.save_state(&mut out);
-        self.ppu.save_state(&mut out);
-        self.memory.save_state(&mut out);
-        out
+        let cpu = CpuState {
+            a: self.registers.a, b: self.registers.b, c: self.registers.c,
+            d: self.registers.d, e: self.registers.e, h: self.registers.h,
+            l: self.registers.l, f: self.registers.f,
+            sp: self.registers.sp, pc: self.registers.pc,
+            ime: self.ime, halted: self.halted, cycle_counter: self.cycle_counter,
+        };
+        SaveState::serialize(cpu, self.timer.to_save_state(), self.ppu.to_save_state(), &self.memory)
     }
 
     /// Restore emulator state from a parsed [`SaveState`].

--- a/core/src/memory/memory.rs
+++ b/core/src/memory/memory.rs
@@ -223,39 +223,8 @@ impl GameBoyMemory {
         }
     }
 
-    /// Deserialize memory state from `data` at `offset`. Advances offset past all regions.
-    /// Deserialize memory state from `data` at byte `offset`. Returns the number of bytes consumed.
-    pub fn load_state(&mut self, data: &[u8], offset: usize) -> usize {
-        let mut cur = offset;
-        for i in 0..0x80u16 {
-            self.write_io(0xFF00 + i, data[cur + i as usize]);
-        }
-        cur += 0x80;
-        self.ie = data[cur];
-        cur += 1;
-        self.set_wram(&data[cur..cur + 0x2000]);
-        cur += 0x2000;
-        self.set_hram(&data[cur..cur + 0x7F]);
-        cur += 0x7F;
-        self.set_vram(&data[cur..cur + 0x2000]);
-        cur += 0x2000;
-        self.set_oam(&data[cur..cur + 0xA0]);
-        cur += 0xA0;
-        cur += self.cartridge.load_mbc_state(data, cur);
-        // External RAM: read u16 LE length, then restore that many bytes.
-        if cur + 2 <= data.len() {
-            let ram_len = u16::from_le_bytes([data[cur], data[cur + 1]]) as usize;
-            cur += 2;
-            if ram_len > 0 && cur + ram_len <= data.len() {
-                self.cartridge.set_external_ram(&data[cur..cur + ram_len]);
-                cur += ram_len;
-            }
-        }
-        cur - offset
-    }
-
     /// Apply memory state from a parsed [`SaveState`]. Zero-copy for large regions.
-    pub fn load_from_save_state(&mut self, state: &SaveState) {
+    pub fn load_state(&mut self, state: &SaveState) {
         let io = state.io_registers();
         for i in 0..0x80u16 {
             self.write_io(0xFF00 + i, io[i as usize]);

--- a/core/src/memory/memory.rs
+++ b/core/src/memory/memory.rs
@@ -209,6 +209,17 @@ impl GameBoyMemory {
         out.extend_from_slice(self.vram());
         out.extend_from_slice(self.oam());
         self.cartridge.save_mbc_state(out);
+        // External RAM (cart SRAM): prefix with u16 LE length so load_state
+        // can handle carts with no RAM (len=0) and varying RAM sizes.
+        match self.cartridge.external_ram() {
+            Some(ram) => {
+                out.extend_from_slice(&(ram.len() as u16).to_le_bytes());
+                out.extend_from_slice(ram);
+            }
+            None => {
+                out.extend_from_slice(&0u16.to_le_bytes());
+            }
+        }
     }
 
     /// Deserialize memory state from `data` at `offset`. Advances offset past all regions.
@@ -230,6 +241,15 @@ impl GameBoyMemory {
         self.set_oam(&data[cur..cur + 0xA0]);
         cur += 0xA0;
         cur += self.cartridge.load_mbc_state(data, cur);
+        // External RAM: read u16 LE length, then restore that many bytes.
+        if cur + 2 <= data.len() {
+            let ram_len = u16::from_le_bytes([data[cur], data[cur + 1]]) as usize;
+            cur += 2;
+            if ram_len > 0 && cur + ram_len <= data.len() {
+                self.cartridge.set_external_ram(&data[cur..cur + ram_len]);
+                cur += ram_len;
+            }
+        }
         cur - offset
     }
 

--- a/core/src/memory/memory.rs
+++ b/core/src/memory/memory.rs
@@ -5,6 +5,7 @@ use core::fmt;
 
 use super::cartridge::{self, Cartridge, NoMbc};
 use super::rom::Ram;
+use crate::cpu::save_state::SaveState;
 
 /// An event produced when a write occurs to an I/O or IE register address.
 #[derive(Debug, PartialEq, Clone)]
@@ -251,6 +252,28 @@ impl GameBoyMemory {
             }
         }
         cur - offset
+    }
+
+    /// Apply memory state from a parsed [`SaveState`]. Zero-copy for large regions.
+    pub fn load_from_save_state(&mut self, state: &SaveState) {
+        let io = state.io_registers();
+        for i in 0..0x80u16 {
+            self.write_io(0xFF00 + i, io[i as usize]);
+        }
+        self.ie = state.ie();
+        self.set_wram(state.wram());
+        self.set_hram(state.hram());
+        self.set_vram(state.vram());
+        self.set_oam(state.oam());
+        if let Some(mbc) = state.mbc() {
+            // Reconstruct MBC register state via the existing load path.
+            // We build a minimal 4-byte buffer and reuse load_mbc_state.
+            let buf = [mbc.rom_bank_lo, mbc.upper_bits, mbc.ram_mode as u8, mbc.ram_enabled as u8];
+            self.cartridge.load_mbc_state(&buf, 0);
+        }
+        if let Some(ram) = state.cart_ram() {
+            self.cartridge.set_external_ram(ram);
+        }
     }
 
     /// Returns the cartridge external RAM (battery save data), or `None` if cart has no RAM.

--- a/core/tests/save_state.rs
+++ b/core/tests/save_state.rs
@@ -6,6 +6,7 @@ use rustyboy_core::cpu::cpu::Cpu;
 use rustyboy_core::cpu::instructions::opcodes::OpCodeDecoder;
 use rustyboy_core::cpu::registers::{Flags, Registers};
 use rustyboy_core::cpu::sm83::Sm83;
+use rustyboy_core::cpu::save_state::SaveState;
 use rustyboy_core::memory::memory::GameBoyMemory;
 
 /// Build a minimal in-memory ROM with a NOP + JR -2 loop at 0x0100.
@@ -58,7 +59,7 @@ fn test_save_state_roundtrip_basic() {
 
     // Restore into a fresh emulator from the same ROM
     let mut cpu2 = make_emulator(rom);
-    cpu2.load_state(&state).expect("load_state failed");
+    cpu2.load_state(SaveState::from_blob(state).expect("from_blob failed")).expect("load_state failed");
 
     let regs_after = cpu2.registers();
     assert_eq!(regs_before.a, regs_after.a, "register A mismatch");
@@ -89,7 +90,7 @@ fn test_save_state_pc_preserved() {
     let state = cpu.save_state();
 
     let mut cpu2 = make_emulator(rom);
-    cpu2.load_state(&state).expect("load_state failed");
+    cpu2.load_state(SaveState::from_blob(state).expect("from_blob failed")).expect("load_state failed");
 
     assert_eq!(pc_before, cpu2.registers().pc, "PC not preserved across save/load");
 }
@@ -111,7 +112,7 @@ fn test_save_state_wram_preserved() {
 
     // Load the patched state into a fresh emulator
     let mut cpu2 = make_emulator(rom);
-    cpu2.load_state(&state).expect("load_state failed");
+    cpu2.load_state(SaveState::from_blob(state).expect("from_blob failed")).expect("load_state failed");
 
     // Read back WRAM via the memory bus (0xC000 maps to WRAM base)
     for (i, &expected) in pattern.iter().enumerate() {
@@ -125,30 +126,21 @@ fn test_save_state_wram_preserved() {
 
 #[test]
 fn test_save_state_invalid_magic() {
-    let rom = make_rom(0x00, 0, 0);
-    let mut cpu = make_emulator(rom);
-
-    // Build a blob of the right length but with wrong magic
     let mut garbage = vec![0xFFu8; 16835];
     garbage[0] = b'X';
     garbage[1] = b'X';
     garbage[2] = b'X';
     garbage[3] = b'X';
 
-    let result = cpu.load_state(&garbage);
-    assert!(result.is_err(), "expected Err for invalid magic, got Ok");
+    assert!(SaveState::from_blob(garbage).is_err(), "expected Err for invalid magic, got Ok");
 }
 
 // ── Too short ─────────────────────────────────────────────────────────────────
 
 #[test]
 fn test_save_state_too_short() {
-    let rom = make_rom(0x00, 0, 0);
-    let mut cpu = make_emulator(rom);
-
-    let short_blob = [0u8; 10];
-    let result = cpu.load_state(&short_blob);
-    assert!(result.is_err(), "expected Err for too-short blob, got Ok");
+    let short_blob = vec![0u8; 10];
+    assert!(SaveState::from_blob(short_blob).is_err(), "expected Err for too-short blob, got Ok");
 }
 
 // ── MBC bank state preserved ──────────────────────────────────────────────────
@@ -194,7 +186,7 @@ fn test_save_state_mbc1_bank_preserved() {
     let mut cpu2 = make_emulator(rom);
     assert_eq!(cpu2.current_rom_bank(), 1, "fresh emulator starts at bank 1");
 
-    cpu2.load_state(&state).expect("load_state failed");
+    cpu2.load_state(SaveState::from_blob(state).expect("from_blob failed")).expect("load_state failed");
 
     // After restoring, bank 7 should be remapped
     assert_eq!(cpu2.current_rom_bank(), 7, "MBC bank not restored across save/load");
@@ -248,7 +240,7 @@ fn test_save_state_mbc1_cart_ram_preserved() {
 
     // Fresh emulator — cart RAM is zeroed
     let mut cpu2 = make_emulator(rom);
-    cpu2.load_state(&state).expect("load_state failed");
+    cpu2.load_state(SaveState::from_blob(state).expect("from_blob failed")).expect("load_state failed");
 
     // Cart RAM must survive the round-trip
     for (i, &expected) in pattern.iter().enumerate() {
@@ -256,6 +248,51 @@ fn test_save_state_mbc1_cart_ram_preserved() {
         assert_eq!(actual, expected,
             "cart RAM byte {i} lost across save/load: got {actual:#04x}, want {expected:#04x}");
     }
+}
+
+// ── SaveState: parse blob, inspect fields, then apply ────────────────────────
+
+#[test]
+fn test_save_state_struct_inspect_then_apply() {
+    let rom = make_rom(0x00, 0, 0);
+    let mut cpu = make_emulator(rom.clone());
+
+    for _ in 0..1000 {
+        cpu.tick().unwrap();
+    }
+
+    let pc_before = cpu.registers().pc;
+    let cycles_before = cpu.cycle_counter();
+
+    // Serialize to blob, then parse into SaveState
+    let blob = cpu.save_state();
+    let state = SaveState::from_blob(blob).expect("SaveState::from_blob failed");
+
+    // Inspect fields before touching any emulator state
+    assert_eq!(state.cpu().pc, pc_before, "SaveState pc field mismatch");
+    assert_eq!(state.cycle_counter(), cycles_before, "SaveState cycle_counter field mismatch");
+
+    // Apply into a fresh emulator and verify
+    let mut cpu2 = make_emulator(rom);
+    cpu2.load_state(state).expect("load_state failed");
+
+    assert_eq!(cpu2.registers().pc, pc_before, "PC not preserved after apply");
+    assert_eq!(cpu2.cycle_counter(), cycles_before, "cycle_counter not preserved after apply");
+}
+
+// ── SaveState: from_blob rejects invalid input ────────────────────────────────
+
+#[test]
+fn test_save_state_from_blob_rejects_bad_magic() {
+    let mut blob = vec![0u8; 16835];
+    blob[0..4].copy_from_slice(b"XXXX");
+    assert!(SaveState::from_blob(blob).is_err());
+}
+
+#[test]
+fn test_save_state_from_blob_rejects_too_short() {
+    let blob = vec![0u8; 10];
+    assert!(SaveState::from_blob(blob).is_err());
 }
 
 // ── Cycle counter preserved ───────────────────────────────────────────────────
@@ -276,7 +313,7 @@ fn test_save_state_roundtrip_preserves_cycle_counter() {
     let state = cpu.save_state();
 
     let mut cpu2 = make_emulator(rom);
-    cpu2.load_state(&state).expect("load_state failed");
+    cpu2.load_state(SaveState::from_blob(state).expect("from_blob failed")).expect("load_state failed");
 
     assert_eq!(cycles_before, cpu2.cycle_counter(), "cycle_counter not preserved across save/load");
 }

--- a/core/tests/save_state.rs
+++ b/core/tests/save_state.rs
@@ -201,6 +201,63 @@ fn test_save_state_mbc1_bank_preserved() {
     assert_eq!(cpu2.read_memory(0x4000).unwrap(), 0xAB, "sentinel should be readable after load_state");
 }
 
+// ── MBC1 cart RAM preserved across save/load ─────────────────────────────────
+
+#[test]
+fn test_save_state_mbc1_cart_ram_preserved() {
+    // MBC1 + RAM + Battery, 32KB ROM, 8KB RAM
+    let mut rom = vec![0u8; 0x8000];
+    rom[0x0147] = 0x03; // MBC1+RAM+BATTERY
+    rom[0x0148] = 0x00; // 32 KB (2 banks)
+    rom[0x0149] = 0x02; // 8 KB RAM (1 bank)
+
+    // Program at 0x0100:
+    //   LD A, 0x0A      ; RAM enable value
+    //   LD (0x0000), A  ; enable external RAM
+    //   NOP / JR -2
+    rom[0x0100] = 0x3E; // LD A, n
+    rom[0x0101] = 0x0A;
+    rom[0x0102] = 0xEA; // LD (nn), A
+    rom[0x0103] = 0x00;
+    rom[0x0104] = 0x00;
+    rom[0x0105] = 0x00; // NOP
+    rom[0x0106] = 0x18; // JR -2
+    rom[0x0107] = 0xFE;
+
+    let mut cpu = make_emulator(rom.clone());
+
+    // Run enough ticks to execute LD A + LD (nn) = ~24 ticks
+    for _ in 0..40 {
+        cpu.tick().unwrap();
+    }
+
+    // Write a known pattern into cart RAM via set_external_ram
+    let pattern: [u8; 16] = [0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88,
+                              0x99, 0xAA, 0xBB, 0xCC, 0xDD, 0xEE, 0xFF, 0x00];
+    let mut ram = vec![0u8; 0x2000];
+    ram[..16].copy_from_slice(&pattern);
+    cpu.set_external_ram(&ram);
+
+    // Verify the write landed (RAM is enabled so bus reads work)
+    for (i, &expected) in pattern.iter().enumerate() {
+        let actual = cpu.read_memory(0xA000 + i as u16).unwrap();
+        assert_eq!(actual, expected, "pre-save cart RAM byte {i} mismatch");
+    }
+
+    let state = cpu.save_state();
+
+    // Fresh emulator — cart RAM is zeroed
+    let mut cpu2 = make_emulator(rom);
+    cpu2.load_state(&state).expect("load_state failed");
+
+    // Cart RAM must survive the round-trip
+    for (i, &expected) in pattern.iter().enumerate() {
+        let actual = cpu2.read_memory(0xA000 + i as u16).unwrap();
+        assert_eq!(actual, expected,
+            "cart RAM byte {i} lost across save/load: got {actual:#04x}, want {expected:#04x}");
+    }
+}
+
 // ── Cycle counter preserved ───────────────────────────────────────────────────
 
 #[test]

--- a/core/tests/save_state.rs
+++ b/core/tests/save_state.rs
@@ -269,8 +269,8 @@ fn test_save_state_struct_inspect_then_apply() {
     let state = SaveState::from_blob(blob).expect("SaveState::from_blob failed");
 
     // Inspect fields before touching any emulator state
-    assert_eq!(state.cpu().pc, pc_before, "SaveState pc field mismatch");
-    assert_eq!(state.cycle_counter(), cycles_before, "SaveState cycle_counter field mismatch");
+    assert_eq!(state.cpu.pc, pc_before, "SaveState pc field mismatch");
+    assert_eq!(state.cpu.cycle_counter, cycles_before, "SaveState cycle_counter field mismatch");
 
     // Apply into a fresh emulator and verify
     let mut cpu2 = make_emulator(rom);

--- a/platform/web/client/src/lib.rs
+++ b/platform/web/client/src/lib.rs
@@ -6,6 +6,7 @@ use rustyboy_core::{
         instructions::opcodes::OpCodeDecoder,
         peripheral::joypad::Button,
         registers::{Flags, Registers},
+        save_state::SaveState,
         sm83::Sm83,
     },
     memory::GameBoyMemory,
@@ -115,7 +116,8 @@ impl EmulatorHandle {
 
     /// Restore emulator state from a blob produced by `save_state`.
     pub fn load_state(&mut self, data: Vec<u8>) -> Result<(), JsValue> {
-        self.cpu.load_state(&data).map_err(|e| JsValue::from_str(e))
+        let state = SaveState::from_blob(data).map_err(|e| JsValue::from_str(e))?;
+        self.cpu.load_state(state).map_err(|e| JsValue::from_str(e))
     }
 
     /// Returns the cartridge external RAM (battery save) as bytes, or an empty Vec


### PR DESCRIPTION
## Summary

- Save states were silently omitting cartridge SRAM contents — only MBC register state was serialized, not the RAM itself
- For games like Wario Land that keep external RAM enabled at runtime and use `0xA000–0xBFFF` as live working memory, loading a save in a different area produced corrupted or crashed state
- Adds a u16-prefixed external RAM region to the RBSS blob (appended after MBC state); carts with no RAM emit `len=0` and are skipped on load, preserving backward compatibility with existing saves

## Test plan

- [ ] New test `test_save_state_mbc1_cart_ram_preserved`: writes a known pattern to cart RAM on an MBC1+RAM cart, saves state, loads into a fresh emulator, verifies pattern survives
- [ ] All 8 existing save state tests still pass
- [ ] Full suite (800+ tests) green

🤖 Generated with [Claude Code](https://claude.com/claude-code)