### PR TITLE
feat: Pico 2W platform scaffold (Bead 1)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -30,6 +30,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
+name = "arrayvec"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
+
+[[package]]
+name = "ascii-canvas"
+version = "4.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef1e3e699d84ab1b0911a1010c5c106aa34ae89aeac103be5ce0c3859db1e891"
+dependencies = [
+ "term",
+]
+
+[[package]]
 name = "async-trait"
 version = "0.1.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -117,6 +132,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "az"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be5eb007b7cacc6c660343e96f650fedf4b5a77512399eb952ca6642cf8d13f7"
+
+[[package]]
+name = "bare-metal"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5deb64efa5bd81e31fcd1938615a6d98c82eafcbcd787162b6f63b91d6bac5b3"
+dependencies = [
+ "rustc_version 0.2.3",
+]
+
+[[package]]
 name = "base16ct"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -141,6 +171,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
 
 [[package]]
+name = "bit-set"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08807e080ed7f9d5433fa9b275196cfc35414f66a0c79d864dc51a0d825231a3"
+dependencies = [
+ "bit-vec",
+]
+
+[[package]]
+name = "bit-vec"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
+
+[[package]]
+name = "bitfield"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46afbd2983a5d5a7bd740ccb198caf5b82f45c40c09c0eed36052d91cb92e719"
+
+[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -148,11 +199,11 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.5.0"
+version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf4b9d6a944f767f8e5e0db018570623c85f3d925ac718db4e06d0187adb21c1"
+checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
 dependencies = [
- "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -169,6 +220,12 @@ name = "bumpalo"
 version = "3.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
+
+[[package]]
+name = "bytemuck"
+version = "1.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8efb64bd706a16a1bdde310ae86b351e4d21550d98d056f22f8a7f7a2183fec"
 
 [[package]]
 name = "byteorder"
@@ -199,6 +256,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
+name = "chrono"
+version = "0.4.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c673075a2e0e5f4a1dde27ce9dee1ea4558c7ffe648f576438a20ca1d2acc4b0"
+dependencies = [
+ "defmt",
+ "num-traits",
+ "pure-rust-locales",
+]
+
+[[package]]
+name = "codespan-reporting"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3538270d33cc669650c4b093848450d380def10c331d38c768e34cac80576e6e"
+dependencies = [
+ "termcolor",
+ "unicode-width",
+]
+
+[[package]]
 name = "concurrent-queue"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -212,6 +290,16 @@ name = "const-oid"
 version = "0.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
+
+[[package]]
+name = "cordyceps"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "688d7fbb8092b8de775ef2536f36c8c31f2bc4006ece2e8d8ad2d17d00ce0a2a"
+dependencies = [
+ "loom",
+ "tracing",
+]
 
 [[package]]
 name = "core-foundation"
@@ -228,6 +316,38 @@ name = "core-foundation-sys"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
+
+[[package]]
+name = "cortex-m"
+version = "0.7.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ec610d8f49840a5b376c69663b6369e71f4b34484b9b2eb29fb918d92516cb9"
+dependencies = [
+ "bare-metal",
+ "bitfield",
+ "embedded-hal 0.2.7",
+ "volatile-register",
+]
+
+[[package]]
+name = "cortex-m-rt"
+version = "0.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "801d4dec46b34c299ccf6b036717ae0fce602faa4f4fe816d9013b9a7c9f5ba6"
+dependencies = [
+ "cortex-m-rt-macros",
+]
+
+[[package]]
+name = "cortex-m-rt-macros"
+version = "0.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e37549a379a9e0e6e576fd208ee60394ccb8be963889eebba3ffe0980364f472"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "cpufeatures"
@@ -248,6 +368,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "crc-any"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a62ec9ff5f7965e4d7280bd5482acd20aadb50d632cf6c1d74493856b011fa73"
+dependencies = [
+ "debug-helper",
+]
+
+[[package]]
 name = "crc-catalog"
 version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -261,6 +390,12 @@ checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
 dependencies = [
  "cfg-if",
 ]
+
+[[package]]
+name = "critical-section"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "790eea4361631c5e7d22598ecd5723ff611904e3344ce8720784c93e3d83d40b"
 
 [[package]]
 name = "crossbeam-queue"
@@ -278,13 +413,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
+name = "crunchy"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
+
+[[package]]
 name = "crypto-bigint"
 version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0dc92fb57ca44df6db8059111ab3af99a63d5d0f8375d9972e319a379c6bab76"
 dependencies = [
  "generic-array",
- "rand_core",
+ "rand_core 0.6.4",
  "subtle",
  "zeroize",
 ]
@@ -310,7 +451,7 @@ dependencies = [
  "curve25519-dalek-derive",
  "digest",
  "fiat-crypto",
- "rustc_version",
+ "rustc_version 0.4.1",
  "subtle",
  "zeroize",
 ]
@@ -324,6 +465,89 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "darling"
+version = "0.20.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc7f46116c46ff9ab3eb1597a45688b6715c6e628b5c133e288e709a29bcb4ee"
+dependencies = [
+ "darling_core",
+ "darling_macro",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.20.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d00b9596d185e565c2207a0b01f8bd1a135483d02d9b7b0a54b11da8d53412e"
+dependencies = [
+ "fnv",
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.20.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
+dependencies = [
+ "darling_core",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "debug-helper"
+version = "0.3.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f578e8e2c440e7297e008bb5486a3a8a194775224bbc23729b0dbdfaeebf162e"
+
+[[package]]
+name = "defmt"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "548d977b6da32fa1d1fda2876453da1e7df63ad0304c8b3dae4dbe7b96f39b78"
+dependencies = [
+ "bitflags 1.3.2",
+ "defmt-macros",
+]
+
+[[package]]
+name = "defmt-macros"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d4fc12a85bcf441cfe44344c4b72d58493178ce635338a3f3b78943aceb258e"
+dependencies = [
+ "defmt-parser",
+ "proc-macro-error2",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "defmt-parser"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10d60334b3b2e7c9d91ef8150abfb6fa4c1c39ebbcf4a81c2e346aad939fee3e"
+dependencies = [
+ "thiserror",
+]
+
+[[package]]
+name = "defmt-rtt"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93d5a25c99d89c40f5676bec8cefe0614f17f0f40e916f98e345dae941807f9e"
+dependencies = [
+ "critical-section",
+ "defmt",
 ]
 
 [[package]]
@@ -367,6 +591,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "document-features"
+version = "0.2.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4b8a88685455ed29a21542a33abd9cb6510b6b129abadabdcef0f4c55bc8f61"
+dependencies = [
+ "litrs",
 ]
 
 [[package]]
@@ -437,10 +670,243 @@ dependencies = [
  "hkdf",
  "pem-rfc7468",
  "pkcs8",
- "rand_core",
+ "rand_core 0.6.4",
  "sec1",
  "subtle",
  "zeroize",
+]
+
+[[package]]
+name = "embassy-embedded-hal"
+version = "0.6.0"
+source = "git+https://github.com/embassy-rs/embassy#6b015329e6784d084c1b589ba31af7a7dee13a7e"
+dependencies = [
+ "embassy-futures",
+ "embassy-hal-internal",
+ "embassy-sync",
+ "embedded-hal 0.2.7",
+ "embedded-hal 1.0.0",
+ "embedded-hal-async",
+ "embedded-storage",
+ "embedded-storage-async",
+ "nb 1.1.0",
+]
+
+[[package]]
+name = "embassy-executor"
+version = "0.10.0"
+source = "git+https://github.com/embassy-rs/embassy#6b015329e6784d084c1b589ba31af7a7dee13a7e"
+dependencies = [
+ "cordyceps",
+ "cortex-m",
+ "critical-section",
+ "defmt",
+ "document-features",
+ "embassy-executor-macros",
+ "embassy-executor-timer-queue",
+]
+
+[[package]]
+name = "embassy-executor-macros"
+version = "0.8.0"
+source = "git+https://github.com/embassy-rs/embassy#6b015329e6784d084c1b589ba31af7a7dee13a7e"
+dependencies = [
+ "darling",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "embassy-executor-timer-queue"
+version = "0.1.0"
+source = "git+https://github.com/embassy-rs/embassy#6b015329e6784d084c1b589ba31af7a7dee13a7e"
+
+[[package]]
+name = "embassy-futures"
+version = "0.1.2"
+source = "git+https://github.com/embassy-rs/embassy#6b015329e6784d084c1b589ba31af7a7dee13a7e"
+
+[[package]]
+name = "embassy-hal-internal"
+version = "0.5.0"
+source = "git+https://github.com/embassy-rs/embassy#6b015329e6784d084c1b589ba31af7a7dee13a7e"
+dependencies = [
+ "cortex-m",
+ "critical-section",
+ "defmt",
+ "num-traits",
+]
+
+[[package]]
+name = "embassy-rp"
+version = "0.10.0"
+source = "git+https://github.com/embassy-rs/embassy#6b015329e6784d084c1b589ba31af7a7dee13a7e"
+dependencies = [
+ "cfg-if",
+ "chrono",
+ "cortex-m",
+ "cortex-m-rt",
+ "critical-section",
+ "defmt",
+ "document-features",
+ "embassy-embedded-hal",
+ "embassy-futures",
+ "embassy-hal-internal",
+ "embassy-sync",
+ "embassy-time",
+ "embassy-time-driver",
+ "embassy-time-queue-utils",
+ "embassy-usb-driver",
+ "embedded-hal 0.2.7",
+ "embedded-hal 1.0.0",
+ "embedded-hal-async",
+ "embedded-hal-nb",
+ "embedded-io",
+ "embedded-io-async",
+ "embedded-storage",
+ "embedded-storage-async",
+ "fixed",
+ "nb 1.1.0",
+ "pio",
+ "rand_core 0.10.1",
+ "rand_core 0.6.4",
+ "rand_core 0.9.5",
+ "rp-binary-info",
+ "rp-pac",
+ "rp2040-boot2",
+ "sha2-const-stable",
+ "smart-leds",
+]
+
+[[package]]
+name = "embassy-sync"
+version = "0.8.0"
+source = "git+https://github.com/embassy-rs/embassy#6b015329e6784d084c1b589ba31af7a7dee13a7e"
+dependencies = [
+ "cfg-if",
+ "critical-section",
+ "embedded-io-async",
+ "futures-core",
+ "futures-sink",
+ "heapless",
+]
+
+[[package]]
+name = "embassy-time"
+version = "0.5.1"
+source = "git+https://github.com/embassy-rs/embassy#6b015329e6784d084c1b589ba31af7a7dee13a7e"
+dependencies = [
+ "cfg-if",
+ "critical-section",
+ "defmt",
+ "document-features",
+ "embassy-time-driver",
+ "embedded-hal 0.2.7",
+ "embedded-hal 1.0.0",
+ "embedded-hal-async",
+ "futures-core",
+]
+
+[[package]]
+name = "embassy-time-driver"
+version = "0.2.2"
+source = "git+https://github.com/embassy-rs/embassy#6b015329e6784d084c1b589ba31af7a7dee13a7e"
+dependencies = [
+ "document-features",
+]
+
+[[package]]
+name = "embassy-time-queue-utils"
+version = "0.3.0"
+source = "git+https://github.com/embassy-rs/embassy#6b015329e6784d084c1b589ba31af7a7dee13a7e"
+dependencies = [
+ "embassy-executor-timer-queue",
+ "heapless",
+]
+
+[[package]]
+name = "embassy-usb-driver"
+version = "0.2.0"
+source = "git+https://github.com/embassy-rs/embassy#6b015329e6784d084c1b589ba31af7a7dee13a7e"
+dependencies = [
+ "bitflags 2.11.1",
+ "defmt",
+ "embedded-io-async",
+]
+
+[[package]]
+name = "embedded-hal"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35949884794ad573cf46071e41c9b60efb0cb311e3ca01f7af807af1debc66ff"
+dependencies = [
+ "nb 0.1.3",
+ "void",
+]
+
+[[package]]
+name = "embedded-hal"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "361a90feb7004eca4019fb28352a9465666b24f840f5c3cddf0ff13920590b89"
+
+[[package]]
+name = "embedded-hal-async"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c4c685bbef7fe13c3c6dd4da26841ed3980ef33e841cddfa15ce8a8fb3f1884"
+dependencies = [
+ "embedded-hal 1.0.0",
+]
+
+[[package]]
+name = "embedded-hal-nb"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fba4268c14288c828995299e59b12babdbe170f6c6d73731af1b4648142e8605"
+dependencies = [
+ "embedded-hal 1.0.0",
+ "nb 1.1.0",
+]
+
+[[package]]
+name = "embedded-io"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9eb1aa714776b75c7e67e1da744b81a129b3ff919c8712b5e1b32252c1f07cc7"
+
+[[package]]
+name = "embedded-io-async"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2564b9f813c544241430e147d8bc454815ef9ac998878d30cc3055449f7fd4c0"
+dependencies = [
+ "embedded-io",
+]
+
+[[package]]
+name = "embedded-storage"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a21dea9854beb860f3062d10228ce9b976da520a73474aed3171ec276bc0c032"
+
+[[package]]
+name = "embedded-storage-async"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1763775e2323b7d5f0aa6090657f5e21cfa02ede71f5dc40eead06d64dcd15cc"
+dependencies = [
+ "embedded-storage",
+]
+
+[[package]]
+name = "ena"
+version = "0.14.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eabffdaee24bd1bf95c5ef7cec31260444317e72ea56c4c91750e8b7ee58d5f1"
+dependencies = [
+ "log",
 ]
 
 [[package]]
@@ -511,7 +977,7 @@ version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0b50bfb653653f9ca9095b427bed08ab8d75a137839d9ad64eb11810d5b6393"
 dependencies = [
- "rand_core",
+ "rand_core 0.6.4",
  "subtle",
 ]
 
@@ -526,6 +992,24 @@ name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+
+[[package]]
+name = "fixed"
+version = "1.31.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9af2cbf772fa6d1c11358f92ef554cb6b386201210bcf0e91fb7fba8a907fb40"
+dependencies = [
+ "az",
+ "bytemuck",
+ "half",
+ "typenum",
+]
+
+[[package]]
+name = "fixedbitset"
+version = "0.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d674e81391d1e1ab681a28d99df07927c6d4aa5b027d7da16ba32d1d21ecd99"
 
 [[package]]
 name = "flate2"
@@ -641,6 +1125,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "generator"
+version = "0.8.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52f04ae4152da20c76fe800fa48659201d5cf627c5149ca0b707b69d7eef6cf9"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "libc",
+ "log",
+ "rustversion",
+ "windows-link",
+ "windows-result",
+]
+
+[[package]]
 name = "generic-array"
 version = "0.14.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -682,7 +1181,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0f9ef7462f7c099f518d754361858f86d8a07af53ba9af0fe635bbccb151a63"
 dependencies = [
  "ff",
- "rand_core",
+ "rand_core 0.6.4",
  "subtle",
 ]
 
@@ -703,6 +1202,26 @@ dependencies = [
  "tokio",
  "tokio-util",
  "tracing",
+]
+
+[[package]]
+name = "half"
+version = "2.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ea2d84b969582b4b1864a92dc5d27cd2b77b622a8d79306834f1be5ba20d84b"
+dependencies = [
+ "cfg-if",
+ "crunchy",
+ "zerocopy",
+]
+
+[[package]]
+name = "hash32"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47d60b12902ba28e2730cd37e95b8c9223af2808df9e902d4df49588d1470606"
+dependencies = [
+ "byteorder",
 ]
 
 [[package]]
@@ -729,6 +1248,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7382cf6263419f2d8df38c55d7da83da5c18aef87fc7a7fc1fb1e344edfe14c1"
 dependencies = [
  "hashbrown 0.15.5",
+]
+
+[[package]]
+name = "heapless"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2af2455f757db2b292a9b1768c4b70186d443bcb3b316252d6b540aec1cd89ed"
+dependencies = [
+ "hash32",
+ "stable_deref_trait",
 ]
 
 [[package]]
@@ -1005,6 +1534,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
 
 [[package]]
+name = "ident_case"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
+
+[[package]]
 name = "idna"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1042,6 +1577,15 @@ name = "ipnet"
 version = "2.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
+
+[[package]]
+name = "itertools"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
+dependencies = [
+ "either",
+]
 
 [[package]]
 name = "itoa"
@@ -1085,6 +1629,47 @@ dependencies = [
 ]
 
 [[package]]
+name = "keccak"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb26cec98cce3a3d96cbb7bced3c4b16e3d13f27ec56dbd62cbc8f39cfb9d653"
+dependencies = [
+ "cpufeatures",
+]
+
+[[package]]
+name = "lalrpop"
+version = "0.22.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba4ebbd48ce411c1d10fb35185f5a51a7bfa3d8b24b4e330d30c9e3a34129501"
+dependencies = [
+ "ascii-canvas",
+ "bit-set",
+ "ena",
+ "itertools",
+ "lalrpop-util",
+ "petgraph",
+ "pico-args",
+ "regex",
+ "regex-syntax",
+ "sha3",
+ "string_cache",
+ "term",
+ "unicode-xid",
+ "walkdir",
+]
+
+[[package]]
+name = "lalrpop-util"
+version = "0.22.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5baa5e9ff84f1aefd264e6869907646538a52147a755d494517a8007fb48733"
+dependencies = [
+ "regex-automata",
+ "rustversion",
+]
+
+[[package]]
 name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1117,7 +1702,7 @@ version = "0.1.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ddbf48fd451246b1f8c2610bd3b4ac0cc6e149d89832867093ab69a17194f08"
 dependencies = [
- "bitflags 2.5.0",
+ "bitflags 2.11.1",
  "libc",
  "plain",
  "redox_syscall 0.7.3",
@@ -1147,6 +1732,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6373607a59f0be73a39b6fe456b8192fcc3585f602af20751600e974dd455e77"
 
 [[package]]
+name = "litrs"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11d3d7f243d5c5a8b9bb5d6dd2b1602c0cb0b9db1621bafc7ed66e35ff9fe092"
+
+[[package]]
 name = "lock_api"
 version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1160,6 +1751,19 @@ name = "log"
 version = "0.4.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
+
+[[package]]
+name = "loom"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "419e0dc8046cb947daa77eb95ae174acfbddb7673b4151f56d1eed8e93fbfaca"
+dependencies = [
+ "cfg-if",
+ "generator",
+ "scoped-tls",
+ "tracing",
+ "tracing-subscriber",
+]
 
 [[package]]
 name = "matchers"
@@ -1228,6 +1832,27 @@ dependencies = [
  "wasi",
  "windows-sys 0.61.2",
 ]
+
+[[package]]
+name = "nb"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "801d31da0513b6ec5214e9bf433a77966320625a37860f910be265be6e18d06f"
+dependencies = [
+ "nb 1.1.0",
+]
+
+[[package]]
+name = "nb"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8d5439c4ad607c3c23abf66de8c8bf57ba8adcd1f129e699851a6e43935d339d"
+
+[[package]]
+name = "new_debug_unreachable"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "650eef8c711430f1a879fdd01d4745a7deea475becfb90269c06775983bbf086"
 
 [[package]]
 name = "nu-ansi-term"
@@ -1301,6 +1926,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "num_enum"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d0bca838442ec211fa11de3a8b0e0e8f3a4522575b5c4c06ed722e005036f26"
+dependencies = [
+ "num_enum_derive",
+ "rustversion",
+]
+
+[[package]]
+name = "num_enum_derive"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "680998035259dcfcafe653688bf2aa6d3e2dc05e98be6ab46afb089dc84f1df8"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "once_cell"
 version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1328,6 +1974,16 @@ dependencies = [
  "elliptic-curve",
  "primeorder",
  "sha2",
+]
+
+[[package]]
+name = "panic-probe"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd402d00b0fb94c5aee000029204a46884b1262e0c443f166d86d2c0747e1a1a"
+dependencies = [
+ "cortex-m",
+ "defmt",
 ]
 
 [[package]]
@@ -1360,6 +2016,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "paste"
+version = "1.0.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
+
+[[package]]
 name = "pem"
 version = "3.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1383,6 +2045,31 @@ name = "percent-encoding"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
+
+[[package]]
+name = "petgraph"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3672b37090dbd86368a4145bc067582552b29c27377cad4e0a306c97f9bd7772"
+dependencies = [
+ "fixedbitset",
+ "indexmap",
+]
+
+[[package]]
+name = "phf_shared"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67eabc2ef2a60eb7faa00097bd1ffdb5bd28e62bf39990626a582201b7a754e5"
+dependencies = [
+ "siphasher",
+]
+
+[[package]]
+name = "pico-args"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5be167a7af36ee22fe3115051bc51f6e6c7054c9348e28deb4f49bd6f705a315"
 
 [[package]]
 name = "pin-project"
@@ -1415,6 +2102,54 @@ name = "pin-utils"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
+
+[[package]]
+name = "pio"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0ba4153cee9585abc451271aa437d9e8defdea8b468d48ba6b8f098cbe03d7f"
+dependencies = [
+ "pio-core",
+ "pio-proc",
+]
+
+[[package]]
+name = "pio-core"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61d90fddc3d67f21bbf93683bc461b05d6a29c708caf3ffb79947d7ff7095406"
+dependencies = [
+ "arrayvec",
+ "num_enum",
+ "paste",
+]
+
+[[package]]
+name = "pio-parser"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "825266c1eaddf54f636d06eefa4bf3c99d774c14ec46a4a6c6e5128a0f10d205"
+dependencies = [
+ "lalrpop",
+ "lalrpop-util",
+ "pio-core",
+]
+
+[[package]]
+name = "pio-proc"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed4a76571f5fe51af43cc80ac870fe0c79cc0cdd686b9002a6c4c84bfdd0176b"
+dependencies = [
+ "codespan-reporting",
+ "lalrpop-util",
+ "pio-core",
+ "pio-parser",
+ "proc-macro-error2",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "pkcs1"
@@ -1487,6 +2222,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "precomputed-hash"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "925383efa346730478fb4838dbe9137d2a47675ad789c546d150a6e1dd4ab31c"
+
+[[package]]
 name = "prettyplease"
 version = "0.2.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1506,12 +2247,43 @@ dependencies = [
 ]
 
 [[package]]
+name = "proc-macro-error-attr2"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96de42df36bb9bba5542fe9f1a054b8cc87e172759a1868aa05c1f3acc89dfc5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+]
+
+[[package]]
+name = "proc-macro-error2"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11ec05c52be0a07b08061f7dd003e7d7092e0472bc731b4af7bb1ef876109802"
+dependencies = [
+ "proc-macro-error-attr2",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "pure-rust-locales"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "869675ad2d7541aea90c6d88c81f46a7f4ea9af8cd0395d38f11a95126998a0d"
+dependencies = [
+ "defmt",
 ]
 
 [[package]]
@@ -1537,7 +2309,7 @@ checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
 dependencies = [
  "libc",
  "rand_chacha",
- "rand_core",
+ "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -1547,7 +2319,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
 dependencies = [
  "ppv-lite86",
- "rand_core",
+ "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -1560,12 +2332,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand_core"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
+
+[[package]]
+name = "rand_core"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
+
+[[package]]
 name = "redox_syscall"
 version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
- "bitflags 2.5.0",
+ "bitflags 2.11.1",
 ]
 
 [[package]]
@@ -1574,7 +2358,19 @@ version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ce70a74e890531977d37e532c34d45e9055d2409ed08ddba14529471ed0be16"
 dependencies = [
- "bitflags 2.5.0",
+ "bitflags 2.11.1",
+]
+
+[[package]]
+name = "regex"
+version = "1.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e10754a14b9137dd7b1e3e5b0493cc9171fdd105e0ab477f51b72e7f3ac0e276"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-automata",
+ "regex-syntax",
 ]
 
 [[package]]
@@ -1646,6 +2442,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "rgb"
+version = "0.8.53"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47b34b781b31e5d73e9fbc8689c70551fd1ade9a19e3e28cfec8580a79290cc4"
+
+[[package]]
 name = "ring"
 version = "0.17.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1657,6 +2459,30 @@ dependencies = [
  "libc",
  "untrusted",
  "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "rp-binary-info"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f582261945fa215d40e2988b4df595d11c0908c0fff97a0fe23df766d117b790"
+
+[[package]]
+name = "rp-pac"
+version = "7.0.0"
+source = "git+https://github.com/embassy-rs/rp-pac?rev=c2e27609b021c444f634673155318977d7f0bdf6#c2e27609b021c444f634673155318977d7f0bdf6"
+dependencies = [
+ "cortex-m",
+ "cortex-m-rt",
+]
+
+[[package]]
+name = "rp2040-boot2"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c92f344f63f950ee36cf4080050e4dce850839b9175da38f9d2ffb69b4dbb21"
+dependencies = [
+ "crc-any",
 ]
 
 [[package]]
@@ -1672,7 +2498,7 @@ dependencies = [
  "num-traits",
  "pkcs1",
  "pkcs8",
- "rand_core",
+ "rand_core 0.6.4",
  "sha2",
  "signature",
  "spki",
@@ -1682,11 +2508,20 @@ dependencies = [
 
 [[package]]
 name = "rustc_version"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "138e3e0acb6c9fb258b19b67cb8abd63c00679d2851805ea151465464fe9030a"
+dependencies = [
+ "semver 0.9.0",
+]
+
+[[package]]
+name = "rustc_version"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
 dependencies = [
- "semver",
+ "semver 1.0.27",
 ]
 
 [[package]]
@@ -1695,7 +2530,7 @@ version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
 dependencies = [
- "bitflags 2.5.0",
+ "bitflags 2.11.1",
  "errno",
  "libc",
  "linux-raw-sys",
@@ -1743,8 +2578,22 @@ checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 name = "rustyboy-core"
 version = "0.1.0"
 dependencies = [
- "bitflags 2.5.0",
+ "bitflags 2.11.1",
  "png",
+]
+
+[[package]]
+name = "rustyboy-pico2w"
+version = "0.1.0"
+dependencies = [
+ "cortex-m",
+ "cortex-m-rt",
+ "defmt",
+ "defmt-rtt",
+ "embassy-executor",
+ "embassy-rp",
+ "embassy-time",
+ "panic-probe",
 ]
 
 [[package]]
@@ -1785,6 +2634,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 
 [[package]]
+name = "same-file"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
+dependencies = [
+ "winapi-util",
+]
+
+[[package]]
+name = "scoped-tls"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1cf6437eb19a8f4a6cc0f7dca544973b0b78843adbfeb3683d1a94a0024a294"
+
+[[package]]
 name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1816,9 +2680,24 @@ dependencies = [
 
 [[package]]
 name = "semver"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d7eb9ef2c18661902cc47e535f9bc51b78acd254da71d375c2f6720d9a40403"
+dependencies = [
+ "semver-parser",
+]
+
+[[package]]
+name = "semver"
 version = "1.0.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d767eb0aabc880b29956c35734170f26ed551a859dbd361d140cdbeca61ab1e2"
+
+[[package]]
+name = "semver-parser"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
 
 [[package]]
 name = "serde"
@@ -1909,6 +2788,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha2-const-stable"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f179d4e11094a893b82fff208f74d448a7512f99f5a0acbd5c679b705f83ed9"
+
+[[package]]
+name = "sha3"
+version = "0.10.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75872d278a8f37ef87fa0ddbda7802605cb18344497949862c0d4dcb291eba60"
+dependencies = [
+ "digest",
+ "keccak",
+]
+
+[[package]]
 name = "sharded-slab"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1940,7 +2835,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
 dependencies = [
  "digest",
- "rand_core",
+ "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -1962,6 +2857,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "siphasher"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2aa850e253778c88a04c3d7323b043aeda9d3e30d5971937c1855769763678e"
+
+[[package]]
 name = "slab"
 version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1974,6 +2875,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 dependencies = [
  "serde",
+]
+
+[[package]]
+name = "smart-leds"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "66df34e571fa9993fa6f99131a374d58ca3d694b75f9baac93458fe0d6057bf0"
+dependencies = [
+ "smart-leds-trait",
+]
+
+[[package]]
+name = "smart-leds-trait"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7f4441a131924d58da6b83a7ad765c460e64630cce504376c3a87a2558c487f"
+dependencies = [
+ "rgb",
 ]
 
 [[package]]
@@ -2108,7 +3027,7 @@ checksum = "aa003f0038df784eb8fecbbac13affe3da23b45194bd57dba231c8f48199c526"
 dependencies = [
  "atoi",
  "base64 0.22.1",
- "bitflags 2.5.0",
+ "bitflags 2.11.1",
  "byteorder",
  "bytes",
  "crc",
@@ -2150,7 +3069,7 @@ checksum = "db58fcd5a53cf07c184b154801ff91347e4c30d17a3562a635ff028ad5deda46"
 dependencies = [
  "atoi",
  "base64 0.22.1",
- "bitflags 2.5.0",
+ "bitflags 2.11.1",
  "byteorder",
  "crc",
  "dotenvy",
@@ -2210,6 +3129,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 
 [[package]]
+name = "string_cache"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf776ba3fa74f83bf4b63c3dcbbf82173db2632ed8452cb2d891d33f459de70f"
+dependencies = [
+ "new_debug_unreachable",
+ "parking_lot",
+ "phf_shared",
+ "precomputed-hash",
+]
+
+[[package]]
 name = "stringprep"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2219,6 +3150,12 @@ dependencies = [
  "unicode-normalization",
  "unicode-properties",
 ]
+
+[[package]]
+name = "strsim"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "subtle"
@@ -2292,6 +3229,24 @@ dependencies = [
  "once_cell",
  "rustix",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "term"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8c27177b12a6399ffc08b98f76f7c9a1f4fe9fc967c784c5a071fa8d93cf7e1"
+dependencies = [
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "termcolor"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06794f8f6c5c898b3275aebefa6b8a1cb24cd2c6c79397ab15774837a0bc5755"
+dependencies = [
+ "winapi-util",
 ]
 
 [[package]]
@@ -2478,7 +3433,7 @@ version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e9cd434a998747dd2c4276bc96ee2e0c7a2eadf3cae88e52be55a05fa9053f5"
 dependencies = [
- "bitflags 2.5.0",
+ "bitflags 2.11.1",
  "bytes",
  "futures-util",
  "http 1.4.0",
@@ -2617,6 +3572,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7df058c713841ad818f1dc5d3fd88063241cc61f49f5fbea4b951e8cf5a8d71d"
 
 [[package]]
+name = "unicode-width"
+version = "0.1.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7dd6e30e90baa6f72411720665d41d89b9a3d039dc45b8faea1ddd07f617f6af"
+
+[[package]]
 name = "unicode-xid"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2664,6 +3625,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
 
 [[package]]
+name = "vcell"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77439c1b53d2303b20d9459b1ade71a83c716e3f9c34f3228c00e6f185d6c002"
+
+[[package]]
 name = "vcpkg"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2674,6 +3641,31 @@ name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
+name = "void"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a02e4885ed3bc0f2de90ea6dd45ebcbb66dacffe03547fadbb0eeae2770887d"
+
+[[package]]
+name = "volatile-register"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de437e2a6208b014ab52972a27e59b33fa2920d3e00fe05026167a1c509d19cc"
+dependencies = [
+ "vcell",
+]
+
+[[package]]
+name = "walkdir"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
+dependencies = [
+ "same-file",
+ "winapi-util",
+]
 
 [[package]]
 name = "want"
@@ -2797,10 +3789,10 @@ version = "0.244.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
 dependencies = [
- "bitflags 2.5.0",
+ "bitflags 2.11.1",
  "hashbrown 0.15.5",
  "indexmap",
- "semver",
+ "semver 1.0.27",
 ]
 
 [[package]]
@@ -2830,10 +3822,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "winapi-util"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
+dependencies = [
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-result"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
+dependencies = [
+ "windows-link",
+]
 
 [[package]]
 name = "windows-sys"
@@ -3051,7 +4061,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
 dependencies = [
  "anyhow",
- "bitflags 2.5.0",
+ "bitflags 2.11.1",
  "indexmap",
  "log",
  "serde",
@@ -3073,7 +4083,7 @@ dependencies = [
  "id-arena",
  "indexmap",
  "log",
- "semver",
+ "semver 1.0.27",
  "serde",
  "serde_derive",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,5 +3,13 @@ members = [
     "core",
     "platform/web/server",
     "platform/web/client",
+    "platform/pico2w",
+]
+# Exclude embedded target from default workspace builds.
+# Build pico2w from within platform/pico2w/ to pick up its .cargo/config.toml.
+default-members = [
+    "core",
+    "platform/web/server",
+    "platform/web/client",
 ]
 resolver = "2"

--- a/README.md
+++ b/README.md
@@ -33,10 +33,14 @@ A cycle-accurate Game Boy (DMG) emulator written in Rust.
 rustyboy/
 ├── core/               # no_std emulator core (CPU, PPU, APU, memory)
 ├── platform/
-│   └── web/            # Browser platform (Axum server + WASM client)
-│       ├── client/     # wasm-bindgen crate compiled to WASM
-│       ├── server/     # Axum HTTP server serving ROMs and static files
-│       └── Dockerfile  # Multi-stage Docker build
+│   ├── web/            # Browser platform (Axum server + WASM client)
+│   │   ├── client/     # wasm-bindgen crate compiled to WASM
+│   │   ├── server/     # Axum HTTP server serving ROMs and static files
+│   │   └── Dockerfile  # Multi-stage Docker build
+│   └── pico2w/         # Raspberry Pi Pico 2W embedded platform
+│       ├── src/        # Embassy async firmware
+│       ├── memory.x    # RP2350A flash/RAM layout
+│       └── README.md   # Setup, wiring, and flash instructions
 └── Cargo.toml          # Workspace root
 ```
 
@@ -45,6 +49,7 @@ rustyboy/
 | Platform | Description |
 |---|---|
 | [web](platform/web/README.md) | Docker-hosted browser emulator with DMG Game Boy UI |
+| [pico2w](platform/pico2w/README.md) | Portable handheld on Raspberry Pi Pico 2W (RP2350A) |
 
 ## Building
 
@@ -54,4 +59,9 @@ cargo test -p rustyboy-core
 
 # Build the web platform (requires wasm-pack)
 # See platform/web/README.md for full instructions
+
+# Build the Pico 2W firmware (requires cross-compilation target)
+# See platform/pico2w/README.md for full instructions
+cd platform/pico2w
+cargo build --release
 ```

--- a/platform/pico2w/.cargo/config.toml
+++ b/platform/pico2w/.cargo/config.toml
@@ -1,0 +1,20 @@
+[target.thumbv8m.main-none-eabihf]
+# probe-rs flash + run via SWD/JTAG debug probe.
+# For picotool (BOOTSEL / drag-and-drop), see CLAUDE.md.
+runner = "probe-rs run --chip RP235x"
+
+rustflags = [
+    # Link against the memory layout defined in memory.x.
+    "-C", "link-arg=-Tlink.x",
+    # Include defmt symbol table (required for defmt RTT decoding).
+    "-C", "link-arg=-Tdefmt.x",
+    # Disable the default linker relaxation pass — required for RP235x.
+    "-C", "link-arg=--nmagic",
+]
+
+[build]
+target = "thumbv8m.main-none-eabihf"
+
+[env]
+# Default log level. Override with DEFMT_LOG=trace cargo run etc.
+DEFMT_LOG = "debug"

--- a/platform/pico2w/CLAUDE.md
+++ b/platform/pico2w/CLAUDE.md
@@ -1,0 +1,117 @@
+# rustyboy-pico2w
+
+Embassy-based Game Boy emulator firmware for the Raspberry Pi Pico 2W (RP2350A).
+
+## Crate layout
+
+```
+platform/pico2w/
+├── .cargo/config.toml   # Cross-compilation target + probe-rs runner
+├── src/
+│   └── main.rs          # Entry point
+├── build.rs             # Exposes memory.x to the linker
+├── memory.x             # Flash/RAM layout for RP2350A
+└── CLAUDE.md            # This file
+```
+
+## Toolchain setup
+
+```sh
+# Add the Cortex-M33 (hard-float) target
+rustup target add thumbv8m.main-none-eabihf
+
+# Install probe-rs for flashing + RTT logging via SWD debug probe
+cargo install probe-rs-tools --locked
+
+# Optional: install picotool for BOOTSEL / drag-and-drop flashing
+# https://github.com/raspberrypi/picotool
+```
+
+## Building
+
+**Always build from within `platform/pico2w/`** so that `.cargo/config.toml`
+is picked up and the correct cross-compilation target is used.
+
+```sh
+cd platform/pico2w
+
+# Debug build
+cargo build
+
+# Release build (use this for flashing)
+cargo build --release
+```
+
+Running `cargo build` from the workspace root targets the host architecture
+and will fail — this is expected. Use `cargo build -p rustyboy-pico2w` only
+if you have the target set workspace-wide.
+
+## Flashing
+
+### Via SWD debug probe (probe-rs) — recommended for development
+
+Connect a Raspberry Pi Debug Probe (or any CMSIS-DAP probe) to the Pico 2W
+SWD header (SWDIO, SWDCLK, GND).
+
+```sh
+cd platform/pico2w
+cargo run --release
+```
+
+`probe-rs run` flashes the binary and immediately starts streaming defmt RTT
+logs to the terminal.
+
+### Via picotool (BOOTSEL) — no debug probe required
+
+1. Hold BOOTSEL on the Pico 2W while connecting USB → appears as mass storage.
+2. Build the ELF:
+   ```sh
+   cargo build --release
+   ```
+3. Flash with picotool:
+   ```sh
+   picotool load -f target/thumbv8m.main-none-eabihf/release/rustyboy-pico2w
+   picotool reboot
+   ```
+
+Note: picotool does not stream RTT logs. Use a separate RTT viewer or fall
+back to syslog (available after Bead 7).
+
+## Logging
+
+Logging uses `defmt` over RTT. When running via `cargo run` / probe-rs,
+logs appear in the terminal automatically.
+
+Log level is controlled by the `DEFMT_LOG` environment variable
+(default: `debug`, set in `.cargo/config.toml`):
+
+```sh
+DEFMT_LOG=trace cargo run --release   # verbose
+DEFMT_LOG=info  cargo run --release   # quieter
+```
+
+## Hardware notes
+
+### RP2350A specs
+- Dual ARM Cortex-M33 @ up to 150MHz
+- 520KB SRAM
+- 4MB QSPI flash (XIP-mapped at 0x10000000)
+
+### Onboard LED
+The Pico 2W LED is routed through the CYW43439 WiFi chip, not a GPIO pin.
+Controlling it requires the cyw43 driver (added in Bead 6). During Bead 1,
+use an external LED on GP15 (LED + 330Ω resistor to GND).
+
+### memory.x (Bead 1 — single-app layout)
+Bead 8 (OTA) will restructure flash into dual-bank partitions for
+`embassy-boot-rp`. When that happens, `memory.x` and this document will be
+updated with the new layout.
+
+## GPIO pin assignment
+
+Full pin table is maintained in `docs/wiring.md` (created in Bead 11).
+Summary of allocations so far:
+
+| GPIO | Function          | Bead |
+|------|-------------------|------|
+| GP15 | Dev blinky LED    |  1   |

--- a/platform/pico2w/Cargo.toml
+++ b/platform/pico2w/Cargo.toml
@@ -1,0 +1,55 @@
+[package]
+name = "rustyboy-pico2w"
+version = "0.1.0"
+edition = "2021"
+
+[[bin]]
+name = "rustyboy-pico2w"
+path = "src/main.rs"
+
+[dependencies]
+# Embassy async runtime and RP2350 HAL.
+# rp235xa = ARM Cortex-M33 variant of the RP2350 (used on Pico 2 / Pico 2W).
+# time-driver = enables embassy-time integration.
+embassy-rp = { git = "https://github.com/embassy-rs/embassy", features = [
+    "rp235xa",
+    "time-driver",
+    "defmt",
+    # Provides the critical-section implementation for the RP2350.
+    # Must NOT also enable cortex-m's critical-section-single-core.
+    "critical-section-impl",
+    # Embeds IMAGE_DEF / binary-info block required by the RP2350 bootrom.
+    "binary-info",
+] }
+embassy-executor = { git = "https://github.com/embassy-rs/embassy", features = [
+    "platform-cortex-m",
+    "executor-thread",
+    "defmt",
+] }
+embassy-time = { git = "https://github.com/embassy-rs/embassy", features = [
+    "defmt",
+    "defmt-timestamp-uptime",
+] }
+
+# Cortex-M runtime. inline-asm required for critical section on bare metal.
+cortex-m = { version = "0.7", features = ["inline-asm"] }
+cortex-m-rt = "0.7"
+
+# Logging over RTT (Real-Time Transfer) — no UART required.
+# defmt 1.x is required by embassy (breaking change from 0.3).
+defmt = "1"
+defmt-rtt = "1"
+
+# Panic handler: prints defmt log then halts. probe-rs will surface the message.
+panic-probe = { version = "1", features = ["print-defmt"] }
+
+[profile.dev]
+# Optimize enough to avoid stack overflows in async state machines.
+opt-level = 1
+debug = 2
+
+[profile.release]
+opt-level = "z"    # Minimise flash usage
+lto = true
+codegen-units = 1
+debug = 2          # Keep debug info for probe-rs backtraces even in release

--- a/platform/pico2w/README.md
+++ b/platform/pico2w/README.md
@@ -1,0 +1,204 @@
+# rustyboy — Pico 2W platform
+
+A portable Game Boy emulator running on the Raspberry Pi Pico 2W (RP2350A), using the `rustyboy-core` no_std emulator core with Embassy async firmware.
+
+## Bill of Materials
+
+| Component | Notes |
+|---|---|
+| Raspberry Pi Pico 2W | RP2350A MCU, 520KB SRAM, 4MB flash, CYW43439 WiFi |
+| ACEIRMC ILI9341 2.8" SPI TFT LCD | 240×320, 5V/3.3V, SPI interface |
+| MicroSD SPI breakout module | 3.3V compatible, SPI mode |
+| MAX98357A I2S DAC breakout | Class D amp, 3.2W @ 5V into 4Ω, mono |
+| 8Ω 2W speaker | 28mm–36mm round |
+| 8× tactile buttons | 6×6mm or 12×12mm (D-pad ×4, A, B, Start, Select) |
+| LiPo battery | 1000–2000mAh single-cell 3.7V (portable use) |
+| TP4056 w/ protection | USB-C LiPo charger + over-discharge protection |
+| MT3608 boost converter | 3.7V → 5V for MAX98357A (portable use) |
+| Power switch | Slide or toggle, rated for battery current |
+| 470µF–1000µF electrolytic capacitor | Across VSYS for brown-out save detection |
+| 330Ω resistor | Current limiting for dev blinky LED on GP15 |
+
+## GPIO pin assignment
+
+| GPIO | Function | Bead |
+|---|---|---|
+| GP8 | Display DC | 2 |
+| GP9 | Display CS | 2 |
+| GP10 | SPI0 CLK (display) | 2 |
+| GP11 | SPI0 MOSI (display) | 2 |
+| GP12 | Display RST | 2 |
+| GP14 | I2S BCLK (MAX98357A) | 5 |
+| GP15 | Dev blinky LED / I2S LRCLK | 1/5 |
+| GP16 | SPI1 MISO (SD card) | 4 |
+| GP17 | SPI1 CS (SD card) | 4 |
+| GP18 | SPI1 CLK (SD card) | 4 |
+| GP19 | SPI1 MOSI (SD card) | 4 |
+| GP20 | I2S DIN (MAX98357A) | 5 |
+| GP21 | Button: D-pad Up | 3 |
+| GP22 | Button: D-pad Down | 3 |
+| GP26 | Button: D-pad Left | 3 |
+| GP27 | Button: D-pad Right | 3 |
+| GP0 | Button: A | 3 |
+| GP1 | Button: B | 3 |
+| GP2 | Button: Start | 3 |
+| GP3 | Button: Select | 3 |
+| GP4 | MAX98357A SD_MODE | 5 |
+| GP5 | Brown-out detect | 9 |
+
+> Pin assignments are finalized in Bead 2–5. The table above reflects the planned allocation.
+
+## Toolchain setup
+
+```sh
+# 1. Add the Cortex-M33 hard-float target
+rustup target add thumbv8m.main-none-eabihf
+
+# 2. Install probe-rs for SWD flashing and RTT log streaming
+cargo install probe-rs-tools --locked
+```
+
+## Building
+
+**Always build from within `platform/pico2w/`** — the `.cargo/config.toml` there sets the correct cross-compilation target.
+
+```sh
+cd platform/pico2w
+
+cargo build --release
+```
+
+Running `cargo build` from the workspace root targets the host architecture and will fail — this is by design.
+
+## Flashing
+
+### Via SWD debug probe — recommended for development
+
+Connect a Raspberry Pi Debug Probe to the Pico 2W SWD header:
+
+| Debug Probe | Pico 2W |
+|---|---|
+| SWDIO | GP_SWDIO |
+| SWDCLK | GP_SWDCLK |
+| GND | GND |
+
+```sh
+cd platform/pico2w
+cargo run --release
+```
+
+`probe-rs` flashes the binary and immediately begins streaming defmt RTT logs to the terminal. You will see output like:
+
+```
+INFO  rustyboy-pico2w v0.1.0 starting
+INFO  heartbeat tick=1
+INFO  heartbeat tick=2
+```
+
+### Via BOOTSEL / picotool — no debug probe required
+
+1. Hold **BOOTSEL** on the Pico 2W while connecting USB. It appears as a mass storage device.
+2. Build the ELF:
+   ```sh
+   cd platform/pico2w
+   cargo build --release
+   ```
+3. Flash with picotool:
+   ```sh
+   picotool load -f ../../target/thumbv8m.main-none-eabihf/release/rustyboy-pico2w
+   picotool reboot
+   ```
+
+RTT logs are not available without a debug probe. After Bead 7, syslog over WiFi provides equivalent visibility.
+
+## Blinky smoke test (Bead 1)
+
+The current firmware blinks an LED on **GP15** at 1Hz and logs a heartbeat every second over defmt RTT. This proves:
+
+- Embassy async runtime boots correctly on RP2350A
+- defmt RTT logging works
+- Watchdog is running (5s timeout, fed every loop iteration)
+
+**Wiring:** LED anode → GP15, LED cathode → 330Ω resistor → GND.
+
+The Pico 2W's onboard LED is routed through the CYW43 WiFi chip and requires the cyw43 driver (added in Bead 6). GP15 is used for bare-PCB development.
+
+## Logging
+
+```sh
+# Default level is debug (set in .cargo/config.toml)
+cargo run --release
+
+# Override log level
+DEFMT_LOG=trace cargo run --release
+DEFMT_LOG=info  cargo run --release
+```
+
+After Bead 7, structured syslog (UDP RFC 5424) is available over WiFi — no debug probe required for log access in the field.
+
+## OTA firmware updates
+
+Firmware is versioned with `pico2w/vMAJOR.MINOR.PATCH` git tags. Pushing a tag triggers a GitHub Actions build that attaches `rustyboy-pico2w-vX.Y.Z.bin` and a SHA256 checksum to the GitHub release.
+
+The device checks `api.github.com/repos/vbonduro/rustyboy/releases/latest` on WiFi connect and prompts the user if a newer version is available. See Bead 8 for implementation details.
+
+## SD card layout
+
+```
+/
+├── roms/          # .gb and .gbc ROM files
+├── saves/
+│   └── <rom>/
+│       ├── slot0.rbss  # Auto-save (RBSS v1 format)
+│       ├── slot1.rbss  # Manual save slots
+│       └── battery.sav # Cartridge external RAM
+└── config/
+    ├── network.toml    # WiFi credentials + syslog host
+    └── auth.toml       # Web server sync token (Bead 10)
+```
+
+## Controls
+
+| Button | Function |
+|---|---|
+| D-pad | D-pad |
+| A | A button |
+| B | B button |
+| Start | Start |
+| Select | Select |
+| Start + Select (hold 1s) | In-game menu (save/load/OTA) |
+
+## Network configuration (first boot)
+
+On first boot with no `/config/network.toml` on the SD card, the device starts in AP mode:
+
+1. Connect to WiFi SSID **`RustyBoy-Setup`** from your phone or laptop
+2. A captive portal page opens automatically (or navigate to `192.168.4.1`)
+3. Enter your WiFi SSID and password and submit
+4. The device writes the config to SD and reboots into station mode
+
+If WiFi credentials fail after 3 connection attempts, the device falls back to AP mode automatically.
+
+### `config/network.toml` format
+
+```toml
+ssid = "MyNetwork"
+password = "secret"
+syslog_host = "192.168.1.10"   # optional
+syslog_port = 514               # optional, default 514
+```
+
+## Platform implementation status
+
+| Bead | Feature | Status |
+|---|---|---|
+| 1 | Scaffold, build system, blinky | ✅ Done |
+| 2 | ILI9341 display driver + framebuffer | 🔲 Pending |
+| 3 | Input (8 buttons, debounce) | 🔲 Pending |
+| 4 | SD card ROM storage + StreamingCartridge | 🔲 Pending |
+| 5 | Core integration + game loop + I2S audio | 🔲 Pending |
+| 6 | WiFi + captive portal setup | 🔲 Pending |
+| 7 | Logging + UDP syslog | 🔲 Pending |
+| 8 | OTA via GitHub Releases | 🔲 Pending |
+| 9 | Save states + battery saves | 🔲 Pending |
+| 10 | Web server sync (low priority) | 🔲 Pending |

--- a/platform/pico2w/build.rs
+++ b/platform/pico2w/build.rs
@@ -1,0 +1,8 @@
+fn main() {
+    // Ensure the linker can find memory.x in the crate root.
+    println!("cargo:rustc-link-search={}", std::env::var("CARGO_MANIFEST_DIR").unwrap());
+
+    // Re-run this build script if memory.x changes.
+    println!("cargo:rerun-if-changed=memory.x");
+    println!("cargo:rerun-if-changed=build.rs");
+}

--- a/platform/pico2w/memory.x
+++ b/platform/pico2w/memory.x
@@ -1,0 +1,69 @@
+/*
+ * Memory layout for Raspberry Pi Pico 2 / Pico 2W (RP2350A)
+ *
+ * Flash: 4MB QSPI, XIP-mapped at 0x10000000
+ * RAM:   512KB striped across SRAM0-SRAM7 (8 × 64KB banks, best for general use)
+ *        SRAM8/SRAM9: 4KB direct-mapped banks (dedicated use, e.g. per-core stacks)
+ *
+ * NOTE: Bead 1 uses a single-app layout (no bootloader).
+ * Bead 8 (OTA) will restructure this into dual-bank partitions
+ * for embassy-boot-rp:
+ *   BOOTLOADER : ORIGIN = 0x10000000, LENGTH = 32K
+ *   APP_A      : ORIGIN = 0x10008000, LENGTH = ~2M   <- active slot
+ *   APP_B      : ORIGIN = 0x10200000, LENGTH = ~2M   <- OTA staging slot
+ */
+MEMORY {
+    FLASH : ORIGIN = 0x10000000, LENGTH = 4M
+    RAM   : ORIGIN = 0x20000000, LENGTH = 512K
+    SRAM8 : ORIGIN = 0x20080000, LENGTH = 4K
+    SRAM9 : ORIGIN = 0x20081000, LENGTH = 4K
+}
+
+SECTIONS {
+    /*
+     * Boot ROM info block — IMAGE_DEF recognized by the RP2350 bootrom.
+     * Must be within the first 4K of flash (after .vector_table) so the
+     * bootrom and picotool can find it.
+     */
+    .start_block : ALIGN(4)
+    {
+        __start_block_addr = .;
+        KEEP(*(.start_block));
+        KEEP(*(.boot_info));
+    } > FLASH
+
+} INSERT AFTER .vector_table;
+
+/* Move .text to start after the boot info block. */
+_stext = ADDR(.start_block) + SIZEOF(.start_block);
+
+SECTIONS {
+    /*
+     * Picotool / probe-rs binary info entries.
+     * Pointers in the start_block header direct tools to this table.
+     */
+    .bi_entries : ALIGN(4)
+    {
+        __bi_entries_start = .;
+        KEEP(*(.bi_entries));
+        . = ALIGN(4);
+        __bi_entries_end = .;
+    } > FLASH
+
+} INSERT AFTER .text;
+
+SECTIONS {
+    /*
+     * End block — can hold a signature for secure boot.
+     * Placed last so it brackets the full image.
+     */
+    .end_block : ALIGN(4)
+    {
+        __end_block_addr = .;
+        KEEP(*(.end_block));
+    } > FLASH
+
+} INSERT AFTER .uninit;
+
+PROVIDE(start_to_end = __end_block_addr - __start_block_addr);
+PROVIDE(end_to_start = __start_block_addr - __end_block_addr);

--- a/platform/pico2w/src/main.rs
+++ b/platform/pico2w/src/main.rs
@@ -1,0 +1,68 @@
+//! rustyboy-pico2w — Bead 1: scaffold + blinky
+//!
+//! Proves the build system, embassy async runtime, defmt RTT logging,
+//! and watchdog are all wired up correctly on the RP2350.
+//!
+//! # Blinky wiring (bare PCB development)
+//! Connect an LED + 330Ω resistor between GP15 and GND.
+//! The onboard LED on Pico 2W is routed through the CYW43 WiFi chip
+//! and requires the cyw43 driver (added in Bead 6) — an external LED
+//! on GP15 is used here to keep the scaffold dependency-free.
+//!
+//! # Running
+//! From platform/pico2w/:
+//!   cargo run --release
+//!
+//! Requires probe-rs and a SWD debug probe (e.g. Raspberry Pi Debug Probe).
+//! See CLAUDE.md for picotool / BOOTSEL flashing instructions.
+
+#![no_std]
+#![no_main]
+
+use defmt::info;
+use embassy_executor::Spawner;
+use embassy_rp::gpio::{Level, Output};
+use embassy_rp::watchdog::Watchdog;
+use embassy_time::{Duration, Timer};
+use {defmt_rtt as _, panic_probe as _};
+
+/// Firmware version, sourced from Cargo.toml.
+/// Will be embedded at a known symbol in Bead 8 for OTA version comparison.
+const FIRMWARE_VERSION: &str = env!("CARGO_PKG_VERSION");
+
+// Binary info block required by the RP2350 bootrom to identify and boot the image.
+// Also surfaced by `picotool info` for firmware identification.
+#[unsafe(link_section = ".bi_entries")]
+#[used]
+pub static PICOTOOL_ENTRIES: [embassy_rp::binary_info::EntryAddr; 3] = [
+    embassy_rp::binary_info::rp_program_name!(c"rustyboy-pico2w"),
+    embassy_rp::binary_info::rp_cargo_version!(),
+    embassy_rp::binary_info::rp_program_build_attribute!(),
+];
+
+#[embassy_executor::main]
+async fn main(_spawner: Spawner) {
+    let p = embassy_rp::init(Default::default());
+
+    // Watchdog: reboot the device if the main loop stalls for more than 5s.
+    // Every iteration of the loop must call watchdog.feed() within this window.
+    let mut watchdog = Watchdog::new(p.WATCHDOG);
+    watchdog.start(Duration::from_millis(5_000));
+
+    info!("rustyboy-pico2w v{} starting", FIRMWARE_VERSION);
+
+    // External LED on GP15 (see module doc for wiring).
+    let mut led = Output::new(p.PIN_15, Level::Low);
+
+    let mut tick: u32 = 0;
+    loop {
+        led.set_high();
+        Timer::after(Duration::from_millis(500)).await;
+        led.set_low();
+        Timer::after(Duration::from_millis(500)).await;
+
+        watchdog.feed(Duration::from_millis(5_000));
+        tick += 1;
+        info!("heartbeat tick={}", tick);
+    }
+}


### PR DESCRIPTION
## Summary

- Adds `platform/pico2w/` — the Raspberry Pi Pico 2W (RP2350A) embedded platform
- Embassy async firmware with blinky smoke test, verified booting on hardware via probe-rs with defmt RTT heartbeat output
- Full platform README with BOM, wiring, build/flash instructions, and implementation status for all 10 planned beads

## What's included

**Firmware (`platform/pico2w/`)**
- `src/main.rs` — blinky on GP15 + defmt RTT heartbeat + 5s watchdog
- `Cargo.toml` — embassy-rp 0.10 (rp235xa), embassy-executor, defmt 1.x, panic-probe 1.x
- `memory.x` — RP2350A layout with `.start_block`/`.bi_entries`/`.end_block` sections required by the RP2350 bootrom
- `.cargo/config.toml` — `thumbv8m.main-none-eabihf` target, `probe-rs run --chip RP235x` runner
- `build.rs` — exposes `memory.x` to the linker
- `CLAUDE.md` — toolchain setup, build/flash workflows, GPIO table stub

**Workspace**
- Root `Cargo.toml`: adds `platform/pico2w` to members, excludes it from `default-members` so host-arch builds are unaffected

**Documentation**
- `platform/pico2w/README.md` — BOM, GPIO pin table, toolchain setup, SWD + BOOTSEL flash instructions, blinky wiring, logging, OTA overview, SD layout, controls, first-boot captive portal, implementation status table
- Root `README.md` — updated layout diagram and platforms table

## Lessons learned during bring-up

| Issue | Fix |
|---|---|
| `arch-cortex-m` unknown feature | Renamed to `platform-cortex-m` in embassy-executor 0.10 |
| defmt 0.3/0.4 incompatible | embassy 0.10 requires defmt 1.x throughout |
| `fixed` crate requires rustc 1.93 | Updated toolchain to 1.94.1 |
| `watchdog.feed()` takes no args | New API: `watchdog.feed(Duration)` |
| Linker: undefined `_critical_section_*` | `critical-section-single-core` conflicts with embassy-rp's own impl; use `critical-section-impl` feature on embassy-rp instead |
| Firmware boots but immediately exceptions | Missing `.start_block`/`.bi_entries`/`.end_block` linker sections + `binary-info` feature — RP2350 bootrom requires IMAGE_DEF to find the application |
| `RP2350A` not in probe-rs chip database | Correct name is `RP235x` |

## Test plan

- [x] `cargo build --release` from `platform/pico2w/` — clean build, 39KB ELF
- [x] `cargo run --release` — flashed via probe-rs, defmt RTT shows `heartbeat tick=N` on hardware
- [x] `cargo test -p rustyboy-core` — existing core tests unaffected
- [ ] Verify LED blink on GP15 with external LED wired (bare PCB, not yet assembled)

🤖 Generated with [Claude Code](https://claude.com/claude-code)