### PR TITLE
Stage ROMs from SD into onboard flash

### DIFF
--- a/platform/pico2w/memory.x
+++ b/platform/pico2w/memory.x
@@ -5,7 +5,11 @@
  * RAM:   512KB striped across SRAM0-SRAM7 (8 × 64KB banks, best for general use)
  *        SRAM8/SRAM9: 4KB direct-mapped banks (dedicated use, e.g. per-core stacks)
  *
- * NOTE: Bead 1 uses a single-app layout (no bootloader).
+ * NOTE: the first 512 KiB of flash are reserved for the firmware image.
+ * The remaining flash is available to runtime-managed data (currently a staged
+ * ROM slot).
+ *
+ * Bead 1 uses a single-app layout (no bootloader).
  * Bead 8 (OTA) will restructure this into dual-bank partitions
  * for embassy-boot-rp:
  *   BOOTLOADER : ORIGIN = 0x10000000, LENGTH = 32K
@@ -13,7 +17,7 @@
  *   APP_B      : ORIGIN = 0x10200000, LENGTH = ~2M   <- OTA staging slot
  */
 MEMORY {
-    FLASH : ORIGIN = 0x10000000, LENGTH = 4M
+    FLASH : ORIGIN = 0x10000000, LENGTH = 512K
     RAM   : ORIGIN = 0x20000000, LENGTH = 512K
     SRAM8 : ORIGIN = 0x20080000, LENGTH = 4K
     SRAM9 : ORIGIN = 0x20081000, LENGTH = 4K

--- a/platform/pico2w/src/flash_rom.rs
+++ b/platform/pico2w/src/flash_rom.rs
@@ -1,0 +1,210 @@
+use core::fmt::Debug;
+
+use embassy_rp::flash::{Blocking, Error as FlashError, Flash, FLASH_BASE, ERASE_SIZE};
+use embassy_rp::peripherals::FLASH;
+use embassy_rp::Peri;
+
+use rustyboy_core::memory::RomReader;
+
+pub const FLASH_CAPACITY_BYTES: usize = 4 * 1024 * 1024;
+pub const FIRMWARE_SLOT_BYTES: usize = 512 * 1024;
+pub const ROM_METADATA_BYTES: usize = ERASE_SIZE;
+pub const ROM_SLOT_OFFSET: usize = FIRMWARE_SLOT_BYTES;
+pub const ROM_DATA_OFFSET: usize = ROM_SLOT_OFFSET + ROM_METADATA_BYTES;
+pub const ROM_DATA_CAPACITY_BYTES: usize = FLASH_CAPACITY_BYTES - ROM_DATA_OFFSET;
+
+const ROM_BANK_BYTES: usize = 0x4000;
+const HEADER_MAGIC: [u8; 8] = *b"RBROM1\0\0";
+const HEADER_VERSION: u32 = 1;
+const HEADER_LEN: usize = 32;
+const ROM_SIZE_CODE_OFFSET: usize = 0x0148;
+
+pub type OnboardFlash<'d> = Flash<'d, FLASH, Blocking, FLASH_CAPACITY_BYTES>;
+
+#[derive(Debug, Clone, Copy)]
+pub struct FlashRomInfo {
+    pub size_bytes: usize,
+    pub bank_count: usize,
+}
+
+#[derive(Debug, Clone, Copy)]
+pub enum FlashRomReadError {
+    OutOfBounds,
+}
+
+#[derive(Debug)]
+pub enum FlashRomStageError<E: Debug> {
+    Reader(E),
+    Flash(FlashError),
+    InvalidRomSizeCode(u8),
+    TooLarge {
+        bytes: usize,
+        capacity: usize,
+    },
+}
+
+pub struct FlashRomReader {
+    info: FlashRomInfo,
+}
+
+impl FlashRomReader {
+    pub fn new(info: FlashRomInfo) -> Self {
+        Self { info }
+    }
+}
+
+impl RomReader for FlashRomReader {
+    type Error = FlashRomReadError;
+
+    fn read_bank(&mut self, bank: usize, buf: &mut [u8; ROM_BANK_BYTES]) -> Result<(), Self::Error> {
+        if bank >= self.info.bank_count {
+            buf.fill(0xFF);
+            return Err(FlashRomReadError::OutOfBounds);
+        }
+
+        let src = (FLASH_BASE as usize) + ROM_DATA_OFFSET + bank * ROM_BANK_BYTES;
+        let src = src as *const u8;
+
+        unsafe {
+            let rom = core::slice::from_raw_parts(src, ROM_BANK_BYTES);
+            buf.copy_from_slice(rom);
+        }
+
+        Ok(())
+    }
+}
+
+pub fn new_onboard_flash<'d>(flash: Peri<'d, FLASH>) -> OnboardFlash<'d> {
+    Flash::new_blocking(flash)
+}
+
+pub fn probe_staged_rom() -> Option<FlashRomInfo> {
+    let header = read_header();
+    parse_header(&header)
+}
+
+pub fn stage_rom_from_reader<R: RomReader>(
+    flash: &mut OnboardFlash<'_>,
+    reader: &mut R,
+) -> Result<FlashRomInfo, FlashRomStageError<R::Error>>
+where
+    R::Error: Debug,
+{
+    let mut bank0 = [0u8; ROM_BANK_BYTES];
+    reader
+        .read_bank(0, &mut bank0)
+        .map_err(FlashRomStageError::Reader)?;
+
+    let rom_size_code = bank0[ROM_SIZE_CODE_OFFSET];
+    let bank_count = rom_bank_count_from_code(rom_size_code)
+        .ok_or(FlashRomStageError::InvalidRomSizeCode(rom_size_code))?;
+    let size_bytes = bank_count * ROM_BANK_BYTES;
+
+    if size_bytes > ROM_DATA_CAPACITY_BYTES {
+        return Err(FlashRomStageError::TooLarge {
+            bytes: size_bytes,
+            capacity: ROM_DATA_CAPACITY_BYTES,
+        });
+    }
+
+    let erase_end = align_up(ROM_DATA_OFFSET + size_bytes, ERASE_SIZE);
+    flash
+        .blocking_erase(ROM_SLOT_OFFSET as u32, erase_end as u32)
+        .map_err(FlashRomStageError::Flash)?;
+
+    flash
+        .blocking_write(ROM_DATA_OFFSET as u32, &bank0)
+        .map_err(FlashRomStageError::Flash)?;
+
+    let mut bank_buf = [0u8; ROM_BANK_BYTES];
+    for bank in 1..bank_count {
+        reader
+            .read_bank(bank, &mut bank_buf)
+            .map_err(FlashRomStageError::Reader)?;
+        flash
+            .blocking_write((ROM_DATA_OFFSET + bank * ROM_BANK_BYTES) as u32, &bank_buf)
+            .map_err(FlashRomStageError::Flash)?;
+    }
+
+    let info = FlashRomInfo {
+        size_bytes,
+        bank_count,
+    };
+    let header = build_header(info);
+    flash
+        .blocking_write(ROM_SLOT_OFFSET as u32, &header)
+        .map_err(FlashRomStageError::Flash)?;
+
+    Ok(info)
+}
+
+fn read_header() -> [u8; HEADER_LEN] {
+    let mut header = [0u8; HEADER_LEN];
+    let src = (FLASH_BASE as usize + ROM_SLOT_OFFSET) as *const u8;
+    unsafe {
+        header.copy_from_slice(core::slice::from_raw_parts(src, HEADER_LEN));
+    }
+    header
+}
+
+fn parse_header(header: &[u8; HEADER_LEN]) -> Option<FlashRomInfo> {
+    if header[..8] != HEADER_MAGIC {
+        return None;
+    }
+
+    let version = u32::from_le_bytes(header[8..12].try_into().ok()?);
+    if version != HEADER_VERSION {
+        return None;
+    }
+
+    let size_bytes = u32::from_le_bytes(header[12..16].try_into().ok()?) as usize;
+    let size_bytes_inv = u32::from_le_bytes(header[16..20].try_into().ok()?) as usize;
+    let bank_count = u32::from_le_bytes(header[20..24].try_into().ok()?) as usize;
+
+    if size_bytes == 0 || size_bytes > ROM_DATA_CAPACITY_BYTES {
+        return None;
+    }
+    if size_bytes ^ size_bytes_inv != u32::MAX as usize {
+        return None;
+    }
+    if size_bytes % ROM_BANK_BYTES != 0 {
+        return None;
+    }
+    if bank_count == 0 || bank_count * ROM_BANK_BYTES != size_bytes {
+        return None;
+    }
+
+    Some(FlashRomInfo {
+        size_bytes,
+        bank_count,
+    })
+}
+
+fn build_header(info: FlashRomInfo) -> [u8; HEADER_LEN] {
+    let mut header = [0xFFu8; HEADER_LEN];
+    header[..8].copy_from_slice(&HEADER_MAGIC);
+    header[8..12].copy_from_slice(&HEADER_VERSION.to_le_bytes());
+    header[12..16].copy_from_slice(&(info.size_bytes as u32).to_le_bytes());
+    header[16..20].copy_from_slice(&(!(info.size_bytes as u32)).to_le_bytes());
+    header[20..24].copy_from_slice(&(info.bank_count as u32).to_le_bytes());
+    header
+}
+
+fn rom_bank_count_from_code(code: u8) -> Option<usize> {
+    match code {
+        0x00..=0x08 => Some(2usize << code),
+        0x52 => Some(72),
+        0x53 => Some(80),
+        0x54 => Some(96),
+        _ => None,
+    }
+}
+
+const fn align_up(value: usize, align: usize) -> usize {
+    let rem = value % align;
+    if rem == 0 {
+        value
+    } else {
+        value + (align - rem)
+    }
+}

--- a/platform/pico2w/src/flash_rom.rs
+++ b/platform/pico2w/src/flash_rom.rs
@@ -1,6 +1,6 @@
 use core::fmt::Debug;
 
-use embassy_rp::flash::{Blocking, Error as FlashError, Flash, FLASH_BASE, ERASE_SIZE};
+use embassy_rp::flash::{Blocking, Error as FlashError, Flash, ERASE_SIZE};
 use embassy_rp::peripherals::FLASH;
 use embassy_rp::Peri;
 
@@ -43,17 +43,18 @@ pub enum FlashRomStageError<E: Debug> {
     },
 }
 
-pub struct FlashRomReader {
+pub struct FlashRomReader<'d> {
+    flash: OnboardFlash<'d>,
     info: FlashRomInfo,
 }
 
-impl FlashRomReader {
-    pub fn new(info: FlashRomInfo) -> Self {
-        Self { info }
+impl<'d> FlashRomReader<'d> {
+    pub fn new(flash: OnboardFlash<'d>, info: FlashRomInfo) -> Self {
+        Self { flash, info }
     }
 }
 
-impl RomReader for FlashRomReader {
+impl RomReader for FlashRomReader<'_> {
     type Error = FlashRomReadError;
 
     fn read_bank(&mut self, bank: usize, buf: &mut [u8; ROM_BANK_BYTES]) -> Result<(), Self::Error> {
@@ -62,13 +63,9 @@ impl RomReader for FlashRomReader {
             return Err(FlashRomReadError::OutOfBounds);
         }
 
-        let src = (FLASH_BASE as usize) + ROM_DATA_OFFSET + bank * ROM_BANK_BYTES;
-        let src = src as *const u8;
-
-        unsafe {
-            let rom = core::slice::from_raw_parts(src, ROM_BANK_BYTES);
-            buf.copy_from_slice(rom);
-        }
+        self.flash
+            .blocking_read((ROM_DATA_OFFSET + bank * ROM_BANK_BYTES) as u32, buf)
+            .map_err(|_| FlashRomReadError::OutOfBounds)?;
 
         Ok(())
     }
@@ -78,8 +75,8 @@ pub fn new_onboard_flash<'d>(flash: Peri<'d, FLASH>) -> OnboardFlash<'d> {
     Flash::new_blocking(flash)
 }
 
-pub fn probe_staged_rom() -> Option<FlashRomInfo> {
-    let header = read_header();
+pub fn probe_staged_rom(flash: &mut OnboardFlash<'_>) -> Option<FlashRomInfo> {
+    let header = read_header(flash).ok()?;
     parse_header(&header)
 }
 
@@ -138,13 +135,10 @@ where
     Ok(info)
 }
 
-fn read_header() -> [u8; HEADER_LEN] {
+fn read_header(flash: &mut OnboardFlash<'_>) -> Result<[u8; HEADER_LEN], FlashError> {
     let mut header = [0u8; HEADER_LEN];
-    let src = (FLASH_BASE as usize + ROM_SLOT_OFFSET) as *const u8;
-    unsafe {
-        header.copy_from_slice(core::slice::from_raw_parts(src, HEADER_LEN));
-    }
-    header
+    flash.blocking_read(ROM_SLOT_OFFSET as u32, &mut header)?;
+    Ok(header)
 }
 
 fn parse_header(header: &[u8; HEADER_LEN]) -> Option<FlashRomInfo> {

--- a/platform/pico2w/src/lib.rs
+++ b/platform/pico2w/src/lib.rs
@@ -3,6 +3,8 @@
 #[cfg(target_arch = "arm")]
 pub mod audio;
 pub mod display;
+#[cfg(target_arch = "arm")]
+pub mod flash_rom;
 pub mod input;
 #[cfg(target_arch = "arm")]
 pub mod sd;

--- a/platform/pico2w/src/main.rs
+++ b/platform/pico2w/src/main.rs
@@ -29,6 +29,9 @@ use rustyboy_core::cpu::sm83::Sm83;
 use rustyboy_core::memory::{GameBoyMemory, StreamingCartridge};
 use rustyboy_pico2w::audio::{AudioBuffers, SAMPLE_RATE};
 use rustyboy_pico2w::display::hw::HwDisplay;
+use rustyboy_pico2w::flash_rom::{
+    new_onboard_flash, probe_staged_rom, stage_rom_from_reader, FlashRomReader,
+};
 use rustyboy_pico2w::input::{ButtonState, InputHandler};
 use rustyboy_pico2w::sd::{DummyClock, SdRomReader};
 
@@ -76,28 +79,58 @@ async fn main(_spawner: Spawner) {
         p.PIN_21, p.PIN_22, p.PIN_26, p.PIN_27, p.PIN_0, p.PIN_1, p.PIN_2, p.PIN_3,
     );
 
-    let mut spi_cfg = spi::Config::default();
-    spi_cfg.frequency = 400_000;
-    let spi_bus = Spi::new_blocking(p.SPI0, p.PIN_6, p.PIN_7, p.PIN_4, spi_cfg);
-    // SD card MISO (GP4) is open-collector — enable the internal pull-up.
-    rp_pac::PADS_BANK0.gpio(4).modify(|w| w.set_pue(true));
-    let spi_dev = ExclusiveDevice::new(spi_bus, Output::new(p.PIN_5, Level::High), Delay);
-    let sdcard = SdCard::new(spi_dev, Delay);
-    let mgr = VolumeManager::new(sdcard, DummyClock);
+    let mut onboard_flash = new_onboard_flash(p.FLASH);
+    let flash_info = if let Some(info) = probe_staged_rom() {
+        info!(
+            "staged ROM found in flash: {} banks ({} KiB)",
+            info.bank_count,
+            info.size_bytes / 1024
+        );
+        info
+    } else {
+        info!("no staged ROM in flash; loading from SD");
 
-    let reader = match SdRomReader::new(mgr) {
-        Ok(r) => r,
-        Err(e) => {
-            error!("SD init failed: {:?}", defmt::Debug2Format(&e));
-            loop {
-                Timer::after(Duration::from_millis(2_000)).await;
+        let mut spi_cfg = spi::Config::default();
+        spi_cfg.frequency = 400_000;
+        let spi_bus = Spi::new_blocking(p.SPI0, p.PIN_6, p.PIN_7, p.PIN_4, spi_cfg);
+        // SD card MISO (GP4) is open-collector — enable the internal pull-up.
+        rp_pac::PADS_BANK0.gpio(4).modify(|w| w.set_pue(true));
+        let spi_dev = ExclusiveDevice::new(spi_bus, Output::new(p.PIN_5, Level::High), Delay);
+        let sdcard = SdCard::new(spi_dev, Delay);
+        let mgr = VolumeManager::new(sdcard, DummyClock);
+
+        let mut reader = match SdRomReader::new(mgr) {
+            Ok(r) => r,
+            Err(e) => {
+                error!("SD init failed: {:?}", defmt::Debug2Format(&e));
+                loop {
+                    Timer::after(Duration::from_millis(2_000)).await;
+                }
             }
-        }
+        };
+
+        let info = match stage_rom_from_reader(&mut onboard_flash, &mut reader) {
+            Ok(info) => info,
+            Err(e) => {
+                error!("ROM staging failed: {:?}", defmt::Debug2Format(&e));
+                loop {
+                    Timer::after(Duration::from_millis(2_000)).await;
+                }
+            }
+        };
+
+        info!(
+            "ROM staged to flash: {} banks ({} KiB)",
+            info.bank_count,
+            info.size_bytes / 1024
+        );
+        info
     };
-    let cart = match StreamingCartridge::new(reader) {
+
+    let cart = match StreamingCartridge::new(FlashRomReader::new(flash_info)) {
         Ok(c) => c,
         Err(e) => {
-            error!("ROM load failed: {:?}", defmt::Debug2Format(&e));
+            error!("flash ROM load failed: {:?}", defmt::Debug2Format(&e));
             loop {
                 Timer::after(Duration::from_millis(2_000)).await;
             }

--- a/platform/pico2w/src/main.rs
+++ b/platform/pico2w/src/main.rs
@@ -80,7 +80,7 @@ async fn main(_spawner: Spawner) {
     );
 
     let mut onboard_flash = new_onboard_flash(p.FLASH);
-    let flash_info = if let Some(info) = probe_staged_rom() {
+    let flash_info = if let Some(info) = probe_staged_rom(&mut onboard_flash) {
         info!(
             "staged ROM found in flash: {} banks ({} KiB)",
             info.bank_count,
@@ -127,7 +127,7 @@ async fn main(_spawner: Spawner) {
         info
     };
 
-    let cart = match StreamingCartridge::new(FlashRomReader::new(flash_info)) {
+    let cart = match StreamingCartridge::new(FlashRomReader::new(onboard_flash, flash_info)) {
         Ok(c) => c,
         Err(e) => {
             error!("flash ROM load failed: {:?}", defmt::Debug2Format(&e));


### PR DESCRIPTION
This PR trims the previous top-of-stack branch down to just the flash ROM staging feature.

It adds:
- a reserved onboard flash ROM slot
- ROM staging from SD into that slot on first successful boot
- staged ROM header probing on later boots
- runtime boot from onboard flash instead of repeated SD streaming

This stacks on #66.