### PR TITLE
Speed up Pico memory bus hot path

### DIFF
--- a/core/src/cpu/sm83.rs
+++ b/core/src/cpu/sm83.rs
@@ -302,7 +302,7 @@ impl Sm83 {
             return Ok(value);
         }
         self.tick_cycle();
-        self.memory.read(addr)
+        Ok(self.memory.read_fast(addr))
     }
 
     /// Perform a bus write: advance all peripherals by one M-cycle (4 T-cycles),
@@ -324,7 +324,14 @@ impl Sm83 {
             return Ok(());
         }
         self.tick_cycle();
-        self.memory.write(addr, value)
+        match addr {
+            0xFF00..=0xFF7F | 0xFFFF => self.memory.write(addr, value),
+            0xE000..=0xFDFF => Err(MemoryError::ReadOnly(addr)),
+            _ => {
+                self.memory.write_fast(addr, value);
+                Ok(())
+            }
+        }
     }
 
     /// Advance peripherals by one M-cycle (4 T-cycles) without a bus access.
@@ -342,8 +349,8 @@ impl Sm83 {
             Some(ref d) => (d.source, d.progress),
             None => return,
         };
-        let byte = self.memory.read(source + progress as u16).unwrap_or(0xFF);
-        let _ = self.memory.write(0xFE00 + progress as u16, byte);
+        let byte = self.memory.read_fast(source + progress as u16);
+        self.memory.write_fast(0xFE00 + progress as u16, byte);
         let next = progress + 1;
         self.dma = if next < 160 {
             Some(DmaState { source, progress: next })

--- a/core/src/memory/memory.rs
+++ b/core/src/memory/memory.rs
@@ -150,6 +150,39 @@ impl GameBoyMemory {
         self.cartridge.tick_rtc(cycles);
     }
 
+    /// Fast infallible memory read used by the CPU hot path.
+    #[inline(always)]
+    pub fn read_fast(&self, address: u16) -> u8 {
+        match address {
+            0x0000..=0x7FFF => self.cartridge.read_rom(address),
+            0x8000..=0x9FFF => self.vram.read_fast(address - 0x8000),
+            0xA000..=0xBFFF => self.cartridge.read_ram(address - 0xA000),
+            0xC000..=0xDFFF => self.wram.read_fast(address - 0xC000),
+            0xE000..=0xFDFF => self.wram.read_fast(address - 0xE000),
+            0xFE00..=0xFE9F => self.oam.read_fast(address - 0xFE00),
+            0xFF00..=0xFF7F => self.io.read_fast(address - 0xFF00),
+            0xFF80..=0xFFFE => self.hram.read_fast(address - 0xFF80),
+            0xFFFF => self.ie,
+            _ => 0xFF,
+        }
+    }
+
+    /// Fast infallible memory write used by hot non-IO paths.
+    #[inline(always)]
+    pub fn write_fast(&mut self, address: u16, value: u8) {
+        match address {
+            0x0000..=0x7FFF | 0xA000..=0xBFFF => self.cartridge.write(address, value),
+            0x8000..=0x9FFF => self.vram.write_fast(address - 0x8000, value),
+            0xC000..=0xDFFF => self.wram.write_fast(address - 0xC000, value),
+            0xE000..=0xFDFF => {}
+            0xFE00..=0xFE9F => self.oam.write_fast(address - 0xFE00, value),
+            0xFF00..=0xFF7F => self.io.write_fast(address - 0xFF00, value),
+            0xFF80..=0xFFFE => self.hram.write_fast(address - 0xFF80, value),
+            0xFFFF => self.ie = value,
+            _ => {}
+        }
+    }
+
     /// Perform OAM DMA: copy 160 bytes from the source page to OAM.
     /// Source address = page * 0x100. Reads go through normal memory mapping.
     pub fn dma_to_oam(&mut self, page: u8) {

--- a/core/src/memory/rom.rs
+++ b/core/src/memory/rom.rs
@@ -66,6 +66,11 @@ impl Ram {
         Ok(self.data[index])
     }
 
+    #[inline(always)]
+    pub fn read_fast(&self, address: u16) -> u8 {
+        self.data[address as usize]
+    }
+
     pub fn as_slice(&self) -> &[u8] {
         &self.data
     }
@@ -77,6 +82,11 @@ impl Ram {
         }
         self.data[index] = value;
         Ok(())
+    }
+
+    #[inline(always)]
+    pub fn write_fast(&mut self, address: u16, value: u8) {
+        self.data[address as usize] = value;
     }
 }
 


### PR DESCRIPTION
## Summary
- add fast-path memory reads and writes for the hot cartridge/VRAM/WRAM/OAM regions
- use the fast path from the CPU bus and OAM DMA path
- leave the normal path in place for IO writes that still need side effects

## Validation
- built and flashed on hardware from the benchmark worktree
- measured improvement on top of the 250 MHz step from about 4.1–4.4 fps to about 4.6–4.9 fps steady-state
