### PR TITLE
Add Pico 2W runtime base and game loop

### DIFF
--- a/platform/pico2w/README.md
+++ b/platform/pico2w/README.md
@@ -131,17 +131,22 @@ RTT logs are not available without a debug probe. After Bead 7, syslog over WiFi
 On boot the firmware:
 
 1. Plays the **VINTENDO** splash animation on the ILI9341 display (~640ms slide-in + 2s hold)
-2. Enters a **~60 Hz main loop** that polls all 8 buttons with 10ms software debounce
-3. Logs button press/release events over defmt RTT
-4. Detects a **Start+Select hold (1s)** and logs a menu-combo event
-5. Blinks the dev LED on GP15 at 1Hz as a heartbeat
+2. Reads the first `.gb` ROM from the SD card and loads it into a `StreamingCartridge`
+3. Starts the **SM83 core** at the DMG post-boot-ROM state (PC = 0x0100, registers seeded)
+4. Enters a **~59.7 Hz game loop**:
+   - Executes exactly **70 224 T-cycles** (one Game Boy frame) per iteration
+   - Renders the 160×144 framebuffer scaled 1.5× to 240×216 on the ILI9341, centred with letterbox bars
+   - Polls all 8 buttons with 10 ms software debounce and feeds changes to the CPU via `set_button()`
+   - Drains APU stereo PCM (48 kHz) and outputs to the MAX98357A via PIO I2S DMA on GP14/GP15/GP16
+   - Detects a **Start+Select hold (1s)** and logs a menu-combo event (save/load UI comes in Bead 9)
+5. Feeds the watchdog every frame
 
 Example RTT output:
 
 ```
 INFO  rustyboy-pico2w v0.1.0 starting
 INFO  display: ILI9341 initialised
-INFO  entering main loop
+INFO  ROM loaded, entering game loop
 INFO  btn press:   A
 INFO  btn release: A
 INFO  btn press:   Start
@@ -223,8 +228,8 @@ syslog_port = 514               # optional, default 514
 | 1 | Scaffold, build system, blinky | ✅ Done |
 | 2 | ILI9341 display driver + framebuffer | ✅ Done |
 | 3 | Input (8 buttons, debounce, menu combo) | ✅ Done |
-| 4 | SD card ROM storage + StreamingCartridge | 🔲 Pending |
-| 5 | Core integration + game loop + I2S audio | 🔲 Pending |
+| 4 | SD card ROM storage + StreamingCartridge | ✅ Done |
+| 5 | Core integration + game loop + I2S audio | ✅ Done |
 | 6 | WiFi + captive portal setup | 🔲 Pending |
 | 7 | Logging + UDP syslog | 🔲 Pending |
 | 8 | OTA via GitHub Releases | 🔲 Pending |

--- a/platform/pico2w/src/audio.rs
+++ b/platform/pico2w/src/audio.rs
@@ -1,0 +1,73 @@
+#![cfg(target_arch = "arm")]
+
+const AUDIO_BUF_SIZE: usize = 1024;
+
+// Double-buffer for I2S DMA: two back-to-back static arrays in .bss.
+static mut AUDIO_BUF_A: [u32; AUDIO_BUF_SIZE] = [0u32; AUDIO_BUF_SIZE];
+static mut AUDIO_BUF_B: [u32; AUDIO_BUF_SIZE] = [0u32; AUDIO_BUF_SIZE];
+
+pub const SAMPLE_RATE: u32 = 48_000;
+
+pub struct AudioBuffers {
+    use_a_as_front: bool,
+    front_n: usize,
+}
+
+impl AudioBuffers {
+    pub const fn new() -> Self {
+        Self {
+            use_a_as_front: true,
+            front_n: 0,
+        }
+    }
+
+    pub fn front_back_buffers(&self) -> (&'static [u32], &'static mut [u32]) {
+        // Safety: A and B are separate statics and are never aliased — one is
+        // read-only (DMA) and the other is write-only (APU fill) per iteration.
+        unsafe {
+            if self.use_a_as_front {
+                (
+                    core::slice::from_raw_parts(
+                        core::ptr::addr_of!(AUDIO_BUF_A).cast::<u32>(),
+                        self.front_n,
+                    ),
+                    core::slice::from_raw_parts_mut(
+                        core::ptr::addr_of_mut!(AUDIO_BUF_B).cast::<u32>(),
+                        AUDIO_BUF_SIZE,
+                    ),
+                )
+            } else {
+                (
+                    core::slice::from_raw_parts(
+                        core::ptr::addr_of!(AUDIO_BUF_B).cast::<u32>(),
+                        self.front_n,
+                    ),
+                    core::slice::from_raw_parts_mut(
+                        core::ptr::addr_of_mut!(AUDIO_BUF_A).cast::<u32>(),
+                        AUDIO_BUF_SIZE,
+                    ),
+                )
+            }
+        }
+    }
+
+    pub fn queue_next_frame(&mut self, samples: &[f32], back_buf: &mut [u32]) {
+        let back_n = samples_to_i2s(samples, back_buf);
+        self.use_a_as_front = !self.use_a_as_front;
+        self.front_n = back_n;
+    }
+}
+
+/// Pack interleaved stereo f32 samples [L, R, L, R …] into I2S u32 words.
+///
+/// Each word carries one stereo pair: left channel in bits 31:16, right in
+/// bits 15:0.  Converts f32 [-1.0, 1.0] → i16 and reinterprets as u16.
+fn samples_to_i2s(samples: &[f32], buf: &mut [u32]) -> usize {
+    let pairs = (samples.len() / 2).min(buf.len());
+    for i in 0..pairs {
+        let l = (samples[i * 2] * 32767.0) as i16;
+        let r = (samples[i * 2 + 1] * 32767.0) as i16;
+        buf[i] = ((l as u16 as u32) << 16) | (r as u16 as u32);
+    }
+    pairs
+}

--- a/platform/pico2w/src/display/mod.rs
+++ b/platform/pico2w/src/display/mod.rs
@@ -81,6 +81,23 @@ impl<D: DrawTarget<Color = Rgb565> + Dimensions> Display<D> {
         self.fill_bar(Y_OFFSET + SCALED_H, Y_OFFSET, Rgb565::BLACK);
     }
 
+    /// Draw the static letterbox bars above and below the game area.
+    ///
+    /// Call once before the game loop. Subsequent frames can use
+    /// [`render_game_only`] to skip repainting the unchanging bars.
+    pub fn draw_letterbox_bars(&mut self) {
+        self.fill_bar(0, Y_OFFSET, C3);
+        self.fill_bar(Y_OFFSET + SCALED_H, Y_OFFSET, Rgb565::BLACK);
+    }
+
+    /// Render only the scaled Game Boy frame (240×216), skipping letterbox bars.
+    ///
+    /// Saves ~6.4 ms per frame vs [`render_frame`] by not repainting the static
+    /// top/bottom bars. Call [`draw_letterbox_bars`] once before the game loop.
+    pub fn render_game_only(&mut self, fb: &[u8; 23040]) {
+        self.fill_scaled_frame(fb);
+    }
+
     fn fill_bar(&mut self, y: i32, height: i32, color: Rgb565) {
         if height <= 0 {
             return;
@@ -358,6 +375,26 @@ mod tests {
 
         assert!(!disp.splash_step(total - 1), "should still be animating");
         assert!(disp.splash_step(total), "should be done on last frame");
+    }
+
+    #[test]
+    fn draw_letterbox_bars_colors() {
+        let mut disp = make_display();
+        disp.draw_letterbox_bars();
+        let fb_ref = disp.inner.as_ref();
+        assert_eq!(fb_ref[0], C3, "top bar should be C3");
+        let bot_start = ((Y_OFFSET + SCALED_H) * SCREEN_W) as usize;
+        assert_eq!(fb_ref[bot_start], Rgb565::BLACK, "bottom bar should be black");
+    }
+
+    #[test]
+    fn render_game_only_updates_game_region() {
+        let mut disp = make_display();
+        let fb = [1u8; 23040]; // all palette index 1 → C1
+        disp.render_game_only(&fb);
+        let fb_ref = disp.inner.as_ref();
+        let mid = (Y_OFFSET * SCREEN_W) as usize;
+        assert_eq!(fb_ref[mid], C1, "game region pixel should be C1");
     }
 
     #[test]

--- a/platform/pico2w/src/lib.rs
+++ b/platform/pico2w/src/lib.rs
@@ -1,5 +1,7 @@
 #![cfg_attr(target_arch = "arm", no_std)]
 
+#[cfg(target_arch = "arm")]
+pub mod audio;
 pub mod display;
 pub mod input;
 #[cfg(target_arch = "arm")]

--- a/platform/pico2w/src/main.rs
+++ b/platform/pico2w/src/main.rs
@@ -10,20 +10,41 @@ static HEAP: Heap = Heap::empty();
 use defmt::{error, info, warn};
 use embassy_executor::Spawner;
 use embassy_rp::gpio::{Level, Output};
+use embassy_rp::peripherals::{DMA_CH0, PIO0};
+use embassy_rp::pio::{InterruptHandler as PioIrqHandler, Pio};
+use embassy_rp::pio_programs::i2s::{PioI2sOut, PioI2sOutProgram};
 use embassy_rp::spi::{self, Spi};
 use embassy_rp::watchdog::Watchdog;
+use embassy_rp::{bind_interrupts, dma};
 use embassy_time::{Delay, Duration, Timer};
 use embedded_hal_bus::spi::ExclusiveDevice;
 use embedded_sdmmc::{SdCard, VolumeManager};
 use {defmt_rtt as _, panic_probe as _};
 
+use rustyboy_core::cpu::cpu::Cpu;
+use rustyboy_core::cpu::instructions::opcodes::OpCodeDecoder;
 use rustyboy_core::cpu::peripheral::joypad::Button;
+use rustyboy_core::cpu::registers::{Flags, Registers};
+use rustyboy_core::cpu::sm83::Sm83;
 use rustyboy_core::memory::{GameBoyMemory, StreamingCartridge};
 use rustyboy_pico2w::display::hw::HwDisplay;
 use rustyboy_pico2w::input::{ButtonState, InputHandler};
 use rustyboy_pico2w::sd::{DummyClock, SdRomReader};
 
 const FIRMWARE_VERSION: &str = env!("CARGO_PKG_VERSION");
+const CYCLES_PER_FRAME: u64 = 70_224;
+const SAMPLE_RATE: u32 = 48_000;
+// One GB frame generates ~804 stereo samples; 1024 gives comfortable headroom.
+const AUDIO_BUF_SIZE: usize = 1024;
+
+bind_interrupts!(struct Irqs {
+    PIO0_IRQ_0 => PioIrqHandler<PIO0>;
+    DMA_IRQ_0  => dma::InterruptHandler<DMA_CH0>;
+});
+
+// Double-buffer for I2S DMA: two back-to-back static arrays in .bss.
+static mut AUDIO_BUF_A: [u32; AUDIO_BUF_SIZE] = [0u32; AUDIO_BUF_SIZE];
+static mut AUDIO_BUF_B: [u32; AUDIO_BUF_SIZE] = [0u32; AUDIO_BUF_SIZE];
 
 #[unsafe(link_section = ".bi_entries")]
 #[used]
@@ -49,8 +70,6 @@ async fn main(_spawner: Spawner) {
 
     info!("rustyboy-pico2w v{} starting", FIRMWARE_VERSION);
 
-    let mut led = Output::new(p.PIN_15, Level::Low);
-
     // GP8=DC  GP9=CS  GP10=CLK  GP11=MOSI  GP12=RST  GP13=BL
     let mut hw_disp = HwDisplay::new(
         p.SPI1, p.PIN_10, p.PIN_11, p.PIN_9, p.PIN_8, p.PIN_12, p.PIN_13,
@@ -64,7 +83,7 @@ async fn main(_spawner: Spawner) {
         p.PIN_0,  p.PIN_1,  p.PIN_2,  p.PIN_3,
     );
 
-    // SD card: power-cycle via GP20, then init SPI0 on GP4-GP7.
+    // SD card: power-cycle via GP20, then init SPI0 on GP4–GP7.
     let mut sd_power = Output::new(p.PIN_20, Level::Low);
     Timer::after(Duration::from_millis(200)).await;
     sd_power.set_high();
@@ -93,21 +112,83 @@ async fn main(_spawner: Spawner) {
             loop { Timer::after(Duration::from_millis(2_000)).await; }
         }
     };
-    let _memory = GameBoyMemory::with_cartridge(alloc::boxed::Box::new(cart));
-    info!("ROM loaded, entering main loop");
 
-    // TODO: run core + I2S audio (Bead 5)
+    let memory  = GameBoyMemory::with_cartridge(alloc::boxed::Box::new(cart));
+    let decoder = alloc::boxed::Box::new(OpCodeDecoder::new());
+    let mut cpu = Sm83::new(alloc::boxed::Box::new(memory), decoder)
+        .with_registers(Registers {
+            a: 0x01, f: Flags::from_bits_truncate(0xB0),
+            b: 0x00, c: 0x13,
+            d: 0x00, e: 0xD8,
+            h: 0x01, l: 0x4D,
+            pc: 0x0100,
+            sp: 0xFFFE,
+        })
+        .with_dmg_state();
+    info!("ROM loaded, entering game loop");
+
+    // I2S audio: GP14=BCLK  GP15=LRCLK  GP16=DIN  GP17=SD_MODE (MAX98357A).
+    // Drive SD_MODE high to enable the amplifier.
+    let _sd_mode = Output::new(p.PIN_17, Level::High);
+    let Pio { mut common, sm0, .. } = Pio::new(p.PIO0, Irqs);
+    let i2s_prog = PioI2sOutProgram::new(&mut common);
+    let mut i2s = PioI2sOut::new(
+        &mut common,
+        sm0,
+        p.DMA_CH0,
+        Irqs,
+        p.PIN_16, // DIN
+        p.PIN_14, // BCLK
+        p.PIN_15, // LRCLK
+        SAMPLE_RATE,
+        16,       // bit depth
+        &i2s_prog,
+    );
+    i2s.start();
+
+    // Draw static letterbox bars once; game loop only repaints the 240×216 area.
+    hw_disp.inner.draw_letterbox_bars();
+
+    // Double-buffering: front_buf is being DMA'd while back_buf is being filled.
+    // `use_a_as_front` tracks which static array is currently the front buffer.
+    let mut use_a_as_front = true;
+    let mut front_n: usize = 0; // valid samples in the current front buffer
 
     let mut prev_state = ButtonState::default();
-    let mut tick: u32 = 0;
 
     loop {
-        Timer::after(Duration::from_millis(16)).await;
-        watchdog.feed(Duration::from_millis(5_000));
+        // Start DMA transfer of last frame's audio output.
+        // Safety: A and B are separate statics and are never aliased — one is
+        // read-only (DMA) and the other is write-only (APU fill) per iteration.
+        let (front_buf, back_buf): (&[u32], &mut [u32]) = unsafe {
+            if use_a_as_front {
+                (
+                    core::slice::from_raw_parts(
+                        core::ptr::addr_of!(AUDIO_BUF_A).cast::<u32>(), front_n),
+                    core::slice::from_raw_parts_mut(
+                        core::ptr::addr_of_mut!(AUDIO_BUF_B).cast::<u32>(), AUDIO_BUF_SIZE),
+                )
+            } else {
+                (
+                    core::slice::from_raw_parts(
+                        core::ptr::addr_of!(AUDIO_BUF_B).cast::<u32>(), front_n),
+                    core::slice::from_raw_parts_mut(
+                        core::ptr::addr_of_mut!(AUDIO_BUF_A).cast::<u32>(), AUDIO_BUF_SIZE),
+                )
+            }
+        };
+        let dma_future = i2s.write(front_buf);
 
+        // Run exactly one Game Boy frame (70 224 T-cycles ≈ 16.74 ms).
+        let frame_start = cpu.cycle_counter();
+        while cpu.cycle_counter().wrapping_sub(frame_start) < CYCLES_PER_FRAME {
+            let _ = cpu.tick();
+        }
+
+        // Propagate button changes to the CPU.
         let (state, menu) = input.poll();
-
         for (btn, pressed) in prev_state.diff(state) {
+            cpu.set_button(btn, pressed);
             if pressed {
                 info!("btn press:   {}", btn_name(btn));
             } else {
@@ -115,16 +196,42 @@ async fn main(_spawner: Spawner) {
             }
         }
         prev_state = state;
-
         if menu {
             warn!("menu combo triggered");
         }
 
-        tick += 1;
-        if tick % 62 == 0 {
-            led.toggle();
-        }
+        // Render the game area.  Letterbox bars are static and not repainted.
+        hw_disp.inner.render_game_only(cpu.framebuffer());
+
+        // Convert APU f32 output into I2S-packed u32 words for the next DMA.
+        let samples = cpu.drain_audio_samples();
+        let back_n = samples_to_i2s(&samples, back_buf);
+
+        // Await DMA completion — this naturally paces the loop to ~59.7 fps.
+        dma_future.await;
+        watchdog.feed(Duration::from_millis(5_000));
+
+        // Flip buffers for the next iteration.
+        use_a_as_front = !use_a_as_front;
+        front_n = back_n;
+
+        // Hold the SD power rail alive so the card stays powered.
+        let _ = &sd_power;
     }
+}
+
+/// Pack interleaved stereo f32 samples [L, R, L, R …] into I2S u32 words.
+///
+/// Each word carries one stereo pair: left channel in bits 31:16, right in
+/// bits 15:0.  Converts f32 [-1.0, 1.0] → i16 and reinterprets as u16.
+fn samples_to_i2s(samples: &[f32], buf: &mut [u32]) -> usize {
+    let pairs = (samples.len() / 2).min(buf.len());
+    for i in 0..pairs {
+        let l = (samples[i * 2]     * 32767.0) as i16;
+        let r = (samples[i * 2 + 1] * 32767.0) as i16;
+        buf[i] = ((l as u16 as u32) << 16) | (r as u16 as u32);
+    }
+    pairs
 }
 
 fn btn_name(b: Button) -> &'static str {

--- a/platform/pico2w/src/main.rs
+++ b/platform/pico2w/src/main.rs
@@ -27,24 +27,18 @@ use rustyboy_core::cpu::peripheral::joypad::Button;
 use rustyboy_core::cpu::registers::{Flags, Registers};
 use rustyboy_core::cpu::sm83::Sm83;
 use rustyboy_core::memory::{GameBoyMemory, StreamingCartridge};
+use rustyboy_pico2w::audio::{AudioBuffers, SAMPLE_RATE};
 use rustyboy_pico2w::display::hw::HwDisplay;
 use rustyboy_pico2w::input::{ButtonState, InputHandler};
 use rustyboy_pico2w::sd::{DummyClock, SdRomReader};
 
 const FIRMWARE_VERSION: &str = env!("CARGO_PKG_VERSION");
 const CYCLES_PER_FRAME: u64 = 70_224;
-const SAMPLE_RATE: u32 = 48_000;
-// One GB frame generates ~804 stereo samples; 1024 gives comfortable headroom.
-const AUDIO_BUF_SIZE: usize = 1024;
 
 bind_interrupts!(struct Irqs {
     PIO0_IRQ_0 => PioIrqHandler<PIO0>;
     DMA_IRQ_0  => dma::InterruptHandler<DMA_CH0>;
 });
-
-// Double-buffer for I2S DMA: two back-to-back static arrays in .bss.
-static mut AUDIO_BUF_A: [u32; AUDIO_BUF_SIZE] = [0u32; AUDIO_BUF_SIZE];
-static mut AUDIO_BUF_B: [u32; AUDIO_BUF_SIZE] = [0u32; AUDIO_BUF_SIZE];
 
 #[unsafe(link_section = ".bi_entries")]
 #[used]
@@ -79,15 +73,8 @@ async fn main(_spawner: Spawner) {
     // GP21=Up  GP22=Down  GP26=Left  GP27=Right
     // GP0=A    GP1=B      GP2=Start  GP3=Select
     let mut input = InputHandler::new(
-        p.PIN_21, p.PIN_22, p.PIN_26, p.PIN_27,
-        p.PIN_0,  p.PIN_1,  p.PIN_2,  p.PIN_3,
+        p.PIN_21, p.PIN_22, p.PIN_26, p.PIN_27, p.PIN_0, p.PIN_1, p.PIN_2, p.PIN_3,
     );
-
-    // SD card: power-cycle via GP20, then init SPI0 on GP4–GP7.
-    let mut sd_power = Output::new(p.PIN_20, Level::Low);
-    Timer::after(Duration::from_millis(200)).await;
-    sd_power.set_high();
-    Timer::after(Duration::from_millis(250)).await;
 
     let mut spi_cfg = spi::Config::default();
     spi_cfg.frequency = 400_000;
@@ -95,32 +82,40 @@ async fn main(_spawner: Spawner) {
     // SD card MISO (GP4) is open-collector — enable the internal pull-up.
     rp_pac::PADS_BANK0.gpio(4).modify(|w| w.set_pue(true));
     let spi_dev = ExclusiveDevice::new(spi_bus, Output::new(p.PIN_5, Level::High), Delay);
-    let sdcard  = SdCard::new(spi_dev, Delay);
-    let mgr     = VolumeManager::new(sdcard, DummyClock);
+    let sdcard = SdCard::new(spi_dev, Delay);
+    let mgr = VolumeManager::new(sdcard, DummyClock);
 
     let reader = match SdRomReader::new(mgr) {
         Ok(r) => r,
         Err(e) => {
             error!("SD init failed: {:?}", defmt::Debug2Format(&e));
-            loop { Timer::after(Duration::from_millis(2_000)).await; }
+            loop {
+                Timer::after(Duration::from_millis(2_000)).await;
+            }
         }
     };
     let cart = match StreamingCartridge::new(reader) {
         Ok(c) => c,
         Err(e) => {
             error!("ROM load failed: {:?}", defmt::Debug2Format(&e));
-            loop { Timer::after(Duration::from_millis(2_000)).await; }
+            loop {
+                Timer::after(Duration::from_millis(2_000)).await;
+            }
         }
     };
 
-    let memory  = GameBoyMemory::with_cartridge(alloc::boxed::Box::new(cart));
+    let memory = GameBoyMemory::with_cartridge(alloc::boxed::Box::new(cart));
     let decoder = alloc::boxed::Box::new(OpCodeDecoder::new());
     let mut cpu = Sm83::new(alloc::boxed::Box::new(memory), decoder)
         .with_registers(Registers {
-            a: 0x01, f: Flags::from_bits_truncate(0xB0),
-            b: 0x00, c: 0x13,
-            d: 0x00, e: 0xD8,
-            h: 0x01, l: 0x4D,
+            a: 0x01,
+            f: Flags::from_bits_truncate(0xB0),
+            b: 0x00,
+            c: 0x13,
+            d: 0x00,
+            e: 0xD8,
+            h: 0x01,
+            l: 0x4D,
             pc: 0x0100,
             sp: 0xFFFE,
         })
@@ -130,7 +125,9 @@ async fn main(_spawner: Spawner) {
     // I2S audio: GP14=BCLK  GP15=LRCLK  GP16=DIN  GP17=SD_MODE (MAX98357A).
     // Drive SD_MODE high to enable the amplifier.
     let _sd_mode = Output::new(p.PIN_17, Level::High);
-    let Pio { mut common, sm0, .. } = Pio::new(p.PIO0, Irqs);
+    let Pio {
+        mut common, sm0, ..
+    } = Pio::new(p.PIO0, Irqs);
     let i2s_prog = PioI2sOutProgram::new(&mut common);
     let mut i2s = PioI2sOut::new(
         &mut common,
@@ -141,7 +138,7 @@ async fn main(_spawner: Spawner) {
         p.PIN_14, // BCLK
         p.PIN_15, // LRCLK
         SAMPLE_RATE,
-        16,       // bit depth
+        16, // bit depth
         &i2s_prog,
     );
     i2s.start();
@@ -149,34 +146,13 @@ async fn main(_spawner: Spawner) {
     // Draw static letterbox bars once; game loop only repaints the 240×216 area.
     hw_disp.inner.draw_letterbox_bars();
 
-    // Double-buffering: front_buf is being DMA'd while back_buf is being filled.
-    // `use_a_as_front` tracks which static array is currently the front buffer.
-    let mut use_a_as_front = true;
-    let mut front_n: usize = 0; // valid samples in the current front buffer
-
+    let mut audio_buffers = AudioBuffers::new();
     let mut prev_state = ButtonState::default();
 
     loop {
-        // Start DMA transfer of last frame's audio output.
-        // Safety: A and B are separate statics and are never aliased — one is
-        // read-only (DMA) and the other is write-only (APU fill) per iteration.
-        let (front_buf, back_buf): (&[u32], &mut [u32]) = unsafe {
-            if use_a_as_front {
-                (
-                    core::slice::from_raw_parts(
-                        core::ptr::addr_of!(AUDIO_BUF_A).cast::<u32>(), front_n),
-                    core::slice::from_raw_parts_mut(
-                        core::ptr::addr_of_mut!(AUDIO_BUF_B).cast::<u32>(), AUDIO_BUF_SIZE),
-                )
-            } else {
-                (
-                    core::slice::from_raw_parts(
-                        core::ptr::addr_of!(AUDIO_BUF_B).cast::<u32>(), front_n),
-                    core::slice::from_raw_parts_mut(
-                        core::ptr::addr_of_mut!(AUDIO_BUF_A).cast::<u32>(), AUDIO_BUF_SIZE),
-                )
-            }
-        };
+        // Start DMA transfer of last frame's audio output while we fill the
+        // other buffer from the current frame's APU samples.
+        let (front_buf, back_buf) = audio_buffers.front_back_buffers();
         let dma_future = i2s.write(front_buf);
 
         // Run exactly one Game Boy frame (70 224 T-cycles ≈ 16.74 ms).
@@ -205,44 +181,23 @@ async fn main(_spawner: Spawner) {
 
         // Convert APU f32 output into I2S-packed u32 words for the next DMA.
         let samples = cpu.drain_audio_samples();
-        let back_n = samples_to_i2s(&samples, back_buf);
+        audio_buffers.queue_next_frame(&samples, back_buf);
 
         // Await DMA completion — this naturally paces the loop to ~59.7 fps.
         dma_future.await;
         watchdog.feed(Duration::from_millis(5_000));
-
-        // Flip buffers for the next iteration.
-        use_a_as_front = !use_a_as_front;
-        front_n = back_n;
-
-        // Hold the SD power rail alive so the card stays powered.
-        let _ = &sd_power;
     }
-}
-
-/// Pack interleaved stereo f32 samples [L, R, L, R …] into I2S u32 words.
-///
-/// Each word carries one stereo pair: left channel in bits 31:16, right in
-/// bits 15:0.  Converts f32 [-1.0, 1.0] → i16 and reinterprets as u16.
-fn samples_to_i2s(samples: &[f32], buf: &mut [u32]) -> usize {
-    let pairs = (samples.len() / 2).min(buf.len());
-    for i in 0..pairs {
-        let l = (samples[i * 2]     * 32767.0) as i16;
-        let r = (samples[i * 2 + 1] * 32767.0) as i16;
-        buf[i] = ((l as u16 as u32) << 16) | (r as u16 as u32);
-    }
-    pairs
 }
 
 fn btn_name(b: Button) -> &'static str {
     match b {
-        Button::Up     => "Up",
-        Button::Down   => "Down",
-        Button::Left   => "Left",
-        Button::Right  => "Right",
-        Button::A      => "A",
-        Button::B      => "B",
-        Button::Start  => "Start",
+        Button::Up => "Up",
+        Button::Down => "Down",
+        Button::Left => "Left",
+        Button::Right => "Right",
+        Button::A => "A",
+        Button::B => "B",
+        Button::Start => "Start",
         Button::Select => "Select",
     }
 }


### PR DESCRIPTION
This PR splits out the Pico 2W runtime foundation from the larger performance branch.

It contains the Bead 5 integration work:
- core integration on-device
- main game loop
- I2S audio transport
- platform bring-up needed before later perf work

This is the stack base for the follow-up Pico performance PRs.