### PR TITLE
feat(pico2w): Bead 4 — SD card ROM storage + StreamingCartridge

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -793,7 +793,7 @@ dependencies = [
  "embedded-hal 1.0.0",
  "embedded-hal-async",
  "embedded-hal-nb",
- "embedded-io",
+ "embedded-io 0.7.1",
  "embedded-io-async",
  "embedded-storage",
  "embedded-storage-async",
@@ -946,6 +946,12 @@ dependencies = [
 
 [[package]]
 name = "embedded-io"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edd0f118536f44f5ccd48bcb8b111bdc3de888b58c74639dfb034a357d0f206d"
+
+[[package]]
+name = "embedded-io"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9eb1aa714776b75c7e67e1da744b81a129b3ff919c8712b5e1b32252c1f07cc7"
@@ -956,7 +962,20 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2564b9f813c544241430e147d8bc454815ef9ac998878d30cc3055449f7fd4c0"
 dependencies = [
- "embedded-io",
+ "embedded-io 0.7.1",
+]
+
+[[package]]
+name = "embedded-sdmmc"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce3c7f9ea039eeafc4a49597b7bd5ae3a1c8e51b2803a381cb0f29ce90fe1ec6"
+dependencies = [
+ "byteorder",
+ "embedded-hal 1.0.0",
+ "embedded-io 0.6.1",
+ "heapless 0.8.0",
+ "log",
 ]
 
 [[package]]
@@ -2715,9 +2734,11 @@ dependencies = [
  "embedded-alloc",
  "embedded-graphics",
  "embedded-hal-bus",
+ "embedded-sdmmc",
  "mipidsi",
  "panic-probe",
  "png",
+ "rp-pac",
  "rustyboy-core",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,3 +14,12 @@ default-members = [
     "platform/web/client",
 ]
 resolver = "2"
+
+[profile.dev]
+opt-level = 1
+debug = 2
+
+[profile.release]
+opt-level = "z"
+lto = true
+debug = 2

--- a/core/src/memory/memory.rs
+++ b/core/src/memory/memory.rs
@@ -41,7 +41,7 @@ pub trait Memory {
 
 /// Resolved mapping for a given address: which region and the offset within it.
 enum RegionMapping {
-    Rom(u16),
+    Rom,
     Vram(u16),
     ExternalRam(u16),
     Wram(u16),
@@ -59,7 +59,7 @@ enum RegionMapping {
 impl RegionMapping {
     fn for_address(address: u16) -> Self {
         match address {
-            0x0000..=0x7FFF => RegionMapping::Rom(address),
+            0x0000..=0x7FFF => RegionMapping::Rom,
             0x8000..=0x9FFF => RegionMapping::Vram(address - 0x8000),
             0xA000..=0xBFFF => RegionMapping::ExternalRam(address - 0xA000),
             0xC000..=0xDFFF => RegionMapping::Wram(address - 0xC000),
@@ -101,6 +101,20 @@ impl GameBoyMemory {
     pub fn new() -> Self {
         Self {
             cartridge: Box::new(NoMbc::new(vec![0u8; 0x8000])),
+            vram: Ram::new(0x2000),
+            wram: Ram::new(0x2000),
+            oam: Ram::new(0xA0),
+            io: Ram::new(0x80),
+            hram: Ram::new(0x7F),
+            ie: 0,
+            events: VecDeque::new(),
+        }
+    }
+
+    /// Construct memory backed by a pre-built cartridge implementation.
+    pub fn with_cartridge(cart: Box<dyn Cartridge>) -> Self {
+        Self {
+            cartridge: cart,
             vram: Ram::new(0x2000),
             wram: Ram::new(0x2000),
             oam: Ram::new(0xA0),
@@ -283,7 +297,7 @@ impl GameBoyMemory {
 impl Memory for GameBoyMemory {
     fn read(&self, address: u16) -> Result<u8, Error> {
         match RegionMapping::for_address(address) {
-            RegionMapping::Rom(_) => Ok(self.cartridge.read_rom(address)),
+            RegionMapping::Rom => Ok(self.cartridge.read_rom(address)),
             RegionMapping::Vram(offset) => self
                 .vram
                 .read(offset)
@@ -317,7 +331,7 @@ impl Memory for GameBoyMemory {
     fn write(&mut self, address: u16, value: u8) -> Result<(), Error> {
         match RegionMapping::for_address(address) {
             // ROM writes and external RAM writes go to the cartridge (MBC registers or RAM)
-            RegionMapping::Rom(_) | RegionMapping::ExternalRam(_) => {
+            RegionMapping::Rom | RegionMapping::ExternalRam(_) => {
                 self.cartridge.write(address, value);
                 Ok(())
             }

--- a/core/src/memory/mod.rs
+++ b/core/src/memory/mod.rs
@@ -3,8 +3,10 @@ pub mod cartridge;
 pub mod fake;
 pub mod memory;
 pub mod rom;
+pub mod streaming;
 
 #[cfg(test)]
 pub use fake::FakeMemory;
 pub use memory::{GameBoyMemory, Memory};
 pub use rom::{ROMVec, Ram, ReadOnlyMemory};
+pub use streaming::{RomReader, StreamingCartridge, StreamingError};

--- a/core/src/memory/streaming.rs
+++ b/core/src/memory/streaming.rs
@@ -1,0 +1,518 @@
+use alloc::vec;
+use alloc::vec::Vec;
+
+use super::cartridge::Cartridge;
+
+// ── RomReader trait ──────────────────────────────────────────────────────────
+
+pub trait RomReader {
+    type Error;
+    fn read_bank(&mut self, bank: usize, buf: &mut [u8; 0x4000]) -> Result<(), Self::Error>;
+}
+
+// ── Header offsets ───────────────────────────────────────────────────────────
+
+const CART_TYPE: usize = 0x0147;
+const ROM_SIZE:  usize = 0x0148;
+const RAM_SIZE:  usize = 0x0149;
+
+// ── MBC state ────────────────────────────────────────────────────────────────
+
+enum MbcState {
+    NoMbc,
+    Mbc1 {
+        rom_bank_lo:    u8,
+        upper_bits:     u8,
+        ram_mode:       bool,
+        ram_enabled:    bool,
+        ram_bank_count: usize,
+    },
+    Mbc3 {
+        rom_bank:        u8,
+        bank_or_rtc:     u8,
+        ram_rtc_enabled: bool,
+    },
+}
+
+// ── StreamingCartridge ───────────────────────────────────────────────────────
+
+#[derive(Debug)]
+pub enum StreamingError<E> {
+    Reader(E),
+    UnsupportedCartType(u8),
+}
+
+pub struct StreamingCartridge<R: RomReader> {
+    reader:           R,
+    bank0_cache:      [u8; 0x4000],
+    banked_cache:     [u8; 0x4000],
+    fixed_bank_num:   usize,
+    current_bank_num: usize,
+    rom_bank_count:   usize,
+    mbc:              MbcState,
+    ram:              Vec<u8>,
+}
+
+impl<R: RomReader> StreamingCartridge<R> {
+    pub fn new(mut reader: R) -> Result<Self, StreamingError<R::Error>> {
+        let mut bank0_cache = [0u8; 0x4000];
+        reader.read_bank(0, &mut bank0_cache).map_err(StreamingError::Reader)?;
+
+        let cart_type      = bank0_cache[CART_TYPE];
+        let rom_bank_count = rom_bank_count_from_code(bank0_cache[ROM_SIZE]);
+        let ram_bytes      = ram_bytes_from_code(bank0_cache[RAM_SIZE]);
+        let mbc = mbc_state_from_header(cart_type, ram_bytes)
+            .ok_or(StreamingError::UnsupportedCartType(cart_type))?;
+
+        let mut banked_cache = [0u8; 0x4000];
+        reader.read_bank(1, &mut banked_cache).map_err(StreamingError::Reader)?;
+
+        Ok(Self {
+            reader,
+            bank0_cache,
+            banked_cache,
+            fixed_bank_num:   0,
+            current_bank_num: 1,
+            rom_bank_count,
+            mbc,
+            ram: vec![0u8; ram_bytes],
+        })
+    }
+
+    fn effective_fixed_bank(&self) -> usize {
+        match &self.mbc {
+            MbcState::NoMbc => 0,
+            MbcState::Mbc1 { upper_bits, ram_mode, .. } => {
+                if *ram_mode {
+                    ((*upper_bits as usize) << 5) % self.rom_bank_count
+                } else {
+                    0
+                }
+            }
+            MbcState::Mbc3 { .. } => 0,
+        }
+    }
+
+    fn effective_switchable_bank(&self) -> usize {
+        match &self.mbc {
+            MbcState::NoMbc => 1,
+            MbcState::Mbc1 { rom_bank_lo, upper_bits, .. } => {
+                let bank = ((*upper_bits as usize) << 5) | (*rom_bank_lo as usize);
+                let bank = if bank == 0 { 1 } else { bank };
+                bank % self.rom_bank_count
+            }
+            MbcState::Mbc3 { rom_bank, .. } => *rom_bank as usize,
+        }
+    }
+
+    fn sync_caches(&mut self) {
+        let new_fixed      = self.effective_fixed_bank();
+        let new_switchable = self.effective_switchable_bank();
+
+        if new_fixed != self.fixed_bank_num {
+            if self.reader.read_bank(new_fixed, &mut self.bank0_cache).is_err() {
+                self.bank0_cache.fill(0xFF);
+            }
+            self.fixed_bank_num = new_fixed;
+        }
+        if new_switchable != self.current_bank_num {
+            if self.reader.read_bank(new_switchable, &mut self.banked_cache).is_err() {
+                self.banked_cache.fill(0xFF);
+            }
+            self.current_bank_num = new_switchable;
+        }
+    }
+
+    fn handle_mbc_write(&mut self, addr: u16, value: u8) {
+        match &mut self.mbc {
+            MbcState::NoMbc => {}
+            MbcState::Mbc1 { rom_bank_lo, upper_bits, ram_mode, ram_enabled, .. } => {
+                match addr {
+                    0x0000..=0x1FFF => *ram_enabled = value & 0x0F == 0x0A,
+                    0x2000..=0x3FFF => {
+                        *rom_bank_lo = value & 0x1F;
+                        if *rom_bank_lo == 0 { *rom_bank_lo = 1; }
+                    }
+                    0x4000..=0x5FFF => *upper_bits = value & 0x03,
+                    0x6000..=0x7FFF => *ram_mode   = value & 0x01 != 0,
+                    _ => {}
+                }
+            }
+            MbcState::Mbc3 { rom_bank, bank_or_rtc, ram_rtc_enabled } => {
+                match addr {
+                    0x0000..=0x1FFF => *ram_rtc_enabled = value & 0x0F == 0x0A,
+                    0x2000..=0x3FFF => {
+                        *rom_bank = if value & 0x7F == 0 { 1 } else { value & 0x7F };
+                    }
+                    0x4000..=0x5FFF => *bank_or_rtc = value,
+                    _ => {}
+                }
+            }
+        }
+    }
+
+    fn mbc1_ram_bank(&self) -> usize {
+        match &self.mbc {
+            MbcState::Mbc1 { upper_bits, ram_mode: true, ram_bank_count, .. } => {
+                (*upper_bits as usize) % (*ram_bank_count).max(1)
+            }
+            _ => 0,
+        }
+    }
+
+    fn is_ram_enabled(&self) -> bool {
+        match &self.mbc {
+            MbcState::NoMbc => false,
+            MbcState::Mbc1 { ram_enabled, .. } => *ram_enabled,
+            MbcState::Mbc3 { ram_rtc_enabled, bank_or_rtc, .. } => {
+                *ram_rtc_enabled && !matches!(bank_or_rtc, 0x08..=0x0C)
+            }
+        }
+    }
+}
+
+impl<R: RomReader> Cartridge for StreamingCartridge<R> {
+    fn read_rom(&self, addr: u16) -> u8 {
+        match addr {
+            0x0000..=0x3FFF => self.bank0_cache[addr as usize],
+            0x4000..=0x7FFF => self.banked_cache[(addr - 0x4000) as usize],
+            _ => 0xFF,
+        }
+    }
+
+    fn read_ram(&self, addr: u16) -> u8 {
+        if !self.is_ram_enabled() || self.ram.is_empty() { return 0xFF; }
+        let offset = self.mbc1_ram_bank() * 0x2000 + addr as usize;
+        self.ram.get(offset).copied().unwrap_or(0xFF)
+    }
+
+    fn write(&mut self, addr: u16, value: u8) {
+        if (0xA000..=0xBFFF).contains(&addr) {
+            if self.is_ram_enabled() && !self.ram.is_empty() {
+                let offset = self.mbc1_ram_bank() * 0x2000 + (addr - 0xA000) as usize;
+                if let Some(b) = self.ram.get_mut(offset) { *b = value; }
+            }
+        } else {
+            self.handle_mbc_write(addr, value);
+            self.sync_caches();
+        }
+    }
+
+    fn current_rom_bank(&self) -> usize { self.current_bank_num }
+
+    fn external_ram(&self) -> Option<&[u8]> {
+        if self.ram.is_empty() { None } else { Some(&self.ram) }
+    }
+
+    fn set_external_ram(&mut self, data: &[u8]) {
+        let len = self.ram.len().min(data.len());
+        self.ram[..len].copy_from_slice(&data[..len]);
+    }
+
+    fn save_mbc_state(&self, out: &mut Vec<u8>) {
+        match &self.mbc {
+            MbcState::NoMbc => {}
+            MbcState::Mbc1 { rom_bank_lo, upper_bits, ram_mode, ram_enabled, .. } => {
+                out.extend_from_slice(&[*rom_bank_lo, *upper_bits, *ram_mode as u8, *ram_enabled as u8]);
+            }
+            MbcState::Mbc3 { rom_bank, bank_or_rtc, ram_rtc_enabled } => {
+                out.extend_from_slice(&[*rom_bank, *bank_or_rtc, *ram_rtc_enabled as u8]);
+            }
+        }
+    }
+
+    fn load_mbc_state(&mut self, data: &[u8], offset: usize) -> usize {
+        let consumed = match &mut self.mbc {
+            MbcState::NoMbc => 0,
+            MbcState::Mbc1 { rom_bank_lo, upper_bits, ram_mode, ram_enabled, .. } => {
+                if data.len() < offset + 4 { return 0; }
+                *rom_bank_lo = data[offset].max(1);
+                *upper_bits  = data[offset + 1] & 0x03;
+                *ram_mode    = data[offset + 2] != 0;
+                *ram_enabled = data[offset + 3] != 0;
+                4
+            }
+            MbcState::Mbc3 { rom_bank, bank_or_rtc, ram_rtc_enabled } => {
+                if data.len() < offset + 3 { return 0; }
+                *rom_bank        = data[offset].max(1);
+                *bank_or_rtc     = data[offset + 1];
+                *ram_rtc_enabled = data[offset + 2] != 0;
+                3
+            }
+        };
+        if consumed > 0 {
+            self.fixed_bank_num   = usize::MAX;
+            self.current_bank_num = usize::MAX;
+            self.sync_caches();
+        }
+        consumed
+    }
+}
+
+// ── Header decoders ──────────────────────────────────────────────────────────
+
+fn rom_bank_count_from_code(code: u8) -> usize {
+    2usize << code
+}
+
+fn ram_bytes_from_code(code: u8) -> usize {
+    match code {
+        0x01 => 2 * 1024,
+        0x02 => 8 * 1024,
+        0x03 => 32 * 1024,
+        0x04 => 128 * 1024,
+        0x05 => 64 * 1024,
+        _ => 0,
+    }
+}
+
+fn mbc_state_from_header(cart_type: u8, ram_bytes: usize) -> Option<MbcState> {
+    let ram_bank_count = if ram_bytes == 0 { 0 } else { (ram_bytes / 0x2000).max(1) };
+    match cart_type {
+        0x00 => Some(MbcState::NoMbc),
+        0x01 | 0x02 | 0x03 => Some(MbcState::Mbc1 {
+            rom_bank_lo: 1,
+            upper_bits: 0,
+            ram_mode: false,
+            ram_enabled: false,
+            ram_bank_count,
+        }),
+        0x0F | 0x10 | 0x11 | 0x12 | 0x13 => Some(MbcState::Mbc3 {
+            rom_bank: 1,
+            bank_or_rtc: 0,
+            ram_rtc_enabled: false,
+        }),
+        _ => None,
+    }
+}
+
+// ── Tests ────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    struct MockRomReader {
+        banks:    Vec<[u8; 0x4000]>,
+        read_log: Vec<usize>,
+    }
+
+    impl MockRomReader {
+        fn new(num_banks: usize, cart_type: u8, ram_size_code: u8) -> Self {
+            let mut banks = vec![[0u8; 0x4000]; num_banks];
+            for (i, bank) in banks.iter_mut().enumerate() {
+                bank.fill(i as u8);
+            }
+            banks[0][CART_TYPE] = cart_type;
+            banks[0][ROM_SIZE]  = rom_size_code_for(num_banks);
+            banks[0][RAM_SIZE]  = ram_size_code;
+            Self { banks, read_log: Vec::new() }
+        }
+    }
+
+    fn rom_size_code_for(num_banks: usize) -> u8 {
+        match num_banks {
+            2  => 0,
+            4  => 1,
+            8  => 2,
+            16 => 3,
+            32 => 4,
+            64 => 5,
+            _  => 0,
+        }
+    }
+
+    impl RomReader for MockRomReader {
+        type Error = ();
+        fn read_bank(&mut self, bank: usize, buf: &mut [u8; 0x4000]) -> Result<(), ()> {
+            self.read_log.push(bank);
+            *buf = *self.banks.get(bank).unwrap_or(&[0xFF; 0x4000]);
+            Ok(())
+        }
+    }
+
+    fn no_mbc() -> StreamingCartridge<MockRomReader> {
+        StreamingCartridge::new(MockRomReader::new(2, 0x00, 0x00)).unwrap()
+    }
+
+    fn mbc1(num_banks: usize) -> StreamingCartridge<MockRomReader> {
+        StreamingCartridge::new(MockRomReader::new(num_banks, 0x01, 0x00)).unwrap()
+    }
+
+    fn mbc1_with_ram() -> StreamingCartridge<MockRomReader> {
+        // cart type 0x03 = MBC1+RAM+BATTERY, ram_size_code 0x02 = 8 KiB
+        StreamingCartridge::new(MockRomReader::new(4, 0x03, 0x02)).unwrap()
+    }
+
+    fn mbc3(num_banks: usize) -> StreamingCartridge<MockRomReader> {
+        // cart type 0x13 = MBC3+RAM+BATTERY
+        StreamingCartridge::new(MockRomReader::new(num_banks, 0x13, 0x00)).unwrap()
+    }
+
+    // ── Construction ──────────────────────────────────────────────────────────
+
+    #[test]
+    fn new_reads_bank0_and_bank1_on_init() {
+        let cart = no_mbc();
+        assert_eq!(cart.reader.read_log, [0, 1]);
+    }
+
+    #[test]
+    fn new_unsupported_cart_type_returns_error() {
+        assert!(matches!(
+            StreamingCartridge::new(MockRomReader::new(2, 0xFF, 0x00)),
+            Err(StreamingError::UnsupportedCartType(0xFF))
+        ));
+    }
+
+    // ── read_rom ──────────────────────────────────────────────────────────────
+
+    #[test]
+    fn read_rom_fixed_window_hits_bank0_cache() {
+        let cart = mbc1(4);
+        assert_eq!(cart.read_rom(0x0000), 0x00);
+        assert_eq!(cart.read_rom(0x3FFF), 0x00);
+    }
+
+    #[test]
+    fn read_rom_banked_window_hits_current_bank_cache() {
+        let cart = mbc1(4);
+        assert_eq!(cart.read_rom(0x4000), 0x01);
+        assert_eq!(cart.read_rom(0x7FFF), 0x01);
+    }
+
+    // ── MBC1 ──────────────────────────────────────────────────────────────────
+
+    #[test]
+    fn mbc1_bank_switch_loads_new_bank() {
+        let mut cart = mbc1(4);
+        cart.write(0x2000, 0x02);
+        assert_eq!(cart.current_rom_bank(), 2);
+        assert_eq!(cart.read_rom(0x4000), 0x02);
+    }
+
+    #[test]
+    fn mbc1_writing_zero_selects_bank1() {
+        let mut cart = mbc1(4);
+        cart.write(0x2000, 0x00);
+        assert_eq!(cart.current_rom_bank(), 1);
+    }
+
+    #[test]
+    fn mbc1_same_bank_reselect_skips_reload() {
+        let mut cart = mbc1(4);
+        cart.reader.read_log.clear();
+        cart.write(0x2000, 0x01); // already on bank 1
+        assert!(cart.reader.read_log.is_empty());
+    }
+
+    #[test]
+    fn mbc1_upper_bits_extend_bank_number() {
+        let mut cart = mbc1(64);
+        cart.write(0x2000, 0x01); // lower = 1 (no change — already bank 1)
+        cart.write(0x4000, 0x01); // upper = 1 → (1<<5)|1 = 33
+        assert_eq!(cart.current_rom_bank(), 33);
+        assert_eq!(cart.read_rom(0x4000), 33);
+    }
+
+    #[test]
+    fn mbc1_ram_mode_remaps_fixed_bank() {
+        let mut cart = mbc1(64);
+        cart.write(0x4000, 0x01); // upper = 1
+        cart.write(0x6000, 0x01); // RAM mode → fixed = (1<<5)%64 = 32
+        assert_eq!(cart.fixed_bank_num, 32);
+        assert_eq!(cart.read_rom(0x0000), 32);
+    }
+
+    // ── MBC3 ──────────────────────────────────────────────────────────────────
+
+    #[test]
+    fn mbc3_bank_switch_loads_new_bank() {
+        let mut cart = mbc3(8);
+        cart.write(0x2000, 0x03);
+        assert_eq!(cart.current_rom_bank(), 3);
+        assert_eq!(cart.read_rom(0x4000), 0x03);
+    }
+
+    #[test]
+    fn mbc3_writing_zero_selects_bank1() {
+        let mut cart = mbc3(8);
+        cart.write(0x2000, 0x00);
+        assert_eq!(cart.current_rom_bank(), 1);
+    }
+
+    #[test]
+    fn mbc3_fixed_window_always_bank0() {
+        let mut cart = mbc3(8);
+        cart.write(0x2000, 0x05);
+        assert_eq!(cart.fixed_bank_num, 0);
+        assert_eq!(cart.read_rom(0x0000), 0x00);
+    }
+
+    // ── External RAM ──────────────────────────────────────────────────────────
+
+    #[test]
+    fn ram_disabled_returns_0xff() {
+        let cart = mbc1_with_ram();
+        assert_eq!(cart.read_ram(0x0000), 0xFF);
+    }
+
+    #[test]
+    fn ram_enable_write_read_roundtrip() {
+        let mut cart = mbc1_with_ram();
+        cart.write(0x0000, 0x0A); // enable
+        cart.write(0xA000, 0x42);
+        assert_eq!(cart.read_ram(0x0000), 0x42);
+    }
+
+    #[test]
+    fn ram_disable_blocks_read() {
+        let mut cart = mbc1_with_ram();
+        cart.write(0x0000, 0x0A);
+        cart.write(0xA000, 0x42);
+        cart.write(0x0000, 0x00); // disable
+        assert_eq!(cart.read_ram(0x0000), 0xFF);
+    }
+
+    // ── NoMBC ─────────────────────────────────────────────────────────────────
+
+    #[test]
+    fn no_mbc_banked_window_is_bank1() {
+        let cart = no_mbc();
+        assert_eq!(cart.read_rom(0x4000), 0x01);
+    }
+
+    #[test]
+    fn no_mbc_writes_do_not_reload_cache() {
+        let mut cart = no_mbc();
+        cart.reader.read_log.clear();
+        cart.write(0x2000, 0x01);
+        assert!(cart.reader.read_log.is_empty());
+    }
+
+    // ── save / load MBC state ─────────────────────────────────────────────────
+
+    #[test]
+    fn mbc1_save_load_state_restores_bank() {
+        let mut cart = mbc1(4);
+        cart.write(0x2000, 0x03);
+        let mut blob = Vec::new();
+        cart.save_mbc_state(&mut blob);
+
+        let mut cart2 = mbc1(4);
+        cart2.load_mbc_state(&blob, 0);
+        assert_eq!(cart2.current_rom_bank(), 3);
+    }
+
+    #[test]
+    fn mbc3_save_load_state_restores_bank() {
+        let mut cart = mbc3(8);
+        cart.write(0x2000, 0x05);
+        let mut blob = Vec::new();
+        cart.save_mbc_state(&mut blob);
+
+        let mut cart2 = mbc3(8);
+        cart2.load_mbc_state(&blob, 0);
+        assert_eq!(cart2.current_rom_bank(), 5);
+    }
+}

--- a/platform/pico2w/CLAUDE.md
+++ b/platform/pico2w/CLAUDE.md
@@ -112,6 +112,37 @@ updated with the new layout.
 Full pin table is maintained in `docs/wiring.md` (created in Bead 11).
 Summary of allocations so far:
 
-| GPIO | Function          | Bead |
-|------|-------------------|------|
-| GP15 | Dev blinky LED    |  1   |
+| GPIO | Function                  | Bead |
+|------|---------------------------|------|
+| GP4  | SPI0 MISO (SD card)       |  4   |
+| GP5  | SPI0 CS   (SD card)       |  4   |
+| GP6  | SPI0 CLK  (SD card)       |  4   |
+| GP7  | SPI0 MOSI (SD card)       |  4   |
+| GP15 | Dev blinky LED            |  1   |
+| GP16 | I2S DIN (MAX98357A)       |  5   |
+| GP17 | MAX98357A SD_MODE         |  5   |
+| GP18 | Brown-out detect          |  9   |
+| GP20 | SD module power enable    |  4   |
+
+### SD module power switch (GP20)
+
+GP20 controls a P-channel MOSFET (or a load switch IC such as AP2112/TPS22860)
+that gates VBUS (5 V) to the SD module's VCC pin. This allows the firmware to
+power-cycle the module for reliable recovery after a stuck SPI transaction:
+
+```
+Pico GP20 ──[1 kΩ]──► NPN base   (e.g. MMBT3904)
+                        NPN emitter ── GND
+                        NPN collector ──[10 kΩ pull-up to VBUS]──► PMOS gate
+VBUS ──────────────────────────────────────────────────────────────► PMOS source
+                                                                      PMOS drain ── Module VCC
+```
+
+Or replace the discrete circuit with a dedicated load switch (EN active-high):
+```
+GP20 ── EN,  VBUS ── VIN,  VOUT ── Module VCC
+```
+
+Logic: GP20 HIGH = module powered, GP20 LOW = module off.
+Hold LOW for ≥ 100 ms (cap discharge), then HIGH + 250 ms (card power-up)
+before reinitialising the SdCard object.

--- a/platform/pico2w/Cargo.toml
+++ b/platform/pico2w/Cargo.toml
@@ -51,22 +51,14 @@ embassy-time = { git = "https://github.com/embassy-rs/embassy", features = [
 
 cortex-m = { version = "0.7", features = ["inline-asm"] }
 cortex-m-rt = "0.7"
+rp-pac = { git = "https://github.com/embassy-rs/rp-pac", rev = "c2e27609b021c444f634673155318977d7f0bdf6" }
 
 defmt = "1"
 defmt-rtt = "1"
 panic-probe = { version = "1", features = ["print-defmt"] }
 
 embedded-alloc = "0.5"
+embedded-sdmmc = "0.9.0"
 mipidsi = "0.8"
 display-interface-spi = "0.5"
 embedded-hal-bus = "0.1"
-
-[profile.dev]
-opt-level = 1
-debug = 2
-
-[profile.release]
-opt-level = "z"
-lto = true
-codegen-units = 1
-debug = 2

--- a/platform/pico2w/README.md
+++ b/platform/pico2w/README.md
@@ -27,8 +27,10 @@ A portable Game Boy emulator running on the Raspberry Pi Pico 2W (RP2350A), usin
 | GP1 | Button: B | 3 |
 | GP2 | Button: Start | 3 |
 | GP3 | Button: Select | 3 |
-| GP4 | MAX98357A SD_MODE | 5 |
-| GP5 | Brown-out detect | 9 |
+| GP4 | SPI0 MISO (SD card) | 4 |
+| GP5 | SPI0 CS (SD card) | 4 |
+| GP6 | SPI0 CLK (SD card) | 4 |
+| GP7 | SPI0 MOSI (SD card) | 4 |
 | GP8 | Display DC | 2 |
 | GP9 | Display CS | 2 |
 | GP10 | SPI1 CLK (display) | 2 |
@@ -37,11 +39,10 @@ A portable Game Boy emulator running on the Raspberry Pi Pico 2W (RP2350A), usin
 | GP13 | Display backlight | 2 |
 | GP14 | I2S BCLK (MAX98357A) | 5 |
 | GP15 | Dev blinky LED / I2S LRCLK | 1/5 |
-| GP16 | SPI0 MISO (SD card) | 4 |
-| GP17 | SPI0 CS (SD card) | 4 |
-| GP18 | SPI0 CLK (SD card) | 4 |
-| GP19 | SPI0 MOSI (SD card) | 4 |
-| GP20 | I2S DIN (MAX98357A) | 5 |
+| GP16 | I2S DIN (MAX98357A) | 5 |
+| GP17 | MAX98357A SD_MODE | 5 |
+| GP18 | Brown-out detect | 9 |
+| GP20 | SD module power enable | 4 |
 | GP21 | Button: D-pad Up | 3 |
 | GP22 | Button: D-pad Down | 3 |
 | GP26 | Button: D-pad Left | 3 |

--- a/platform/pico2w/SD_MODULE_NOTES.md
+++ b/platform/pico2w/SD_MODULE_NOTES.md
@@ -1,0 +1,173 @@
+# SD Card Module (ACEIRMC) — SPI Behaviour Notes
+
+## Module circuit
+
+The ACEIRMC micro-SD module is a clone of the Catalex design.  Key components:
+
+| Component     | Part         | Role |
+|---------------|--------------|------|
+| LDO regulator | AMS1117-3.3  | VBUS (5 V) → 3.3 V for SD card |
+| Level buffer  | 74LVC125A    | Quad 3-state buffer, Vcc tied to **3.3 V rail** (AMS1117 output) |
+| Pull-ups      | ~10 kΩ       | On all four SPI lines between SD socket and buffer inputs |
+
+Because the 74LVC125A is powered from 3.3 V, all buffer outputs are 3.3 V.
+The module is safe to connect directly to the RP2350 (3.3 V GPIO).
+
+### Signal routing through the buffer
+
+| Signal | Direction   | Buffer path |
+|--------|-------------|-------------|
+| CLK    | MCU → card  | A = MCU CLK,  Y = card CLK  |
+| MOSI   | MCU → card  | A = MCU MOSI, Y = card MOSI |
+| CS     | MCU → card  | A = MCU CS,   Y = card CS   |
+| MISO   | card → MCU  | A = card MISO, Y = MCU MISO |
+
+### /OE pins
+
+All four /OE (output enable, active-LOW) pins are **permanently tied to GND**.
+This means every buffer is always enabled — the MISO buffer never tri-states,
+even when CS is HIGH.  This is a known design issue in this class of modules
+(documented in the Catalex/Open-Smart errata; a fix is to lift pin 13 of the
+74LVC125A and connect it to the CS net instead of GND, so MISO tri-states when
+the card is deselected).
+
+For a single-device SPI bus this does not cause bus contention, but it does
+mean the MCU always sees the buffered SD card MISO regardless of CS state.
+
+---
+
+## Why MISO reads 0xFF
+
+### 1. SD card MISO is open-collector / tristate (SD spec behaviour)
+
+The SD Physical Layer spec defines the card's DO (MISO) pin as open-drain.
+The card only **actively drives MISO LOW** (for 0-bits and R1 response bytes
+with bit 7 = 0).  It either weakly drives or releases MISO for 1-bits and
+during idle periods.
+
+Confirmed by carlk3's well-tested Pico SD library:
+> "The SPI MISO (DO on SD card) is open collector (or tristate).
+>  It should be pulled up.  The Pico internal pull-up is weak (~56 kΩ / 60 µA).
+>  It's best to add an external pull-up of around 5 kΩ to 3.3 V."
+
+### 2. RP2350 MISO pull-up is disabled by embassy-rp
+
+Embassy-rp's `Spi::new_blocking` explicitly disables both pull-up and
+pull-down on the MISO pin (spi.rs, pad_ctrl write for miso):
+
+```rust
+w.set_pue(false);   // pull-up disabled
+w.set_pde(false);   // pull-down disabled
+```
+
+The only pull-up on the MISO line is therefore the module's ~10 kΩ resistor.
+
+### 3. What 0xFF means in practice
+
+| MISO state             | Who is driving it | MCU reads |
+|------------------------|-------------------|-----------|
+| Card actively LOW      | SD card           | 0x00 – 0x7F (valid R1) |
+| Card releases / high-Z | 10 kΩ module pull-up | 0xFF (filler / not responding) |
+| Card stuck / non-responsive | 10 kΩ module pull-up | 0xFF on every byte |
+
+When the SD card is functioning correctly it pulls MISO LOW for R1 response
+bytes.  When it enters a stuck or non-responsive state it stops driving MISO
+at all, the module pull-up holds the line HIGH, and the MCU reads 0xFF on
+every SPI transfer → `TimeoutCommand` in embedded-sdmmc.
+
+---
+
+## Observed SPI / SD init behaviour in this project
+
+| Session state                        | CMD0 response | Meaning |
+|--------------------------------------|--------------|---------|
+| Card not powered (3.3 V VCC typo)   | 0xFF timeout  | AMS1117 output ~2.3 V, card off |
+| Clean power-on (VBUS), first run     | **0x01**      | R1_IDLE_STATE — correct, card entered SPI mode |
+| Soft MCU reset, card still init'd   | **0x00**      | R1_READY_STATE — card stayed in SPI mode from previous session |
+| After many CS-toggle retry cycles   | 0xFF timeout  | Card stopped driving MISO — stuck state |
+
+### Normal expected SD init sequence (for reference)
+
+```
+CS HIGH + ≥80 CLK pulses    → card internal state machine wakes (native → SPI receptive)
+CS LOW  + CMD0 (CRC=0x95)   → R1 = 0x01  (idle state)           ← only seen once cleanly
+CMD8    (0x1AA)             → R1 = 0x01 + 4 bytes voltage echo
+CMD55 + ACMD41 loop         → R1 = 0x01 while initialising, 0x00 when ready
+CMD58                       → OCR register, check CCS bit for SDHC/SDXC
+```
+
+---
+
+## Known causes of getting stuck in 0xFF
+
+1. **Repeated CS-toggle retries** — toggling CS HIGH/LOW 50+ times while the
+   card is in an intermediate state can confuse the SPI state machine.
+   The SdFat reference implementation keeps CS LOW throughout all CMD0 retries
+   (clocking 0xFF bytes with CS asserted) rather than deasserting between
+   retries.  Our CS-toggle patch was intended to help the "already active" case
+   but likely caused the deeper stuck state.
+
+2. **Card in mid-transaction after MCU reset** — after a watchdog or
+   probe-rs-triggered reset the card retains its SPI state.  If the card was
+   mid-block-read or mid-write, it may not respond to CMD0 until the
+   in-progress block is clocked out (515 bytes max).
+
+3. **Card in native SD mode** — per spec this should not happen without a
+   power cycle, but some cheap cards behave non-conformantly.
+
+---
+
+## Fixes / mitigations
+
+### Software — enable RP2350 internal pull-up on MISO (GP16)
+
+After `Spi::new_blocking`, add:
+
+```rust
+// embassy-rp disables pull-ups on SPI pins; re-enable on MISO (GP16)
+// because SD card MISO is open-collector and needs a pull-up.
+embassy_rp::pac::PADS_BANK0.gpio(16).modify(|w| w.set_pue(true));
+```
+
+This puts the RP2350 ~56 kΩ pull-up in parallel with the module's ~10 kΩ,
+giving ~9 kΩ total — closer to the recommended 5 kΩ and better for
+open-collector signal integrity.
+
+### Software — keep CS LOW during CMD0 retries (revert CS-toggle patch)
+
+The original embedded-sdmmc / SdFat behaviour: flush 0xFF bytes with CS
+**asserted** (LOW) between CMD0 retries.  This clocks out any pending
+data block without confusing the card with CS transitions.  Only raise CS
+between full `acquire()` attempts, not between individual CMD0 commands.
+
+### Hardware — GP20 power switch (planned, Bead 4)
+
+Wire GP20 to a P-MOSFET or load switch (AP2112 / TPS22860) that gates VBUS
+to the module VCC pin.  The firmware can then:
+
+```
+GP20 LOW  for ≥100 ms  → module off, capacitors discharge
+GP20 HIGH + 250 ms     → module on, card power-on reset
+re-initialise SdCard object
+```
+
+Circuit and logic level details are in CLAUDE.md (SD module power switch
+section).  This is the definitive fix for stuck-card recovery without manual
+power cycling.
+
+### Hardware — external 4.7 kΩ pull-up on MISO (optional improvement)
+
+Add a 4.7 kΩ resistor from GP16 (MISO) to the 3.3 V rail.  Together with the
+module's 10 kΩ this gives ~3.2 kΩ, well within the recommended range and
+robust for SDXC cards at higher SPI speeds.
+
+---
+
+## References
+
+- [SD Card Reader MISO Hack — Hackaday.io](https://hackaday.io/project/164296-sd-card-reader-miso-hack)
+- [MicroSD Card Hardware Fault Fixed — Arduino Forum](https://forum.arduino.cc/t/microsd-card-hardware-fault-fixed/625442)
+- [no-OS-FatFS-SD-SPI-RPi-Pico README — carlk3/GitHub](https://github.com/carlk3/no-OS-FatFS-SD-SPI-RPi-Pico)
+- [SD Card Not Working Without Pull-up on MISO — Arduino Forum](https://forum.arduino.cc/t/sd-card-not-working-unless-i-enable-pullup-on-miso-is-this-okay/147327)
+- [In-Depth Tutorial: Micro SD Card Module — Last Minute Engineers](https://lastminuteengineers.com/arduino-micro-sd-card-module-tutorial/)
+- [SD Level Shifting Using 74HC125 — Arduino Forum](https://forum.arduino.cc/t/sd-card-level-shifting-using-74hc125-ic/174703)

--- a/platform/pico2w/src/lib.rs
+++ b/platform/pico2w/src/lib.rs
@@ -2,3 +2,5 @@
 
 pub mod display;
 pub mod input;
+#[cfg(target_arch = "arm")]
+pub mod sd;

--- a/platform/pico2w/src/main.rs
+++ b/platform/pico2w/src/main.rs
@@ -1,21 +1,27 @@
 #![no_std]
 #![no_main]
+extern crate alloc;
 
 use embedded_alloc::Heap;
 
 #[global_allocator]
 static HEAP: Heap = Heap::empty();
 
-use defmt::{info, warn};
+use defmt::{error, info, warn};
 use embassy_executor::Spawner;
 use embassy_rp::gpio::{Level, Output};
+use embassy_rp::spi::{self, Spi};
 use embassy_rp::watchdog::Watchdog;
-use embassy_time::{Duration, Timer};
+use embassy_time::{Delay, Duration, Timer};
+use embedded_hal_bus::spi::ExclusiveDevice;
+use embedded_sdmmc::{SdCard, VolumeManager};
 use {defmt_rtt as _, panic_probe as _};
 
 use rustyboy_core::cpu::peripheral::joypad::Button;
+use rustyboy_core::memory::{GameBoyMemory, StreamingCartridge};
 use rustyboy_pico2w::display::hw::HwDisplay;
 use rustyboy_pico2w::input::{ButtonState, InputHandler};
+use rustyboy_pico2w::sd::{DummyClock, SdRomReader};
 
 const FIRMWARE_VERSION: &str = env!("CARGO_PKG_VERSION");
 
@@ -33,7 +39,7 @@ async fn main(_spawner: Spawner) {
         use core::mem::MaybeUninit;
         const HEAP_SIZE: usize = 32 * 1024;
         static mut HEAP_MEM: [MaybeUninit<u8>; HEAP_SIZE] = [MaybeUninit::uninit(); HEAP_SIZE];
-        unsafe { HEAP.init(HEAP_MEM.as_ptr() as usize, HEAP_SIZE) }
+        unsafe { HEAP.init(core::ptr::addr_of!(HEAP_MEM) as usize, HEAP_SIZE) }
     }
 
     let p = embassy_rp::init(Default::default());
@@ -58,10 +64,39 @@ async fn main(_spawner: Spawner) {
         p.PIN_0,  p.PIN_1,  p.PIN_2,  p.PIN_3,
     );
 
-    info!("entering main loop");
+    // SD card: power-cycle via GP20, then init SPI0 on GP4-GP7.
+    let mut sd_power = Output::new(p.PIN_20, Level::Low);
+    Timer::after(Duration::from_millis(200)).await;
+    sd_power.set_high();
+    Timer::after(Duration::from_millis(250)).await;
 
-    // TODO: load ROM from SD card
-    // TODO: run core + I2S audio
+    let mut spi_cfg = spi::Config::default();
+    spi_cfg.frequency = 400_000;
+    let spi_bus = Spi::new_blocking(p.SPI0, p.PIN_6, p.PIN_7, p.PIN_4, spi_cfg);
+    // SD card MISO (GP4) is open-collector — enable the internal pull-up.
+    rp_pac::PADS_BANK0.gpio(4).modify(|w| w.set_pue(true));
+    let spi_dev = ExclusiveDevice::new(spi_bus, Output::new(p.PIN_5, Level::High), Delay);
+    let sdcard  = SdCard::new(spi_dev, Delay);
+    let mgr     = VolumeManager::new(sdcard, DummyClock);
+
+    let reader = match SdRomReader::new(mgr) {
+        Ok(r) => r,
+        Err(e) => {
+            error!("SD init failed: {:?}", defmt::Debug2Format(&e));
+            loop { Timer::after(Duration::from_millis(2_000)).await; }
+        }
+    };
+    let cart = match StreamingCartridge::new(reader) {
+        Ok(c) => c,
+        Err(e) => {
+            error!("ROM load failed: {:?}", defmt::Debug2Format(&e));
+            loop { Timer::after(Duration::from_millis(2_000)).await; }
+        }
+    };
+    let _memory = GameBoyMemory::with_cartridge(alloc::boxed::Box::new(cart));
+    info!("ROM loaded, entering main loop");
+
+    // TODO: run core + I2S audio (Bead 5)
 
     let mut prev_state = ButtonState::default();
     let mut tick: u32 = 0;

--- a/platform/pico2w/src/sd.rs
+++ b/platform/pico2w/src/sd.rs
@@ -1,0 +1,106 @@
+use embedded_sdmmc::{
+    BlockDevice, Mode, RawFile, RawVolume, ShortFileName, TimeSource, VolumeIdx, VolumeManager,
+};
+
+use rustyboy_core::memory::RomReader;
+
+// ── Time source ───────────────────────────────────────────────────────────────
+
+pub struct DummyClock;
+impl TimeSource for DummyClock {
+    fn get_timestamp(&self) -> embedded_sdmmc::Timestamp {
+        embedded_sdmmc::Timestamp::from_fat(0, 0)
+    }
+}
+
+// ── SdRomReader ───────────────────────────────────────────────────────────────
+
+pub struct SdRomReader<D, T = DummyClock>
+where
+    D: BlockDevice,
+    <D as BlockDevice>::Error: core::fmt::Debug,
+    T: TimeSource,
+{
+    mgr:    VolumeManager<D, T>,
+    volume: RawVolume,
+    file:   RawFile,
+}
+
+#[derive(Debug)]
+pub enum SdError<E: core::fmt::Debug> {
+    Sdmmc(embedded_sdmmc::Error<E>),
+    NoRomFound,
+}
+
+impl<E: core::fmt::Debug> From<embedded_sdmmc::Error<E>> for SdError<E> {
+    fn from(e: embedded_sdmmc::Error<E>) -> Self {
+        SdError::Sdmmc(e)
+    }
+}
+
+impl<D, T> SdRomReader<D, T>
+where
+    D: BlockDevice,
+    <D as BlockDevice>::Error: core::fmt::Debug,
+    T: TimeSource,
+{
+    /// Mount the first partition, scan the root directory for a `.gb` or `.gbc`
+    /// file, and open it for sequential bank reads.
+    pub fn new(mgr: VolumeManager<D, T>) -> Result<Self, SdError<D::Error>> {
+        let volume = mgr.open_raw_volume(VolumeIdx(0))?;
+        let dir    = mgr.open_root_dir(volume)?;
+
+        let mut found: Option<ShortFileName> = None;
+        mgr.iterate_dir(dir, |entry| {
+            if found.is_none() && is_rom_file(&entry.name) {
+                found = Some(entry.name.clone());
+            }
+        })?;
+
+        let name = found.ok_or(SdError::NoRomFound)?;
+        let file = mgr.open_file_in_dir(dir, name, Mode::ReadOnly)?;
+        mgr.close_dir(dir)?;
+
+        Ok(Self { mgr, volume, file })
+    }
+}
+
+impl<D, T> Drop for SdRomReader<D, T>
+where
+    D: BlockDevice,
+    <D as BlockDevice>::Error: core::fmt::Debug,
+    T: TimeSource,
+{
+    fn drop(&mut self) {
+        let _ = self.mgr.close_file(self.file);
+        let _ = self.mgr.close_volume(self.volume);
+    }
+}
+
+impl<D, T> RomReader for SdRomReader<D, T>
+where
+    D: BlockDevice,
+    <D as BlockDevice>::Error: core::fmt::Debug,
+    T: TimeSource,
+{
+    type Error = SdError<D::Error>;
+
+    fn read_bank(&mut self, bank: usize, buf: &mut [u8; 0x4000]) -> Result<(), Self::Error> {
+        let offset = (bank as u32) * 0x4000;
+        self.mgr.file_seek_from_start(self.file, offset)?;
+        let mut total = 0;
+        while total < 0x4000 {
+            let n = self.mgr.read(self.file, &mut buf[total..])?;
+            if n == 0 { break; }
+            total += n;
+        }
+        Ok(())
+    }
+}
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+fn is_rom_file(name: &ShortFileName) -> bool {
+    let ext = name.extension();
+    ext == b"GB " || ext == b"GBC"
+}

--- a/platform/web/client/Cargo.toml
+++ b/platform/web/client/Cargo.toml
@@ -13,6 +13,3 @@ debug-overlay = []
 rustyboy-core = { path = "../../../core" }
 wasm-bindgen = "0.2"
 
-[profile.release]
-opt-level = "s"
-lto = true


### PR DESCRIPTION
## Summary

- **`StreamingCartridge<R: RomReader>`** added to `core`: bank-cached cartridge (16 KB bank 0 fixed + 16 KB switchable) with MBC1/MBC3/NoMBC support and 19 unit tests
- **`SdRomReader`** added to `pico2w`: mounts FAT32 on SPI0, scans root for `.gb`/`.gbc`, implements `RomReader` via seek+read
- **GPIO wiring** in `main.rs`: GP20 power-cycle → SPI0 400 kHz on GP4–7 → `VolumeManager` → `StreamingCartridge` → `GameBoyMemory`
- **Pin table** updated in README + CLAUDE.md (SD on GP4–7/GP20; I2S/SD_MODE/brown-out rehomed to GP16–18)
- **SD_MODULE_NOTES.md**: 74LVC125A module circuit analysis, MISO open-collector behaviour, CMD0 stuck-state root causes
- **Build hygiene**: profiles moved to workspace root, unused embedded-sdmmc 0.7 patch removed, all warnings fixed

## Test plan

- [ ] `cargo test-host -p rustyboy-core` — all 19 StreamingCartridge unit tests pass
- [ ] `cargo build --release --bin rustyboy-pico2w` — zero warnings, clean ARM build
- [ ] Flash to Pico 2W with a `.gb` ROM on SD card root — verify `ROM loaded, entering main loop` in RTT log
- [ ] Flash without SD card / without ROM — verify `SD init failed` error log and graceful hang

🤖 Generated with [Claude Code](https://claude.com/claude-code)