### PR TITLE
Expand button hit areas to reduce missed edge presses

### DIFF
--- a/platform/web/client/static/style.css
+++ b/platform/web/client/static/style.css
@@ -482,8 +482,8 @@ body {
 .dpad-wrap { flex: 0 0 auto; }
 
 .dpad {
-  width: clamp(110px, 30vw, 140px);
-  height: clamp(110px, 30vw, 140px);
+  width: clamp(120px, 33vw, 152px);
+  height: clamp(120px, 33vw, 152px);
   display: grid;
   grid-template-columns: 1fr 1fr 1fr;
   grid-template-rows: 1fr 1fr 1fr;
@@ -522,8 +522,8 @@ body {
 
 .ab-cluster {
   position: relative;
-  width: clamp(110px, 30vw, 140px);
-  height: clamp(88px, 24vw, 110px);
+  width: clamp(120px, 33vw, 152px);
+  height: clamp(96px, 26vw, 120px);
 }
 
 .ab-btn-wrap {
@@ -539,8 +539,8 @@ body {
 .btn-b-wrap { bottom: 0; left: 0;  }
 
 .action-btn {
-  width: clamp(50px, 13vw, 62px);
-  height: clamp(50px, 13vw, 62px);
+  width: clamp(56px, 14.5vw, 68px);
+  height: clamp(56px, 14.5vw, 68px);
   border-radius: 50%;
   border: none;
   cursor: pointer;
@@ -586,8 +586,8 @@ body {
 }
 
 .mid-btn {
-  width: clamp(44px, 12vw, 56px);
-  height: clamp(18px, 4.5vw, 22px);
+  width: clamp(50px, 13.5vw, 63px);
+  height: clamp(22px, 5.5vw, 27px);
   background: var(--btn-mid);
   border: none;
   border-radius: 20px;


### PR DESCRIPTION
## Summary
- D-pad increased from 110–140px to 120–152px
- A/B buttons increased from 50–62px to 56–68px diameter
- Select/Start width 44–56px → 50–63px, height 18–22px → 22–27px

## Test plan
- [ ] Tap near the outer edge of each d-pad arm — should register
- [ ] Tap near the edge of A and B buttons — should register
- [ ] Tap near the edge of Select and Start — should register
- [ ] Verify no visual regression on desktop and mobile layouts

🤖 Generated with [Claude Code](https://claude.com/claude-code)