### PR TITLE
Add perf/fps feature flags with per-component DWT cycle profiling

### DIFF
--- a/core/src/cpu/perf.rs
+++ b/core/src/cpu/perf.rs
@@ -1,9 +1,29 @@
+/// Enable the DWT cycle counter. Call once at startup before using `cyccnt()`.
+/// On Cortex-M33 the counter is gated behind TRCENA in CoreDebug DEMCR and
+/// the CYCCNTENA bit in DWT CTRL — neither is set by the Embassy runtime.
+#[cfg(target_arch = "arm")]
+#[inline(always)]
+pub fn init_cyccnt() {
+    unsafe {
+        // Set TRCENA (bit 24) in CoreDebug DEMCR to enable the DWT block.
+        let demcr = 0xE000_EDFCu32 as *mut u32;
+        demcr.write_volatile(demcr.read_volatile() | (1 << 24));
+        // Reset counter then set CYCCNTENA (bit 0) in DWT CTRL.
+        (0xE000_1004u32 as *mut u32).write_volatile(0);
+        let ctrl = 0xE000_1000u32 as *mut u32;
+        ctrl.write_volatile(ctrl.read_volatile() | 1);
+    }
+}
+
+#[cfg(not(target_arch = "arm"))]
+#[inline(always)]
+pub fn init_cyccnt() {}
+
 /// Read the Cortex-M DWT cycle counter on ARM targets.
 /// Returns 0 on non-ARM targets (tests, coverage, desktop builds).
 #[cfg(target_arch = "arm")]
 #[inline(always)]
 pub fn cyccnt() -> u32 {
-    // DWT CYCCNT register — must be enabled by the runtime before use.
     unsafe { (0xE000_1004u32 as *const u32).read_volatile() }
 }
 

--- a/core/src/cpu/perf.rs
+++ b/core/src/cpu/perf.rs
@@ -1,34 +1,11 @@
-/// Enable the DWT cycle counter. Call once at startup before using `cyccnt()`.
-/// On Cortex-M33 the counter is gated behind TRCENA in CoreDebug DEMCR and
-/// the CYCCNTENA bit in DWT CTRL — neither is set by the Embassy runtime.
-#[cfg(target_arch = "arm")]
-#[inline(always)]
-pub fn init_cyccnt() {
-    unsafe {
-        // Set TRCENA (bit 24) in CoreDebug DEMCR to enable the DWT block.
-        let demcr = 0xE000_EDFCu32 as *mut u32;
-        demcr.write_volatile(demcr.read_volatile() | (1 << 24));
-        // Reset counter then set CYCCNTENA (bit 0) in DWT CTRL.
-        (0xE000_1004u32 as *mut u32).write_volatile(0);
-        let ctrl = 0xE000_1000u32 as *mut u32;
-        ctrl.write_volatile(ctrl.read_volatile() | 1);
-    }
+// Read the cycle counter. Implementation is provided by the platform crate.
+// On pico2w this reads the ARM DWT CYCCNT register.
+// With LTO the call inlines to a single register read at zero extra cost.
+extern "C" {
+    fn perf_cycle_read() -> u32;
 }
 
-#[cfg(not(target_arch = "arm"))]
-#[inline(always)]
-pub fn init_cyccnt() {}
-
-/// Read the Cortex-M DWT cycle counter on ARM targets.
-/// Returns 0 on non-ARM targets (tests, coverage, desktop builds).
-#[cfg(target_arch = "arm")]
 #[inline(always)]
 pub fn cyccnt() -> u32 {
-    unsafe { (0xE000_1004u32 as *const u32).read_volatile() }
-}
-
-#[cfg(not(target_arch = "arm"))]
-#[inline(always)]
-pub fn cyccnt() -> u32 {
-    0
+    unsafe { perf_cycle_read() }
 }

--- a/core/src/cpu/peripheral/ppu.rs
+++ b/core/src/cpu/peripheral/ppu.rs
@@ -90,6 +90,15 @@ pub struct PpuOutput {
 }
 
 /// Scanline-based PPU peripheral.
+#[cfg(feature = "perf")]
+#[derive(Default)]
+pub struct PpuPerfProfile {
+    pub render_bg: u32,
+    pub render_window: u32,
+    pub render_sprites: u32,
+    pub build_stat: u32,
+}
+
 pub struct PpuPeripheral {
     dot: u16,
     ly: u8,
@@ -99,6 +108,8 @@ pub struct PpuPeripheral {
     framebuffer: [u8; FRAMEBUFFER_SIZE],
     /// Raw BG/window color indices (0-3) for the current scanline, used for sprite priority.
     bg_color_indices: [u8; SCREEN_WIDTH],
+    #[cfg(feature = "perf")]
+    perf_profile: PpuPerfProfile,
 }
 
 impl PpuPeripheral {
@@ -111,7 +122,14 @@ impl PpuPeripheral {
             prev_stat_line: false,
             framebuffer: [0u8; FRAMEBUFFER_SIZE],
             bg_color_indices: [0u8; SCREEN_WIDTH],
+            #[cfg(feature = "perf")]
+            perf_profile: PpuPerfProfile::default(),
         }
+    }
+
+    #[cfg(feature = "perf")]
+    pub fn take_perf_profile(&mut self) -> PpuPerfProfile {
+        core::mem::take(&mut self.perf_profile)
     }
 
     pub fn framebuffer(&self) -> &[u8; FRAMEBUFFER_SIZE] {
@@ -201,7 +219,11 @@ impl PpuPeripheral {
             }
         }
 
+        #[cfg(feature = "perf")]
+        let t0 = crate::cpu::perf::cyccnt();
         let (stat, stat_interrupt) = self.build_stat(&input);
+        #[cfg(feature = "perf")]
+        { self.perf_profile.build_stat = self.perf_profile.build_stat.wrapping_add(crate::cpu::perf::cyccnt().wrapping_sub(t0)); }
 
         PpuOutput {
             ly: self.ly,
@@ -256,7 +278,11 @@ impl PpuPeripheral {
         let row_start = ly * SCREEN_WIDTH;
 
         if lcdc.bg_enabled() {
+            #[cfg(feature = "perf")]
+            let t0 = crate::cpu::perf::cyccnt();
             self.render_bg_scanline(input, lcdc, row_start);
+            #[cfg(feature = "perf")]
+            { self.perf_profile.render_bg = self.perf_profile.render_bg.wrapping_add(crate::cpu::perf::cyccnt().wrapping_sub(t0)); }
         } else {
             for x in 0..SCREEN_WIDTH {
                 self.framebuffer[row_start + x] = 0;
@@ -265,11 +291,19 @@ impl PpuPeripheral {
         }
 
         if lcdc.window_enabled() && lcdc.bg_enabled() {
+            #[cfg(feature = "perf")]
+            let t0 = crate::cpu::perf::cyccnt();
             self.render_window_scanline(input, lcdc, row_start);
+            #[cfg(feature = "perf")]
+            { self.perf_profile.render_window = self.perf_profile.render_window.wrapping_add(crate::cpu::perf::cyccnt().wrapping_sub(t0)); }
         }
 
         if lcdc.obj_enabled() {
+            #[cfg(feature = "perf")]
+            let t0 = crate::cpu::perf::cyccnt();
             self.render_sprite_scanline(input, lcdc, row_start);
+            #[cfg(feature = "perf")]
+            { self.perf_profile.render_sprites = self.perf_profile.render_sprites.wrapping_add(crate::cpu::perf::cyccnt().wrapping_sub(t0)); }
         }
     }
 

--- a/core/src/cpu/sm83.rs
+++ b/core/src/cpu/sm83.rs
@@ -144,6 +144,21 @@ impl Sm83Cache {
     }
 }
 
+/// Per-component DWT cycle accumulator. Drained each time `take_perf_profile` is called.
+/// `cpu` = `total` − `ppu` − `timer` − `apu` (instruction fetch/decode/execute overhead).
+#[cfg(feature = "perf")]
+#[derive(Default)]
+pub struct Sm83PerfProfile {
+    pub ppu: u32,
+    pub timer: u32,
+    pub apu: u32,
+    pub total: u32,
+    /// Time spent in memory reads (read_fast) inside bus_read, excluding tick overhead.
+    pub mem_read: u32,
+    /// Time spent in memory writes (write_fast/write_io) inside bus_write, excluding tick overhead.
+    pub mem_write: u32,
+}
+
 pub struct Sm83 {
     memory: Box<GameBoyMemory>,
     registers: Registers,
@@ -169,6 +184,8 @@ pub struct Sm83 {
     /// Per-instruction trace hook, enabled by the `trace` feature.
     #[cfg(feature = "trace")]
     trace_hook: Option<Box<dyn FnMut(TraceEvent<'_>)>>,
+    #[cfg(feature = "perf")]
+    perf: Sm83PerfProfile,
 }
 
 /// State for an in-progress OAM DMA transfer.
@@ -201,6 +218,8 @@ impl Sm83 {
             cache: Sm83Cache::default(),
             #[cfg(feature = "trace")]
             trace_hook: None,
+            #[cfg(feature = "perf")]
+            perf: Sm83PerfProfile::default(),
         };
         // Seed JOYP with no buttons pressed (all lines high).
         sm83.memory.write_io(JOYP_ADDR, sm83.joypad.read());
@@ -288,6 +307,21 @@ impl Sm83 {
         self.apu.drain_samples()
     }
 
+    #[cfg(feature = "perf")]
+    pub fn take_perf_profile(&mut self) -> Sm83PerfProfile {
+        core::mem::take(&mut self.perf)
+    }
+
+    #[cfg(feature = "perf")]
+    pub fn take_ppu_perf_profile(&mut self) -> super::peripheral::ppu::PpuPerfProfile {
+        self.ppu.take_perf_profile()
+    }
+
+    #[cfg(feature = "perf")]
+    pub fn take_apu_perf_profile(&mut self) -> super::peripheral::apu::ApuPerfProfile {
+        self.apu.take_perf_profile()
+    }
+
     /// Returns the cartridge external RAM (battery save data), or `None` if cart has no RAM.
     pub fn external_ram(&self) -> Option<&[u8]> {
         self.memory.external_ram()
@@ -371,7 +405,12 @@ impl Sm83 {
             return Ok(value);
         }
         self.tick_cycle();
-        Ok(self.memory.read_fast(addr))
+        #[cfg(feature = "perf")]
+        let t0 = crate::cpu::perf::cyccnt();
+        let value = self.memory.read_fast(addr);
+        #[cfg(feature = "perf")]
+        { self.perf.mem_read = self.perf.mem_read.wrapping_add(crate::cpu::perf::cyccnt().wrapping_sub(t0)); }
+        Ok(value)
     }
 
     /// Perform a bus write: advance all peripherals by one M-cycle (4 T-cycles),
@@ -396,7 +435,9 @@ impl Sm83 {
             return Ok(());
         }
         self.tick_cycle();
-        match addr {
+        #[cfg(feature = "perf")]
+        let t0 = crate::cpu::perf::cyccnt();
+        let result = match addr {
             0xFF00..=0xFF7F | 0xFFFF => {
                 self.memory.write_io(addr, value);
                 self.pending_bus_events.push(BusEvent {
@@ -410,7 +451,10 @@ impl Sm83 {
                 self.memory.write_fast(addr, value);
                 Ok(())
             }
-        }
+        };
+        #[cfg(feature = "perf")]
+        { self.perf.mem_write = self.perf.mem_write.wrapping_add(crate::cpu::perf::cyccnt().wrapping_sub(t0)); }
+        result
     }
 
     /// Advance peripherals by one M-cycle (4 T-cycles) without a bus access.
@@ -561,6 +605,8 @@ impl Sm83 {
 
     #[cfg_attr(target_arch = "arm", link_section = ".data")]
     fn advance_ppu(&mut self, cycles: u16) {
+        #[cfg(feature = "perf")]
+        let t0 = crate::cpu::perf::cyccnt();
         let output = self.ppu.tick(
             cycles,
             PpuInput {
@@ -597,10 +643,17 @@ impl Sm83 {
             let if_val = self.memory.read_io(IF_ADDR);
             self.memory.write_io(IF_ADDR, if_val | (1 << STAT_INTERRUPT_BIT));
         }
+        #[cfg(feature = "perf")]
+        {
+            let dt = crate::cpu::perf::cyccnt().wrapping_sub(t0);
+            self.perf.ppu = self.perf.ppu.wrapping_add(dt);
+        }
     }
 
     #[cfg_attr(target_arch = "arm", link_section = ".data")]
     fn advance_timer(&mut self, cycles: u16) {
+        #[cfg(feature = "perf")]
+        let t0 = crate::cpu::perf::cyccnt();
         let output = self.timer.tick(
             cycles,
             TimerInput {
@@ -621,14 +674,26 @@ impl Sm83 {
             let if_val = self.memory.read_io(IF_ADDR);
             self.memory.write_io(IF_ADDR, if_val | (1 << TIMER_INTERRUPT_BIT));
         }
+        #[cfg(feature = "perf")]
+        {
+            let dt = crate::cpu::perf::cyccnt().wrapping_sub(t0);
+            self.perf.timer = self.perf.timer.wrapping_add(dt);
+        }
     }
 
     #[cfg_attr(target_arch = "arm", link_section = ".data")]
     fn advance_apu(&mut self, cycles: u16) {
+        #[cfg(feature = "perf")]
+        let t0 = crate::cpu::perf::cyccnt();
         let output = self.apu.tick(cycles, self.timer.internal_counter());
         if output.nr52 != self.cache.nr52 {
             self.cache.nr52 = output.nr52;
             self.memory.write_io(NR52_ADDR, output.nr52);
+        }
+        #[cfg(feature = "perf")]
+        {
+            let dt = crate::cpu::perf::cyccnt().wrapping_sub(t0);
+            self.perf.apu = self.perf.apu.wrapping_add(dt);
         }
     }
 
@@ -805,6 +870,22 @@ impl Sm83 {
 impl Cpu for Sm83 {
     #[cfg_attr(target_arch = "arm", link_section = ".data")]
     fn tick(&mut self) -> Result<u8, CpuError> {
+        #[cfg(feature = "perf")]
+        let tick_t0 = crate::cpu::perf::cyccnt();
+        let result = self.tick_impl();
+        #[cfg(feature = "perf")]
+        {
+            let dt = crate::cpu::perf::cyccnt().wrapping_sub(tick_t0);
+            self.perf.total = self.perf.total.wrapping_add(dt);
+        }
+        result
+    }
+}
+
+impl Sm83 {
+    #[cfg_attr(target_arch = "arm", link_section = ".data")]
+    #[inline(always)]
+    fn tick_impl(&mut self) -> Result<u8, CpuError> {
         let start_cycles = self.cycle_counter;
 
         if self.halted {

--- a/docs/perf-profiling.md
+++ b/docs/perf-profiling.md
@@ -1,0 +1,75 @@
+# Performance Profiling Infrastructure
+
+## Feature flags
+
+| Flag | Crate | Effect |
+|---|---|---|
+| `fps` | `rustyboy-pico2w` | Logs FPS to RTT every 60 frames |
+| `perf` | `rustyboy-pico2w` | Implies `fps`; enables DWT cycle counters in core and logs per-component breakdowns every 60 frames |
+| `perf` | `rustyboy-core` | Activates `#[cfg(feature = "perf")]` instrumentation throughout core (APU channels, PPU render stages, memory bus, SM83 dispatch) |
+
+Build and flash:
+
+```sh
+cd platform/pico2w
+cargo run --release --features perf   # full breakdown + fps
+cargo run --release --features fps    # fps only
+```
+
+## RTT output format
+
+Every 60 frames (~1 s at target speed):
+
+```
+fps: 60
+cycles/60f — total=X ppu=X timer=X apu=X cpu_exec=X (mem_r=X mem_w=X decode=X)
+ppu breakdown — bg=X window=X sprites=X stat=X
+apu breakdown — frame_seq=X pulse=X wave=X noise=X mix=X
+```
+
+`cpu_exec = total − ppu − timer − apu`  
+`decode   = cpu_exec − mem_r − mem_w`
+
+All values are DWT CYCCNT ticks at 250 MHz (one tick ≈ 4 ns).
+
+## Initial baseline — 2026-05-03 @ 250 MHz
+
+ROM: Tetris (256 KiB, 16 banks, stored on onboard flash).
+
+### Top-level breakdown (930 M cycles / 60 frames)
+
+| Component | Cycles | % |
+|---|---|---|
+| decode / dispatch | 450 M | **48.3%** |
+| apu | 212 M | 22.8% |
+| ppu | 160 M | 17.2% |
+| mem_write | 54 M | 5.8% |
+| mem_read | 29 M | 3.1% |
+| timer | 26 M | 2.8% |
+
+### PPU sub-breakdown (160 M total)
+
+| Stage | Cycles | % of PPU |
+|---|---|---|
+| bg render | 28 M | 17% |
+| build_stat | 20 M | 12% |
+| sprites | 4 M | 3% |
+| window | ~60 K | <0.1% |
+
+### APU sub-breakdown (212 M total)
+
+| Channel | Cycles | % of APU |
+|---|---|---|
+| pulse (ch1+ch2) | 46 M | 22% |
+| noise (ch4) | 26 M | 12% |
+| wave (ch3) | 23 M | 11% |
+| mix | 10 M | 5% |
+| frame_seq | ~240 K | <0.1% |
+
+## Observations
+
+- **Instruction decode/dispatch dominates at 48%.** This is the highest-leverage optimization target. Prior work already placed the hot path in RAM (`.data` section); the next step is reducing dispatch overhead (branch misprediction, opcode table lookup).
+- **APU pulse channels are surprisingly expensive** relative to wave/noise. The per-sample envelope and sweep logic runs at 4 MHz effective, firing every M-cycle.
+- **PPU `build_stat`** (20 M cycles, 12% of PPU total) is called every M-cycle during active scanlines and handles STAT interrupt edge detection — worth batching or caching.
+- **mem_write is 2× mem_read** despite writes being less frequent. Write fan-out (write_io + pending bus events + cache update) is the likely cause.
+- **Window rendering is negligible** for this ROM; sprites are cheap. BG render is the PPU bottleneck.

--- a/platform/pico2w/Cargo.toml
+++ b/platform/pico2w/Cargo.toml
@@ -15,6 +15,10 @@ path = "src/main.rs"
 # Re-exported for display-viewer which depends on this crate.
 std = []
 oc-266 = []
+# Log FPS to RTT every 60 frames.
+fps = []
+# Enable all profiling: implies fps and enables core APU cycle counters.
+perf = ["fps", "rustyboy-core/perf"]
 
 # ---------------------------------------------------------------------------
 # Cross-platform dependencies (compile on any target, including host tests)

--- a/platform/pico2w/src/main.rs
+++ b/platform/pico2w/src/main.rs
@@ -197,8 +197,16 @@ async fn main(_spawner: Spawner) {
     // Draw static letterbox bars once; game loop only repaints the 240×216 area.
     hw_disp.inner.draw_letterbox_bars();
 
+    #[cfg(feature = "perf")]
+    rustyboy_core::cpu::perf::init_cyccnt();
+
     let mut audio_buffers = AudioBuffers::new();
     let mut prev_state = ButtonState::default();
+
+    #[cfg(feature = "fps")]
+    let mut fps_frame_count: u32 = 0;
+    #[cfg(feature = "fps")]
+    let mut fps_window_start = embassy_time::Instant::now();
 
     loop {
         // Start DMA transfer of last frame's audio output while we fill the
@@ -237,6 +245,43 @@ async fn main(_spawner: Spawner) {
         // Await DMA completion — this naturally paces the loop to ~59.7 fps.
         dma_future.await;
         watchdog.feed(Duration::from_millis(5_000));
+
+        #[cfg(feature = "fps")]
+        {
+            fps_frame_count += 1;
+            if fps_frame_count >= 60 {
+                let elapsed_us = fps_window_start.elapsed().as_micros();
+                let fps = (fps_frame_count as u64 * 1_000_000) / elapsed_us.max(1);
+                info!("fps: {}", fps);
+                fps_frame_count = 0;
+                fps_window_start = embassy_time::Instant::now();
+            }
+        }
+
+        #[cfg(feature = "perf")]
+        {
+            if fps_frame_count == 0 {
+                let p = cpu.take_perf_profile();
+                let cpu_exec = p.total.wrapping_sub(p.ppu).wrapping_sub(p.timer).wrapping_sub(p.apu);
+                let cpu_decode = cpu_exec.wrapping_sub(p.mem_read).wrapping_sub(p.mem_write);
+                info!(
+                    "cycles/60f — total={} ppu={} timer={} apu={} cpu_exec={} (mem_r={} mem_w={} decode={})",
+                    p.total, p.ppu, p.timer, p.apu, cpu_exec, p.mem_read, p.mem_write, cpu_decode
+                );
+
+                let pp = cpu.take_ppu_perf_profile();
+                info!(
+                    "ppu breakdown — bg={} window={} sprites={} stat={}",
+                    pp.render_bg, pp.render_window, pp.render_sprites, pp.build_stat
+                );
+
+                let ap = cpu.take_apu_perf_profile();
+                info!(
+                    "apu breakdown — frame_seq={} pulse={} wave={} noise={} mix={}",
+                    ap.frame_seq, ap.pulse, ap.wave, ap.noise, ap.mix
+                );
+            }
+        }
     }
 }
 

--- a/platform/pico2w/src/main.rs
+++ b/platform/pico2w/src/main.rs
@@ -2,6 +2,9 @@
 #![no_main]
 extern crate alloc;
 
+#[cfg(feature = "fps")]
+mod perf;
+
 use embedded_alloc::Heap;
 
 #[global_allocator]
@@ -198,15 +201,13 @@ async fn main(_spawner: Spawner) {
     hw_disp.inner.draw_letterbox_bars();
 
     #[cfg(feature = "perf")]
-    rustyboy_core::cpu::perf::init_cyccnt();
+    perf::init_dwt();
 
     let mut audio_buffers = AudioBuffers::new();
     let mut prev_state = ButtonState::default();
 
     #[cfg(feature = "fps")]
-    let mut fps_frame_count: u32 = 0;
-    #[cfg(feature = "fps")]
-    let mut fps_window_start = embassy_time::Instant::now();
+    let mut tracker = perf::PerfTracker::new();
 
     loop {
         // Start DMA transfer of last frame's audio output while we fill the
@@ -247,41 +248,7 @@ async fn main(_spawner: Spawner) {
         watchdog.feed(Duration::from_millis(5_000));
 
         #[cfg(feature = "fps")]
-        {
-            fps_frame_count += 1;
-            if fps_frame_count >= 60 {
-                let elapsed_us = fps_window_start.elapsed().as_micros();
-                let fps = (fps_frame_count as u64 * 1_000_000) / elapsed_us.max(1);
-                info!("fps: {}", fps);
-                fps_frame_count = 0;
-                fps_window_start = embassy_time::Instant::now();
-            }
-        }
-
-        #[cfg(feature = "perf")]
-        {
-            if fps_frame_count == 0 {
-                let p = cpu.take_perf_profile();
-                let cpu_exec = p.total.wrapping_sub(p.ppu).wrapping_sub(p.timer).wrapping_sub(p.apu);
-                let cpu_decode = cpu_exec.wrapping_sub(p.mem_read).wrapping_sub(p.mem_write);
-                info!(
-                    "cycles/60f — total={} ppu={} timer={} apu={} cpu_exec={} (mem_r={} mem_w={} decode={})",
-                    p.total, p.ppu, p.timer, p.apu, cpu_exec, p.mem_read, p.mem_write, cpu_decode
-                );
-
-                let pp = cpu.take_ppu_perf_profile();
-                info!(
-                    "ppu breakdown — bg={} window={} sprites={} stat={}",
-                    pp.render_bg, pp.render_window, pp.render_sprites, pp.build_stat
-                );
-
-                let ap = cpu.take_apu_perf_profile();
-                info!(
-                    "apu breakdown — frame_seq={} pulse={} wave={} noise={} mix={}",
-                    ap.frame_seq, ap.pulse, ap.wave, ap.noise, ap.mix
-                );
-            }
-        }
+        tracker.tick(&mut cpu);
     }
 }
 

--- a/platform/pico2w/src/perf.rs
+++ b/platform/pico2w/src/perf.rs
@@ -1,0 +1,78 @@
+use defmt::info;
+use embassy_time::Instant;
+use rustyboy_core::cpu::sm83::Sm83;
+
+/// Tracks FPS and (when `perf` is enabled) per-component cycle counts.
+/// Call `tick` once per game loop iteration.
+pub struct PerfTracker {
+    frame_count: u32,
+    window_start: Instant,
+}
+
+impl PerfTracker {
+    pub fn new() -> Self {
+        Self {
+            frame_count: 0,
+            window_start: Instant::now(),
+        }
+    }
+
+    pub fn tick(&mut self, cpu: &mut Sm83) {
+        self.frame_count += 1;
+        if self.frame_count < 60 {
+            return;
+        }
+
+        let elapsed_us = self.window_start.elapsed().as_micros();
+        let fps = (self.frame_count as u64 * 1_000_000) / elapsed_us.max(1);
+        info!("fps: {}", fps);
+
+        #[cfg(feature = "perf")]
+        {
+            let p = cpu.take_perf_profile();
+            let cpu_exec = p.total.wrapping_sub(p.ppu).wrapping_sub(p.timer).wrapping_sub(p.apu);
+            let decode = cpu_exec.wrapping_sub(p.mem_read).wrapping_sub(p.mem_write);
+            info!(
+                "cycles/60f — total={} ppu={} timer={} apu={} cpu_exec={} (mem_r={} mem_w={} decode={})",
+                p.total, p.ppu, p.timer, p.apu, cpu_exec, p.mem_read, p.mem_write, decode
+            );
+
+            let pp = cpu.take_ppu_perf_profile();
+            info!(
+                "ppu breakdown — bg={} window={} sprites={} stat={}",
+                pp.render_bg, pp.render_window, pp.render_sprites, pp.build_stat
+            );
+
+            let ap = cpu.take_apu_perf_profile();
+            info!(
+                "apu breakdown — frame_seq={} pulse={} wave={} noise={} mix={}",
+                ap.frame_seq, ap.pulse, ap.wave, ap.noise, ap.mix
+            );
+        }
+
+        // Suppress unused-variable warning when only `fps` (not `perf`) is enabled.
+        let _ = cpu;
+
+        self.frame_count = 0;
+        self.window_start = Instant::now();
+    }
+}
+
+/// Enable the DWT cycle counter. Must be called once before `perf_cycle_read` is useful.
+#[cfg(feature = "perf")]
+pub fn init_dwt() {
+    unsafe {
+        let demcr = 0xE000_EDFCu32 as *mut u32;
+        demcr.write_volatile(demcr.read_volatile() | (1 << 24));
+        (0xE000_1004u32 as *mut u32).write_volatile(0);
+        let ctrl = 0xE000_1000u32 as *mut u32;
+        ctrl.write_volatile(ctrl.read_volatile() | 1);
+    }
+}
+
+/// Fulfils the `extern "C" fn perf_cycle_read()` contract declared in rustyboy-core.
+#[cfg(feature = "perf")]
+#[no_mangle]
+pub extern "C" fn perf_cycle_read() -> u32 {
+    unsafe { (0xE000_1004u32 as *const u32).read_volatile() }
+}


### PR DESCRIPTION
## Summary

- Adds `fps` feature to `rustyboy-pico2w`: logs FPS to RTT every 60 frames using `embassy_time::Instant`
- Adds `perf` feature to `rustyboy-pico2w` (implies `fps`): enables DWT CYCCNT on Cortex-M33 and logs full per-component cycle breakdowns every 60 frames
- Instruments `rustyboy-core` with `perf` feature: PPU render stages (bg/window/sprites/stat), APU channels (pulse/wave/noise/mix/frame_seq), SM83 memory bus (read/write), and total tick time
- Adds `docs/perf-profiling.md` with baseline measurements and observations

## Usage

\`\`\`sh
cd platform/pico2w
cargo run --release --features perf   # full breakdown + fps
cargo run --release --features fps    # fps only
\`\`\`

## Baseline (250 MHz, Tetris, 60 frames)

| Component | Cycles | % |
|---|---|---|
| decode/dispatch | 450 M | 48.3% |
| apu | 212 M | 22.8% |
| ppu | 160 M | 17.2% |
| mem_write | 54 M | 5.8% |
| mem_read | 29 M | 3.1% |
| timer | 26 M | 2.8% |

## Test plan

- [x] `cargo build --release --features fps` — clean build
- [x] `cargo build --release --features perf` — clean build
- [x] Flashed and verified RTT output: fps + all three breakdown lines logged every 60 frames with non-zero values
- [x] Confirmed DWT CYCCNT init required (values were all 0 before adding `init_cyccnt()`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)