### PR TITLE
Replace Arc<dyn OpCode> dispatch with flat fn-pointer table

### DIFF
--- a/core/src/cpu/instructions/arg.rs
+++ b/core/src/cpu/instructions/arg.rs
@@ -1,0 +1,107 @@
+/// Flat operand constants and pack helpers for the function-pointer dispatch table.
+///
+/// Data word layout (32-bit):
+///   bits  [7:0]  = arg0  (operand, condition, CB op, etc.)
+///   bits [15:8]  = arg1  (dst operand for LD, bit index for CB, 0 otherwise)
+///   bits [23:16] = cycles_taken
+///   bits [31:24] = cycles_not_taken (conditional insns only; 0 for unconditional)
+///
+/// For pack_cc:
+///   bits  [7:0]  = cond
+///   bits [15:8]  = (unused, 0)
+///   bits [23:16] = cycles_taken
+///   bits [31:24] = cycles_not_taken
+
+// ── r8 arg constants ─────────────────────────────────────────────────────────
+// Also used as CB target encoding: matches SM83 CB r8 slot order
+pub const B:      u8 = 0;
+pub const C:      u8 = 1;
+pub const D:      u8 = 2;
+pub const E:      u8 = 3;
+pub const H:      u8 = 4;
+pub const L:      u8 = 5;
+pub const MEM_HL: u8 = 6;  // (HL) memory — matches SM83 r8 encoding slot 6
+pub const A:      u8 = 7;
+pub const IMM8:   u8 = 8;
+pub const IMMS8:  u8 = 9;  // signed immediate (for ADD SP, e)
+
+// ── r16 arg constants ─────────────────────────────────────────────────────────
+pub const BC: u8 = 10;
+pub const DE: u8 = 11;
+pub const HL: u8 = 12;
+pub const SP: u8 = 13;
+pub const AF: u8 = 14;
+
+// ── condition constants ───────────────────────────────────────────────────────
+pub const NZ: u8 = 0;
+pub const Z:  u8 = 1;
+pub const NC: u8 = 2;
+pub const CC: u8 = 3;  // named CC to avoid clash with Flags::C
+
+// ── CB shift/rotate op constants (bits [7:3] of CB opcode >> 3) ──────────────
+pub const RLC:  u8 = 0;
+pub const RRC:  u8 = 1;
+pub const RL:   u8 = 2;
+pub const RR:   u8 = 3;
+pub const SLA:  u8 = 4;
+pub const SRA:  u8 = 5;
+pub const SWAP: u8 = 6;
+pub const SRL:  u8 = 7;
+
+// ── rotate-accumulator op constants ──────────────────────────────────────────
+pub const RLCA: u8 = 0;
+pub const RRCA: u8 = 1;
+pub const RLA:  u8 = 2;
+pub const RRA:  u8 = 3;
+
+// ── Pack helpers ──────────────────────────────────────────────────────────────
+
+/// Pack: no operand — just cycles.
+///   bits [23:16] = cycles
+#[inline(always)]
+pub const fn pack0(cycles: u8) -> u32 {
+    (cycles as u32) << 16
+}
+
+/// Pack: one operand in arg0.
+///   bits [7:0] = arg0, bits [23:16] = cycles
+#[inline(always)]
+pub const fn pack1(arg0: u8, cycles: u8) -> u32 {
+    (arg0 as u32) | ((cycles as u32) << 16)
+}
+
+/// Pack: two operands.
+///   bits [7:0] = arg0, bits [15:8] = arg1, bits [23:16] = cycles
+#[inline(always)]
+pub const fn pack2(arg0: u8, arg1: u8, cycles: u8) -> u32 {
+    (arg0 as u32) | ((arg1 as u32) << 8) | ((cycles as u32) << 16)
+}
+
+/// Pack: condition-code branch.
+///   bits [7:0] = cond, bits [23:16] = cycles_taken, bits [31:24] = cycles_not_taken
+#[inline(always)]
+pub const fn pack_cc(cond: u8, cycles_taken: u8, cycles_not_taken: u8) -> u32 {
+    (cond as u32) | ((cycles_taken as u32) << 16) | ((cycles_not_taken as u32) << 24)
+}
+
+// ── Unpack helpers ────────────────────────────────────────────────────────────
+
+#[inline(always)]
+pub const fn unpack_arg0(data: u32) -> u8 {
+    data as u8
+}
+
+#[inline(always)]
+pub const fn unpack_arg1(data: u32) -> u8 {
+    (data >> 8) as u8
+}
+
+#[inline(always)]
+pub const fn unpack_cycles(data: u32) -> u8 {
+    (data >> 16) as u8
+}
+
+#[inline(always)]
+pub const fn unpack_cycles_not_taken(data: u32) -> u8 {
+    (data >> 24) as u8
+}

--- a/core/src/cpu/instructions/mod.rs
+++ b/core/src/cpu/instructions/mod.rs
@@ -1,3 +1,4 @@
+pub mod arg;
 pub mod adc;
 pub mod add;
 pub mod call;

--- a/core/src/cpu/instructions/opcodes.rs
+++ b/core/src/cpu/instructions/opcodes.rs
@@ -1,5 +1,6 @@
 use alloc::{boxed::Box, sync::Arc, vec, vec::Vec};
 
+use super::arg;
 use super::cb::decoder::CbDecoder;
 use super::adc::decoder::AdcDecoder;
 use super::add::decoder::{Add16Decoder, Add8Decoder, AddSP16Decoder};
@@ -21,6 +22,28 @@ use super::rst::decoder::RstDecoder;
 use super::sbc::decoder::Sbc8Decoder;
 use super::stack::decoder::{Pop16Decoder, Push16Decoder};
 use super::sub::decoder::Sub8Decoder;
+
+use crate::cpu::sm83::Sm83;
+use crate::cpu::instructions::instructions::Error as InstructionError;
+
+/// A function pointer to a handler method on `Sm83`.
+pub type Handler = fn(&mut Sm83, u32) -> Result<(), InstructionError>;
+
+/// One entry in the flat opcode dispatch table.
+/// Two words, `Copy` — no heap, no atomics.
+#[derive(Clone, Copy)]
+pub struct OpcodeEntry {
+    pub handler: Handler,
+    pub data:    u32,
+}
+
+impl OpcodeEntry {
+    /// Sentinel for unimplemented/illegal opcodes.
+    const INVALID: Self = Self {
+        handler: Sm83::handle_invalid,
+        data:    0,
+    };
+}
 
 pub struct OpCodeDecoder {
     opcodes: Vec<Box<dyn Decoder>>,
@@ -71,12 +94,34 @@ impl Decoder for OpCodeDecoder {
 /// Pre-decoded opcode table: 256-entry `Arc` arrays built once at startup.
 /// `get()` / `get_cb()` are O(1) array index + one `Arc::clone` (atomic increment)
 /// — no heap allocation per call.
+///
+/// Also contains a flat `[OpcodeEntry; 512]` function-pointer table for the hot
+/// dispatch path: indices 0–255 are main opcodes, 256–511 are CB-prefixed opcodes.
 pub struct OpCodeTable {
-    main: Vec<Option<Arc<dyn OpCode>>>,
-    cb:   Vec<Option<Arc<dyn OpCode>>>,
+    pub(crate) main: Vec<Option<Arc<dyn OpCode>>>,
+    pub(crate) cb:   Vec<Option<Arc<dyn OpCode>>>,
+    /// Flat function-pointer table. Indices 0–255 = main; 256–511 = CB-prefixed.
+    pub flat: alloc::boxed::Box<[OpcodeEntry; 512]>,
 }
 
 impl OpCodeTable {
+    /// Build the complete table: flat function-pointer entries for the hot path
+    /// AND `Arc`-based entries for the test/compatibility path.
+    pub fn new() -> Self {
+        let decoder = OpCodeDecoder::new();
+        let mut main: Vec<Option<Arc<dyn OpCode>>> = Vec::with_capacity(256);
+        for i in 0..=255u8 {
+            main.push(decoder.decode(i).ok().map(Arc::from));
+        }
+        let mut cb: Vec<Option<Arc<dyn OpCode>>> = Vec::with_capacity(256);
+        for i in 0..=255u8 {
+            cb.push(CbDecoder.decode(i).ok().map(Arc::from));
+        }
+
+        let flat = Self::build_flat();
+        Self { main, cb, flat }
+    }
+
     /// Build the table from any `Decoder` for the main (non-CB) opcodes.
     /// CB opcodes are always decoded via `CbDecoder`.
     pub fn from_decoder(decoder: &dyn Decoder) -> Self {
@@ -88,7 +133,367 @@ impl OpCodeTable {
         for i in 0..=255u8 {
             cb.push(CbDecoder.decode(i).ok().map(Arc::from));
         }
-        Self { main, cb }
+        let flat = Self::build_flat();
+        Self { main, cb, flat }
+    }
+
+    /// Build the flat 512-entry function-pointer table.
+    ///
+    /// Indices 0–255: main opcodes.
+    /// Indices 256–511: CB-prefixed opcodes (index = 256 + cb_byte).
+    fn build_flat() -> alloc::boxed::Box<[OpcodeEntry; 512]> {
+        let mut t = alloc::boxed::Box::new([OpcodeEntry::INVALID; 512]);
+
+        // ── Helper aliases ──────────────────────────────────────────────────
+        use arg::*;
+
+        // ─── Main opcode table (indices 0–255) ──────────────────────────────
+
+        // NOP
+        t[0x00] = OpcodeEntry { handler: Sm83::handle_nop,  data: pack0(4) };
+        // STOP 0x00 (consumes next byte)
+        t[0x10] = OpcodeEntry { handler: Sm83::handle_stop, data: pack0(4) };
+        // HALT
+        t[0x76] = OpcodeEntry { handler: Sm83::handle_halt, data: pack0(4) };
+        // DAA/CPL/SCF/CCF/DI/EI
+        t[0x27] = OpcodeEntry { handler: Sm83::handle_daa,  data: pack0(4) };
+        t[0x2F] = OpcodeEntry { handler: Sm83::handle_cpl,  data: pack0(4) };
+        t[0x37] = OpcodeEntry { handler: Sm83::handle_scf,  data: pack0(4) };
+        t[0x3F] = OpcodeEntry { handler: Sm83::handle_ccf,  data: pack0(4) };
+        t[0xF3] = OpcodeEntry { handler: Sm83::handle_di,   data: pack0(4) };
+        t[0xFB] = OpcodeEntry { handler: Sm83::handle_ei,   data: pack0(4) };
+
+        // RLCA / RRCA / RLA / RRA
+        t[0x07] = OpcodeEntry { handler: Sm83::handle_rot_acc, data: pack1(RLCA, 4) };
+        t[0x0F] = OpcodeEntry { handler: Sm83::handle_rot_acc, data: pack1(RRCA, 4) };
+        t[0x17] = OpcodeEntry { handler: Sm83::handle_rot_acc, data: pack1(RLA,  4) };
+        t[0x1F] = OpcodeEntry { handler: Sm83::handle_rot_acc, data: pack1(RRA,  4) };
+
+        // ADD A, r8 / (HL) / imm8  (0x80–0x87, 0xC6)
+        t[0x80] = OpcodeEntry { handler: Sm83::handle_add8, data: pack1(B,      4) };
+        t[0x81] = OpcodeEntry { handler: Sm83::handle_add8, data: pack1(C,      4) };
+        t[0x82] = OpcodeEntry { handler: Sm83::handle_add8, data: pack1(D,      4) };
+        t[0x83] = OpcodeEntry { handler: Sm83::handle_add8, data: pack1(E,      4) };
+        t[0x84] = OpcodeEntry { handler: Sm83::handle_add8, data: pack1(H,      4) };
+        t[0x85] = OpcodeEntry { handler: Sm83::handle_add8, data: pack1(L,      4) };
+        t[0x86] = OpcodeEntry { handler: Sm83::handle_add8, data: pack1(MEM_HL, 8) };
+        t[0x87] = OpcodeEntry { handler: Sm83::handle_add8, data: pack1(A,      4) };
+        t[0xC6] = OpcodeEntry { handler: Sm83::handle_add8, data: pack1(IMM8,   8) };
+
+        // ADC A, r8 / (HL) / imm8  (0x88–0x8F, 0xCE)
+        t[0x88] = OpcodeEntry { handler: Sm83::handle_adc, data: pack1(B,      4) };
+        t[0x89] = OpcodeEntry { handler: Sm83::handle_adc, data: pack1(C,      4) };
+        t[0x8A] = OpcodeEntry { handler: Sm83::handle_adc, data: pack1(D,      4) };
+        t[0x8B] = OpcodeEntry { handler: Sm83::handle_adc, data: pack1(E,      4) };
+        t[0x8C] = OpcodeEntry { handler: Sm83::handle_adc, data: pack1(H,      4) };
+        t[0x8D] = OpcodeEntry { handler: Sm83::handle_adc, data: pack1(L,      4) };
+        t[0x8E] = OpcodeEntry { handler: Sm83::handle_adc, data: pack1(MEM_HL, 8) };
+        t[0x8F] = OpcodeEntry { handler: Sm83::handle_adc, data: pack1(A,      4) };
+        t[0xCE] = OpcodeEntry { handler: Sm83::handle_adc, data: pack1(IMM8,   8) };
+
+        // SUB A, r8 / (HL) / imm8  (0x90–0x97, 0xD6)
+        t[0x90] = OpcodeEntry { handler: Sm83::handle_sub8, data: pack1(B,      4) };
+        t[0x91] = OpcodeEntry { handler: Sm83::handle_sub8, data: pack1(C,      4) };
+        t[0x92] = OpcodeEntry { handler: Sm83::handle_sub8, data: pack1(D,      4) };
+        t[0x93] = OpcodeEntry { handler: Sm83::handle_sub8, data: pack1(E,      4) };
+        t[0x94] = OpcodeEntry { handler: Sm83::handle_sub8, data: pack1(H,      4) };
+        t[0x95] = OpcodeEntry { handler: Sm83::handle_sub8, data: pack1(L,      4) };
+        t[0x96] = OpcodeEntry { handler: Sm83::handle_sub8, data: pack1(MEM_HL, 8) };
+        t[0x97] = OpcodeEntry { handler: Sm83::handle_sub8, data: pack1(A,      4) };
+        t[0xD6] = OpcodeEntry { handler: Sm83::handle_sub8, data: pack1(IMM8,   8) };
+
+        // SBC A, r8 / (HL) / imm8  (0x98–0x9F, 0xDE)
+        t[0x98] = OpcodeEntry { handler: Sm83::handle_sbc8, data: pack1(B,      4) };
+        t[0x99] = OpcodeEntry { handler: Sm83::handle_sbc8, data: pack1(C,      4) };
+        t[0x9A] = OpcodeEntry { handler: Sm83::handle_sbc8, data: pack1(D,      4) };
+        t[0x9B] = OpcodeEntry { handler: Sm83::handle_sbc8, data: pack1(E,      4) };
+        t[0x9C] = OpcodeEntry { handler: Sm83::handle_sbc8, data: pack1(H,      4) };
+        t[0x9D] = OpcodeEntry { handler: Sm83::handle_sbc8, data: pack1(L,      4) };
+        t[0x9E] = OpcodeEntry { handler: Sm83::handle_sbc8, data: pack1(MEM_HL, 8) };
+        t[0x9F] = OpcodeEntry { handler: Sm83::handle_sbc8, data: pack1(A,      4) };
+        t[0xDE] = OpcodeEntry { handler: Sm83::handle_sbc8, data: pack1(IMM8,   8) };
+
+        // AND A, r8 / (HL) / imm8  (0xA0–0xA7, 0xE6)
+        t[0xA0] = OpcodeEntry { handler: Sm83::handle_and8, data: pack1(B,      4) };
+        t[0xA1] = OpcodeEntry { handler: Sm83::handle_and8, data: pack1(C,      4) };
+        t[0xA2] = OpcodeEntry { handler: Sm83::handle_and8, data: pack1(D,      4) };
+        t[0xA3] = OpcodeEntry { handler: Sm83::handle_and8, data: pack1(E,      4) };
+        t[0xA4] = OpcodeEntry { handler: Sm83::handle_and8, data: pack1(H,      4) };
+        t[0xA5] = OpcodeEntry { handler: Sm83::handle_and8, data: pack1(L,      4) };
+        t[0xA6] = OpcodeEntry { handler: Sm83::handle_and8, data: pack1(MEM_HL, 8) };
+        t[0xA7] = OpcodeEntry { handler: Sm83::handle_and8, data: pack1(A,      4) };
+        t[0xE6] = OpcodeEntry { handler: Sm83::handle_and8, data: pack1(IMM8,   8) };
+
+        // XOR A, r8 / (HL) / imm8  (0xA8–0xAF, 0xEE)
+        t[0xA8] = OpcodeEntry { handler: Sm83::handle_xor8, data: pack1(B,      4) };
+        t[0xA9] = OpcodeEntry { handler: Sm83::handle_xor8, data: pack1(C,      4) };
+        t[0xAA] = OpcodeEntry { handler: Sm83::handle_xor8, data: pack1(D,      4) };
+        t[0xAB] = OpcodeEntry { handler: Sm83::handle_xor8, data: pack1(E,      4) };
+        t[0xAC] = OpcodeEntry { handler: Sm83::handle_xor8, data: pack1(H,      4) };
+        t[0xAD] = OpcodeEntry { handler: Sm83::handle_xor8, data: pack1(L,      4) };
+        t[0xAE] = OpcodeEntry { handler: Sm83::handle_xor8, data: pack1(MEM_HL, 8) };
+        t[0xAF] = OpcodeEntry { handler: Sm83::handle_xor8, data: pack1(A,      4) };
+        t[0xEE] = OpcodeEntry { handler: Sm83::handle_xor8, data: pack1(IMM8,   8) };
+
+        // OR A, r8 / (HL) / imm8  (0xB0–0xB7, 0xF6)
+        t[0xB0] = OpcodeEntry { handler: Sm83::handle_or8, data: pack1(B,      4) };
+        t[0xB1] = OpcodeEntry { handler: Sm83::handle_or8, data: pack1(C,      4) };
+        t[0xB2] = OpcodeEntry { handler: Sm83::handle_or8, data: pack1(D,      4) };
+        t[0xB3] = OpcodeEntry { handler: Sm83::handle_or8, data: pack1(E,      4) };
+        t[0xB4] = OpcodeEntry { handler: Sm83::handle_or8, data: pack1(H,      4) };
+        t[0xB5] = OpcodeEntry { handler: Sm83::handle_or8, data: pack1(L,      4) };
+        t[0xB6] = OpcodeEntry { handler: Sm83::handle_or8, data: pack1(MEM_HL, 8) };
+        t[0xB7] = OpcodeEntry { handler: Sm83::handle_or8, data: pack1(A,      4) };
+        t[0xF6] = OpcodeEntry { handler: Sm83::handle_or8, data: pack1(IMM8,   8) };
+
+        // CP A, r8 / (HL) / imm8  (0xB8–0xBF, 0xFE)
+        t[0xB8] = OpcodeEntry { handler: Sm83::handle_cp8, data: pack1(B,      4) };
+        t[0xB9] = OpcodeEntry { handler: Sm83::handle_cp8, data: pack1(C,      4) };
+        t[0xBA] = OpcodeEntry { handler: Sm83::handle_cp8, data: pack1(D,      4) };
+        t[0xBB] = OpcodeEntry { handler: Sm83::handle_cp8, data: pack1(E,      4) };
+        t[0xBC] = OpcodeEntry { handler: Sm83::handle_cp8, data: pack1(H,      4) };
+        t[0xBD] = OpcodeEntry { handler: Sm83::handle_cp8, data: pack1(L,      4) };
+        t[0xBE] = OpcodeEntry { handler: Sm83::handle_cp8, data: pack1(MEM_HL, 8) };
+        t[0xBF] = OpcodeEntry { handler: Sm83::handle_cp8, data: pack1(A,      4) };
+        t[0xFE] = OpcodeEntry { handler: Sm83::handle_cp8, data: pack1(IMM8,   8) };
+
+        // INC r8 / (HL)
+        t[0x04] = OpcodeEntry { handler: Sm83::handle_inc8, data: pack1(B,       4) };
+        t[0x0C] = OpcodeEntry { handler: Sm83::handle_inc8, data: pack1(C,       4) };
+        t[0x14] = OpcodeEntry { handler: Sm83::handle_inc8, data: pack1(D,       4) };
+        t[0x1C] = OpcodeEntry { handler: Sm83::handle_inc8, data: pack1(E,       4) };
+        t[0x24] = OpcodeEntry { handler: Sm83::handle_inc8, data: pack1(H,       4) };
+        t[0x2C] = OpcodeEntry { handler: Sm83::handle_inc8, data: pack1(L,       4) };
+        t[0x34] = OpcodeEntry { handler: Sm83::handle_inc8, data: pack1(MEM_HL, 12) };
+        t[0x3C] = OpcodeEntry { handler: Sm83::handle_inc8, data: pack1(A,       4) };
+
+        // DEC r8 / (HL)
+        t[0x05] = OpcodeEntry { handler: Sm83::handle_dec8, data: pack1(B,       4) };
+        t[0x0D] = OpcodeEntry { handler: Sm83::handle_dec8, data: pack1(C,       4) };
+        t[0x15] = OpcodeEntry { handler: Sm83::handle_dec8, data: pack1(D,       4) };
+        t[0x1D] = OpcodeEntry { handler: Sm83::handle_dec8, data: pack1(E,       4) };
+        t[0x25] = OpcodeEntry { handler: Sm83::handle_dec8, data: pack1(H,       4) };
+        t[0x2D] = OpcodeEntry { handler: Sm83::handle_dec8, data: pack1(L,       4) };
+        t[0x35] = OpcodeEntry { handler: Sm83::handle_dec8, data: pack1(MEM_HL, 12) };
+        t[0x3D] = OpcodeEntry { handler: Sm83::handle_dec8, data: pack1(A,       4) };
+
+        // INC r16
+        t[0x03] = OpcodeEntry { handler: Sm83::handle_inc16, data: pack1(BC, 8) };
+        t[0x13] = OpcodeEntry { handler: Sm83::handle_inc16, data: pack1(DE, 8) };
+        t[0x23] = OpcodeEntry { handler: Sm83::handle_inc16, data: pack1(HL, 8) };
+        t[0x33] = OpcodeEntry { handler: Sm83::handle_inc16, data: pack1(SP, 8) };
+
+        // DEC r16
+        t[0x0B] = OpcodeEntry { handler: Sm83::handle_dec16, data: pack1(BC, 8) };
+        t[0x1B] = OpcodeEntry { handler: Sm83::handle_dec16, data: pack1(DE, 8) };
+        t[0x2B] = OpcodeEntry { handler: Sm83::handle_dec16, data: pack1(HL, 8) };
+        t[0x3B] = OpcodeEntry { handler: Sm83::handle_dec16, data: pack1(SP, 8) };
+
+        // ADD HL, r16
+        t[0x09] = OpcodeEntry { handler: Sm83::handle_add16, data: pack1(BC, 8) };
+        t[0x19] = OpcodeEntry { handler: Sm83::handle_add16, data: pack1(DE, 8) };
+        t[0x29] = OpcodeEntry { handler: Sm83::handle_add16, data: pack1(HL, 8) };
+        t[0x39] = OpcodeEntry { handler: Sm83::handle_add16, data: pack1(SP, 8) };
+
+        // ADD SP, e8
+        t[0xE8] = OpcodeEntry { handler: Sm83::handle_add_sp_e8, data: pack0(16) };
+
+        // LD r8, r8 / LD r8, (HL) / LD (HL), r8  (0x40–0x7F, skip 0x76 = HALT)
+        // Encoded as pack2(dst_arg, src_arg, cycles)
+        for dst in 0u8..8 {
+            for src in 0u8..8 {
+                let op = 0x40u8 | (dst << 3) | src;
+                if op == 0x76 { continue; } // HALT already set above
+                let dst_arg = Self::reg_bits_to_arg(dst);
+                let src_arg = Self::reg_bits_to_arg(src);
+                let cycles: u8 = if dst == 6 || src == 6 { 8 } else { 4 };
+                t[op as usize] = OpcodeEntry {
+                    handler: Sm83::handle_ld8,
+                    data: pack2(dst_arg, src_arg, cycles),
+                };
+            }
+        }
+
+        // LD r8, imm8  (0x06,0x0E,0x16,0x1E,0x26,0x2E,0x36,0x3E)
+        t[0x06] = OpcodeEntry { handler: Sm83::handle_ld8, data: pack2(B,      IMM8,  8) };
+        t[0x0E] = OpcodeEntry { handler: Sm83::handle_ld8, data: pack2(C,      IMM8,  8) };
+        t[0x16] = OpcodeEntry { handler: Sm83::handle_ld8, data: pack2(D,      IMM8,  8) };
+        t[0x1E] = OpcodeEntry { handler: Sm83::handle_ld8, data: pack2(E,      IMM8,  8) };
+        t[0x26] = OpcodeEntry { handler: Sm83::handle_ld8, data: pack2(H,      IMM8,  8) };
+        t[0x2E] = OpcodeEntry { handler: Sm83::handle_ld8, data: pack2(L,      IMM8,  8) };
+        t[0x36] = OpcodeEntry { handler: Sm83::handle_ld8, data: pack2(MEM_HL, IMM8, 12) };
+        t[0x3E] = OpcodeEntry { handler: Sm83::handle_ld8, data: pack2(A,      IMM8,  8) };
+
+        // LD rr, nn
+        t[0x01] = OpcodeEntry { handler: Sm83::handle_ld16_rr_imm16, data: pack1(BC, 12) };
+        t[0x11] = OpcodeEntry { handler: Sm83::handle_ld16_rr_imm16, data: pack1(DE, 12) };
+        t[0x21] = OpcodeEntry { handler: Sm83::handle_ld16_rr_imm16, data: pack1(HL, 12) };
+        t[0x31] = OpcodeEntry { handler: Sm83::handle_ld16_rr_imm16, data: pack1(SP, 12) };
+
+        // LD (nn), SP
+        t[0x08] = OpcodeEntry { handler: Sm83::handle_ld_nn_sp,  data: pack0(20) };
+        // LD SP, HL
+        t[0xF9] = OpcodeEntry { handler: Sm83::handle_ld_sp_hl,  data: pack0(8) };
+        // LD HL, SP+e
+        t[0xF8] = OpcodeEntry { handler: Sm83::handle_ld_hl_sp_e, data: pack0(12) };
+        // LD (BC), A
+        t[0x02] = OpcodeEntry { handler: Sm83::handle_ld_bc_a,   data: pack0(8) };
+        // LD (DE), A
+        t[0x12] = OpcodeEntry { handler: Sm83::handle_ld_de_a,   data: pack0(8) };
+        // LD A, (BC)
+        t[0x0A] = OpcodeEntry { handler: Sm83::handle_ld_a_bc,   data: pack0(8) };
+        // LD A, (DE)
+        t[0x1A] = OpcodeEntry { handler: Sm83::handle_ld_a_de,   data: pack0(8) };
+        // LD (HL+), A
+        t[0x22] = OpcodeEntry { handler: Sm83::handle_ld_hli_a,  data: pack0(8) };
+        // LD (HL-), A
+        t[0x32] = OpcodeEntry { handler: Sm83::handle_ld_hld_a,  data: pack0(8) };
+        // LD A, (HL+)
+        t[0x2A] = OpcodeEntry { handler: Sm83::handle_ld_a_hli,  data: pack0(8) };
+        // LD A, (HL-)
+        t[0x3A] = OpcodeEntry { handler: Sm83::handle_ld_a_hld,  data: pack0(8) };
+        // LD (nn), A
+        t[0xEA] = OpcodeEntry { handler: Sm83::handle_ld_nn_a,   data: pack0(16) };
+        // LD A, (nn)
+        t[0xFA] = OpcodeEntry { handler: Sm83::handle_ld_a_nn,   data: pack0(16) };
+        // LDH (n), A
+        t[0xE0] = OpcodeEntry { handler: Sm83::handle_ldh_n_a,   data: pack0(12) };
+        // LDH A, (n)
+        t[0xF0] = OpcodeEntry { handler: Sm83::handle_ldh_a_n,   data: pack0(12) };
+        // LD (C), A
+        t[0xE2] = OpcodeEntry { handler: Sm83::handle_ld_c_a,    data: pack0(8) };
+        // LD A, (C)
+        t[0xF2] = OpcodeEntry { handler: Sm83::handle_ld_a_c,    data: pack0(8) };
+
+        // PUSH rr
+        t[0xC5] = OpcodeEntry { handler: Sm83::handle_push16, data: pack1(BC, 16) };
+        t[0xD5] = OpcodeEntry { handler: Sm83::handle_push16, data: pack1(DE, 16) };
+        t[0xE5] = OpcodeEntry { handler: Sm83::handle_push16, data: pack1(HL, 16) };
+        t[0xF5] = OpcodeEntry { handler: Sm83::handle_push16, data: pack1(AF, 16) };
+
+        // POP rr
+        t[0xC1] = OpcodeEntry { handler: Sm83::handle_pop16, data: pack1(BC, 12) };
+        t[0xD1] = OpcodeEntry { handler: Sm83::handle_pop16, data: pack1(DE, 12) };
+        t[0xE1] = OpcodeEntry { handler: Sm83::handle_pop16, data: pack1(HL, 12) };
+        t[0xF1] = OpcodeEntry { handler: Sm83::handle_pop16, data: pack1(AF, 12) };
+
+        // JP nn (unconditional, 16 cycles)
+        t[0xC3] = OpcodeEntry { handler: Sm83::handle_jp_nn,  data: pack0(16) };
+        // JP HL (4 cycles)
+        t[0xE9] = OpcodeEntry { handler: Sm83::handle_jp_hl,  data: pack0(4) };
+        // JR e (12 cycles)
+        t[0x18] = OpcodeEntry { handler: Sm83::handle_jr,     data: pack0(12) };
+
+        // JP cc, nn  (taken=16, not-taken=12)
+        t[0xC2] = OpcodeEntry { handler: Sm83::handle_jp_cc, data: pack_cc(NZ, 16, 12) };
+        t[0xCA] = OpcodeEntry { handler: Sm83::handle_jp_cc, data: pack_cc(Z,  16, 12) };
+        t[0xD2] = OpcodeEntry { handler: Sm83::handle_jp_cc, data: pack_cc(NC, 16, 12) };
+        t[0xDA] = OpcodeEntry { handler: Sm83::handle_jp_cc, data: pack_cc(CC, 16, 12) };
+
+        // JR cc, e  (taken=12, not-taken=8)
+        t[0x20] = OpcodeEntry { handler: Sm83::handle_jr_cc, data: pack_cc(NZ, 12, 8) };
+        t[0x28] = OpcodeEntry { handler: Sm83::handle_jr_cc, data: pack_cc(Z,  12, 8) };
+        t[0x30] = OpcodeEntry { handler: Sm83::handle_jr_cc, data: pack_cc(NC, 12, 8) };
+        t[0x38] = OpcodeEntry { handler: Sm83::handle_jr_cc, data: pack_cc(CC, 12, 8) };
+
+        // CALL nn (24 cycles)
+        t[0xCD] = OpcodeEntry { handler: Sm83::handle_call,    data: pack0(24) };
+
+        // CALL cc, nn  (taken=24, not-taken=12)
+        t[0xC4] = OpcodeEntry { handler: Sm83::handle_call_cc, data: pack_cc(NZ, 24, 12) };
+        t[0xCC] = OpcodeEntry { handler: Sm83::handle_call_cc, data: pack_cc(Z,  24, 12) };
+        t[0xD4] = OpcodeEntry { handler: Sm83::handle_call_cc, data: pack_cc(NC, 24, 12) };
+        t[0xDC] = OpcodeEntry { handler: Sm83::handle_call_cc, data: pack_cc(CC, 24, 12) };
+
+        // RET (16 cycles)
+        t[0xC9] = OpcodeEntry { handler: Sm83::handle_ret,     data: pack0(16) };
+        // RETI (16 cycles)
+        t[0xD9] = OpcodeEntry { handler: Sm83::handle_reti,    data: pack0(16) };
+
+        // RET cc  (taken=20, not-taken=8)
+        t[0xC0] = OpcodeEntry { handler: Sm83::handle_ret_cc, data: pack_cc(NZ, 20, 8) };
+        t[0xC8] = OpcodeEntry { handler: Sm83::handle_ret_cc, data: pack_cc(Z,  20, 8) };
+        t[0xD0] = OpcodeEntry { handler: Sm83::handle_ret_cc, data: pack_cc(NC, 20, 8) };
+        t[0xD8] = OpcodeEntry { handler: Sm83::handle_ret_cc, data: pack_cc(CC, 20, 8) };
+
+        // RST n  (16 cycles each; arg0 = target vector / 8, actual addr = arg0 * 8)
+        t[0xC7] = OpcodeEntry { handler: Sm83::handle_rst, data: pack1(0x00, 16) };
+        t[0xCF] = OpcodeEntry { handler: Sm83::handle_rst, data: pack1(0x08, 16) };
+        t[0xD7] = OpcodeEntry { handler: Sm83::handle_rst, data: pack1(0x10, 16) };
+        t[0xDF] = OpcodeEntry { handler: Sm83::handle_rst, data: pack1(0x18, 16) };
+        t[0xE7] = OpcodeEntry { handler: Sm83::handle_rst, data: pack1(0x20, 16) };
+        t[0xEF] = OpcodeEntry { handler: Sm83::handle_rst, data: pack1(0x28, 16) };
+        t[0xF7] = OpcodeEntry { handler: Sm83::handle_rst, data: pack1(0x30, 16) };
+        t[0xFF] = OpcodeEntry { handler: Sm83::handle_rst, data: pack1(0x38, 16) };
+
+        // ── CB-prefixed opcode table (indices 256–511) ───────────────────────
+        // CB opcode byte layout:
+        //   bits [7:6]: group (00=shift/rot, 01=BIT, 10=RES, 11=SET)
+        //   bits [5:3]: op or bit index
+        //   bits [2:0]: register target (0=B..5=L,6=(HL),7=A)
+        for cb in 0u8..=255u8 {
+            let idx = 256 + cb as usize;
+            let tgt = cb & 0x07;           // 0–7 (same as arg::B..=arg::A)
+            let is_hl = tgt == MEM_HL;
+            match cb >> 6 {
+                0x00 => {
+                    // Shift/rotate group — bits [5:3] = op
+                    let op_field = (cb >> 3) & 0x07;
+                    let cycles: u8 = if is_hl { 16 } else { 8 };
+                    // pack2(target, shift_op, cycles)
+                    t[idx] = OpcodeEntry {
+                        handler: Sm83::handle_cb_shift,
+                        data: pack2(tgt, op_field, cycles),
+                    };
+                }
+                0x01 => {
+                    // BIT b, r — bits [5:3] = bit index
+                    let bit = (cb >> 3) & 0x07;
+                    let cycles: u8 = if is_hl { 12 } else { 8 };
+                    // pack2(target, bit, cycles)
+                    t[idx] = OpcodeEntry {
+                        handler: Sm83::handle_cb_bit,
+                        data: pack2(tgt, bit, cycles),
+                    };
+                }
+                0x02 => {
+                    // RES b, r
+                    let bit = (cb >> 3) & 0x07;
+                    let cycles: u8 = if is_hl { 16 } else { 8 };
+                    t[idx] = OpcodeEntry {
+                        handler: Sm83::handle_cb_res,
+                        data: pack2(tgt, bit, cycles),
+                    };
+                }
+                0x03 => {
+                    // SET b, r
+                    let bit = (cb >> 3) & 0x07;
+                    let cycles: u8 = if is_hl { 16 } else { 8 };
+                    t[idx] = OpcodeEntry {
+                        handler: Sm83::handle_cb_set,
+                        data: pack2(tgt, bit, cycles),
+                    };
+                }
+                _ => unreachable!(),
+            }
+        }
+
+        t
+    }
+
+    /// Convert the 3-bit register field from the LD r8,r8 opcode to an `arg` constant.
+    const fn reg_bits_to_arg(bits: u8) -> u8 {
+        match bits {
+            0 => arg::B,
+            1 => arg::C,
+            2 => arg::D,
+            3 => arg::E,
+            4 => arg::H,
+            5 => arg::L,
+            6 => arg::MEM_HL,
+            7 => arg::A,
+            _ => 0xFF, // unreachable in well-formed opcodes
+        }
     }
 
     /// Return a clone of the pre-decoded handler for this opcode.

--- a/core/src/cpu/sm83.rs
+++ b/core/src/cpu/sm83.rs
@@ -3,10 +3,10 @@ use alloc::{boxed::Box, format, vec::Vec};
 use super::cpu::{Cpu, CpuError};
 use super::instructions::adc::opcode::Adc;
 use super::instructions::add::opcode::{Add16, Add8, AddSP16};
+use super::instructions::arg;
 use super::instructions::call::opcode::{Call, CallOp};
 use super::instructions::cb::opcode::{CbInstruction, CbOp, CbTarget};
 use super::instructions::cp::opcode::Cp8;
-use super::instructions::decoder::Decoder;
 use super::instructions::opcodes::OpCodeTable;
 use super::instructions::inc_dec::opcode::{Dec16, Dec8, Inc16, Inc8};
 use super::instructions::instructions::{Error as InstructionError, Instructions};
@@ -197,9 +197,9 @@ struct DmaState {
 }
 
 impl Sm83 {
-    pub fn new(memory: Box<GameBoyMemory>, opcode_decoder: Box<dyn Decoder>) -> Self {
+    pub fn new(memory: Box<GameBoyMemory>) -> Self {
         let joypad = JoypadPeripheral::new();
-        let opcodes = OpCodeTable::from_decoder(&*opcode_decoder);
+        let opcodes = OpCodeTable::new();
         let mut sm83 = Self {
             memory,
             registers: Registers::default(),
@@ -865,6 +865,725 @@ impl Sm83 {
             Condition::C => self.registers.f.contains(Flags::C),
         }
     }
+
+    // ── Flat-dispatch helpers ────────────────────────────────────────────────
+
+    /// Check a condition from an encoded `arg::NZ/Z/NC/CC` constant.
+    #[cfg_attr(target_arch = "arm", link_section = ".data")]
+    #[inline(always)]
+    fn check_cond_u8(&self, cond: u8) -> bool {
+        match cond {
+            arg::NZ => !self.registers.f.contains(Flags::Z),
+            arg::Z  =>  self.registers.f.contains(Flags::Z),
+            arg::NC => !self.registers.f.contains(Flags::C),
+            arg::CC =>  self.registers.f.contains(Flags::C),
+            _       => false,
+        }
+    }
+
+    /// Resolve an r8 arg constant to its current value, advancing peripherals
+    /// for memory reads.
+    #[cfg_attr(target_arch = "arm", link_section = ".data")]
+    fn resolve_r8(&mut self, arg0: u8) -> Result<u8, InstructionError> {
+        Ok(match arg0 {
+            arg::B      => self.registers.b,
+            arg::C      => self.registers.c,
+            arg::D      => self.registers.d,
+            arg::E      => self.registers.e,
+            arg::H      => self.registers.h,
+            arg::L      => self.registers.l,
+            arg::MEM_HL => self.bus_read(self.registers.hl())?,
+            arg::A      => self.registers.a,
+            arg::IMM8   => self.read_next_pc()?,
+            _           => return Err(InstructionError::Failed(format!("bad r8 arg {}", arg0))),
+        })
+    }
+
+    /// Write a value to the register/memory target encoded as an r8 arg constant.
+    #[cfg_attr(target_arch = "arm", link_section = ".data")]
+    fn set_r8(&mut self, arg0: u8, val: u8) -> Result<(), InstructionError> {
+        match arg0 {
+            arg::B      => self.registers.b = val,
+            arg::C      => self.registers.c = val,
+            arg::D      => self.registers.d = val,
+            arg::E      => self.registers.e = val,
+            arg::H      => self.registers.h = val,
+            arg::L      => self.registers.l = val,
+            arg::MEM_HL => self.bus_write(self.registers.hl(), val)?,
+            arg::A      => self.registers.a = val,
+            _           => return Err(InstructionError::Failed(format!("bad r8 dst arg {}", arg0))),
+        }
+        Ok(())
+    }
+
+    /// Resolve an r16 arg constant to its current 16-bit value.
+    #[cfg_attr(target_arch = "arm", link_section = ".data")]
+    fn resolve_r16(&self, arg0: u8) -> Result<u16, InstructionError> {
+        Ok(match arg0 {
+            arg::BC => self.registers.bc(),
+            arg::DE => self.registers.de(),
+            arg::HL => self.registers.hl(),
+            arg::SP => self.registers.sp,
+            arg::AF => self.registers.af(),
+            _       => return Err(InstructionError::Failed(format!("bad r16 arg {}", arg0))),
+        })
+    }
+
+    /// Write a 16-bit value to the register pair encoded as an r16 arg constant.
+    #[cfg_attr(target_arch = "arm", link_section = ".data")]
+    fn set_r16(&mut self, arg0: u8, val: u16) -> Result<(), InstructionError> {
+        match arg0 {
+            arg::BC => self.registers.set_bc(val),
+            arg::DE => self.registers.set_de(val),
+            arg::HL => self.registers.set_hl(val),
+            arg::SP => self.registers.sp = val,
+            arg::AF => self.registers.set_af(val),
+            _       => return Err(InstructionError::Failed(format!("bad r16 dst arg {}", arg0))),
+        }
+        Ok(())
+    }
+
+    // ── Flat dispatch handlers ───────────────────────────────────────────────
+
+    /// Sentinel handler for invalid / unimplemented opcodes.
+    #[cfg_attr(target_arch = "arm", link_section = ".data")]
+    pub fn handle_invalid(_cpu: &mut Sm83, _data: u32) -> Result<(), InstructionError> {
+        Err(InstructionError::Failed("invalid opcode".into()))
+    }
+
+    // ── Misc ─────────────────────────────────────────────────────────────────
+
+    #[cfg_attr(target_arch = "arm", link_section = ".data")]
+    pub fn handle_nop(_cpu: &mut Sm83, _data: u32) -> Result<(), InstructionError> {
+        Ok(())
+    }
+
+    #[cfg_attr(target_arch = "arm", link_section = ".data")]
+    pub fn handle_halt(cpu: &mut Sm83, _data: u32) -> Result<(), InstructionError> {
+        cpu.halted = true;
+        Ok(())
+    }
+
+    #[cfg_attr(target_arch = "arm", link_section = ".data")]
+    pub fn handle_stop(cpu: &mut Sm83, _data: u32) -> Result<(), InstructionError> {
+        let _ = cpu.read_next_pc()?;
+        Ok(())
+    }
+
+    #[cfg_attr(target_arch = "arm", link_section = ".data")]
+    pub fn handle_daa(cpu: &mut Sm83, _data: u32) -> Result<(), InstructionError> {
+        use super::operations::misc::daa_u8;
+        (cpu.registers.a, cpu.registers.f) = daa_u8(cpu.registers.a, cpu.registers.f);
+        Ok(())
+    }
+
+    #[cfg_attr(target_arch = "arm", link_section = ".data")]
+    pub fn handle_cpl(cpu: &mut Sm83, _data: u32) -> Result<(), InstructionError> {
+        cpu.registers.a = !cpu.registers.a;
+        cpu.registers.f.insert(Flags::N);
+        cpu.registers.f.insert(Flags::H);
+        Ok(())
+    }
+
+    #[cfg_attr(target_arch = "arm", link_section = ".data")]
+    pub fn handle_scf(cpu: &mut Sm83, _data: u32) -> Result<(), InstructionError> {
+        cpu.registers.f.remove(Flags::N);
+        cpu.registers.f.remove(Flags::H);
+        cpu.registers.f.insert(Flags::C);
+        Ok(())
+    }
+
+    #[cfg_attr(target_arch = "arm", link_section = ".data")]
+    pub fn handle_ccf(cpu: &mut Sm83, _data: u32) -> Result<(), InstructionError> {
+        let c = cpu.registers.f.contains(Flags::C);
+        cpu.registers.f.remove(Flags::N);
+        cpu.registers.f.remove(Flags::H);
+        cpu.registers.f.set(Flags::C, !c);
+        Ok(())
+    }
+
+    #[cfg_attr(target_arch = "arm", link_section = ".data")]
+    pub fn handle_di(cpu: &mut Sm83, _data: u32) -> Result<(), InstructionError> {
+        cpu.ime = ImeState::Disabled;
+        Ok(())
+    }
+
+    #[cfg_attr(target_arch = "arm", link_section = ".data")]
+    pub fn handle_ei(cpu: &mut Sm83, _data: u32) -> Result<(), InstructionError> {
+        cpu.ime = ImeState::Pending;
+        Ok(())
+    }
+
+    // ── Rotate accumulator ────────────────────────────────────────────────────
+
+    /// data = pack1(rot_op, cycles) where rot_op is one of RLCA/RRCA/RLA/RRA
+    #[cfg_attr(target_arch = "arm", link_section = ".data")]
+    pub fn handle_rot_acc(cpu: &mut Sm83, data: u32) -> Result<(), InstructionError> {
+        let op = arg::unpack_arg0(data);
+        let a = cpu.registers.a;
+        let carry_in = cpu.registers.f.contains(Flags::C) as u8;
+        let (result, carry_out) = match op {
+            arg::RLCA => { let b7 = a >> 7; ((a << 1) | b7,    b7 != 0) }
+            arg::RRCA => { let b0 = a & 1;  ((a >> 1) | (b0 << 7), b0 != 0) }
+            arg::RLA  => { let b7 = a >> 7; ((a << 1) | carry_in, b7 != 0) }
+            arg::RRA  => { let b0 = a & 1;  ((a >> 1) | (carry_in << 7), b0 != 0) }
+            _ => return Err(InstructionError::Failed("bad rot_acc op".into())),
+        };
+        cpu.registers.a = result;
+        cpu.registers.f = Flags::empty();
+        cpu.registers.f.set(Flags::C, carry_out);
+        Ok(())
+    }
+
+    // ── ALU 8-bit ─────────────────────────────────────────────────────────────
+
+    /// data = pack1(r8_arg, cycles)
+    #[cfg_attr(target_arch = "arm", link_section = ".data")]
+    pub fn handle_add8(cpu: &mut Sm83, data: u32) -> Result<(), InstructionError> {
+        use super::operations::add::add_u8;
+        let val = cpu.resolve_r8(arg::unpack_arg0(data))?;
+        (cpu.registers.a, cpu.registers.f) = add_u8(cpu.registers.a, val);
+        Ok(())
+    }
+
+    #[cfg_attr(target_arch = "arm", link_section = ".data")]
+    pub fn handle_adc(cpu: &mut Sm83, data: u32) -> Result<(), InstructionError> {
+        use super::operations::add::adc_u8;
+        let carry = cpu.registers.f.contains(Flags::C) as u8;
+        let val = cpu.resolve_r8(arg::unpack_arg0(data))?;
+        (cpu.registers.a, cpu.registers.f) = adc_u8(cpu.registers.a, val, carry);
+        Ok(())
+    }
+
+    #[cfg_attr(target_arch = "arm", link_section = ".data")]
+    pub fn handle_sub8(cpu: &mut Sm83, data: u32) -> Result<(), InstructionError> {
+        use super::operations::sub::sub_u8;
+        let val = cpu.resolve_r8(arg::unpack_arg0(data))?;
+        (cpu.registers.a, cpu.registers.f) = sub_u8(cpu.registers.a, val);
+        Ok(())
+    }
+
+    #[cfg_attr(target_arch = "arm", link_section = ".data")]
+    pub fn handle_sbc8(cpu: &mut Sm83, data: u32) -> Result<(), InstructionError> {
+        use super::operations::sub::sbc_u8;
+        let carry = cpu.registers.f.contains(Flags::C) as u8;
+        let val = cpu.resolve_r8(arg::unpack_arg0(data))?;
+        (cpu.registers.a, cpu.registers.f) = sbc_u8(cpu.registers.a, val, carry);
+        Ok(())
+    }
+
+    #[cfg_attr(target_arch = "arm", link_section = ".data")]
+    pub fn handle_and8(cpu: &mut Sm83, data: u32) -> Result<(), InstructionError> {
+        use super::operations::logic::and_u8;
+        let val = cpu.resolve_r8(arg::unpack_arg0(data))?;
+        (cpu.registers.a, cpu.registers.f) = and_u8(cpu.registers.a, val);
+        Ok(())
+    }
+
+    #[cfg_attr(target_arch = "arm", link_section = ".data")]
+    pub fn handle_xor8(cpu: &mut Sm83, data: u32) -> Result<(), InstructionError> {
+        use super::operations::logic::xor_u8;
+        let val = cpu.resolve_r8(arg::unpack_arg0(data))?;
+        (cpu.registers.a, cpu.registers.f) = xor_u8(cpu.registers.a, val);
+        Ok(())
+    }
+
+    #[cfg_attr(target_arch = "arm", link_section = ".data")]
+    pub fn handle_or8(cpu: &mut Sm83, data: u32) -> Result<(), InstructionError> {
+        use super::operations::logic::or_u8;
+        let val = cpu.resolve_r8(arg::unpack_arg0(data))?;
+        (cpu.registers.a, cpu.registers.f) = or_u8(cpu.registers.a, val);
+        Ok(())
+    }
+
+    #[cfg_attr(target_arch = "arm", link_section = ".data")]
+    pub fn handle_cp8(cpu: &mut Sm83, data: u32) -> Result<(), InstructionError> {
+        use super::operations::sub::cp_u8;
+        let val = cpu.resolve_r8(arg::unpack_arg0(data))?;
+        cpu.registers.f = cp_u8(cpu.registers.a, val);
+        Ok(())
+    }
+
+    // ── INC/DEC 8-bit ─────────────────────────────────────────────────────────
+
+    /// data = pack1(r8_arg, cycles)
+    #[cfg_attr(target_arch = "arm", link_section = ".data")]
+    pub fn handle_inc8(cpu: &mut Sm83, data: u32) -> Result<(), InstructionError> {
+        use super::operations::inc_dec::inc_u8;
+        let a0 = arg::unpack_arg0(data);
+        let val = cpu.resolve_r8(a0)?;
+        let (result, flags) = inc_u8(val, cpu.registers.f);
+        cpu.registers.f = flags;
+        cpu.set_r8(a0, result)?;
+        Ok(())
+    }
+
+    #[cfg_attr(target_arch = "arm", link_section = ".data")]
+    pub fn handle_dec8(cpu: &mut Sm83, data: u32) -> Result<(), InstructionError> {
+        use super::operations::inc_dec::dec_u8;
+        let a0 = arg::unpack_arg0(data);
+        let val = cpu.resolve_r8(a0)?;
+        let (result, flags) = dec_u8(val, cpu.registers.f);
+        cpu.registers.f = flags;
+        cpu.set_r8(a0, result)?;
+        Ok(())
+    }
+
+    // ── INC/DEC 16-bit ────────────────────────────────────────────────────────
+
+    /// data = pack1(r16_arg, cycles)
+    #[cfg_attr(target_arch = "arm", link_section = ".data")]
+    pub fn handle_inc16(cpu: &mut Sm83, data: u32) -> Result<(), InstructionError> {
+        let a0 = arg::unpack_arg0(data);
+        let val = cpu.resolve_r16(a0)?;
+        cpu.set_r16(a0, val.wrapping_add(1))?;
+        cpu.tick_cycle(); // internal
+        Ok(())
+    }
+
+    #[cfg_attr(target_arch = "arm", link_section = ".data")]
+    pub fn handle_dec16(cpu: &mut Sm83, data: u32) -> Result<(), InstructionError> {
+        let a0 = arg::unpack_arg0(data);
+        let val = cpu.resolve_r16(a0)?;
+        cpu.set_r16(a0, val.wrapping_sub(1))?;
+        cpu.tick_cycle(); // internal
+        Ok(())
+    }
+
+    // ── ADD 16-bit ────────────────────────────────────────────────────────────
+
+    /// data = pack1(r16_arg, cycles)
+    #[cfg_attr(target_arch = "arm", link_section = ".data")]
+    pub fn handle_add16(cpu: &mut Sm83, data: u32) -> Result<(), InstructionError> {
+        use super::operations::add::add_u16;
+        let operand = cpu.resolve_r16(arg::unpack_arg0(data))?;
+        let (hl, new_flags) = add_u16(cpu.registers.hl(), operand);
+        cpu.registers.f.set(Flags::N, false);
+        cpu.registers.f.set(Flags::H, new_flags.contains(Flags::H));
+        cpu.registers.f.set(Flags::C, new_flags.contains(Flags::C));
+        cpu.registers.set_hl(hl);
+        cpu.tick_cycle(); // internal — 16-bit ALU
+        Ok(())
+    }
+
+    /// ADD SP, e8 — data = pack0(cycles)
+    #[cfg_attr(target_arch = "arm", link_section = ".data")]
+    pub fn handle_add_sp_e8(cpu: &mut Sm83, _data: u32) -> Result<(), InstructionError> {
+        use super::operations::add::add_sp_u16;
+        let offset = cpu.read_next_pc()? as i8;
+        (cpu.registers.sp, cpu.registers.f) = add_sp_u16(cpu.registers.sp, offset);
+        cpu.tick_cycle(); // internal
+        cpu.tick_cycle(); // internal
+        Ok(())
+    }
+
+    // ── LD 8-bit ──────────────────────────────────────────────────────────────
+
+    /// data = pack2(dst_arg, src_arg, cycles)
+    #[cfg_attr(target_arch = "arm", link_section = ".data")]
+    pub fn handle_ld8(cpu: &mut Sm83, data: u32) -> Result<(), InstructionError> {
+        let dst = arg::unpack_arg0(data);
+        let src = arg::unpack_arg1(data);
+        let val = cpu.resolve_r8(src)?;
+        cpu.set_r8(dst, val)?;
+        Ok(())
+    }
+
+    // ── LD 16-bit ─────────────────────────────────────────────────────────────
+
+    /// LD rr, nn — data = pack1(r16_arg, cycles)
+    #[cfg_attr(target_arch = "arm", link_section = ".data")]
+    pub fn handle_ld16_rr_imm16(cpu: &mut Sm83, data: u32) -> Result<(), InstructionError> {
+        let lo = cpu.read_next_pc()? as u16;
+        let hi = cpu.read_next_pc()? as u16;
+        let val = (hi << 8) | lo;
+        cpu.set_r16(arg::unpack_arg0(data), val)?;
+        Ok(())
+    }
+
+    /// LD (nn), SP
+    #[cfg_attr(target_arch = "arm", link_section = ".data")]
+    pub fn handle_ld_nn_sp(cpu: &mut Sm83, _data: u32) -> Result<(), InstructionError> {
+        let lo = cpu.read_next_pc()? as u16;
+        let hi = cpu.read_next_pc()? as u16;
+        let addr = (hi << 8) | lo;
+        let sp = cpu.registers.sp;
+        cpu.bus_write(addr, (sp & 0xFF) as u8)?;
+        cpu.bus_write(addr.wrapping_add(1), (sp >> 8) as u8)?;
+        Ok(())
+    }
+
+    /// LD SP, HL
+    #[cfg_attr(target_arch = "arm", link_section = ".data")]
+    pub fn handle_ld_sp_hl(cpu: &mut Sm83, _data: u32) -> Result<(), InstructionError> {
+        cpu.registers.sp = cpu.registers.hl();
+        cpu.tick_cycle(); // internal
+        Ok(())
+    }
+
+    /// LD HL, SP+e
+    #[cfg_attr(target_arch = "arm", link_section = ".data")]
+    pub fn handle_ld_hl_sp_e(cpu: &mut Sm83, _data: u32) -> Result<(), InstructionError> {
+        use super::operations::add::add_sp_u16;
+        let offset = cpu.read_next_pc()? as i8;
+        let (result, flags) = add_sp_u16(cpu.registers.sp, offset);
+        cpu.registers.set_hl(result);
+        cpu.registers.f = flags;
+        cpu.tick_cycle(); // internal
+        Ok(())
+    }
+
+    /// LD (BC), A
+    #[cfg_attr(target_arch = "arm", link_section = ".data")]
+    pub fn handle_ld_bc_a(cpu: &mut Sm83, _data: u32) -> Result<(), InstructionError> {
+        cpu.bus_write(cpu.registers.bc(), cpu.registers.a)?;
+        Ok(())
+    }
+
+    /// LD (DE), A
+    #[cfg_attr(target_arch = "arm", link_section = ".data")]
+    pub fn handle_ld_de_a(cpu: &mut Sm83, _data: u32) -> Result<(), InstructionError> {
+        cpu.bus_write(cpu.registers.de(), cpu.registers.a)?;
+        Ok(())
+    }
+
+    /// LD A, (BC)
+    #[cfg_attr(target_arch = "arm", link_section = ".data")]
+    pub fn handle_ld_a_bc(cpu: &mut Sm83, _data: u32) -> Result<(), InstructionError> {
+        cpu.registers.a = cpu.bus_read(cpu.registers.bc())?;
+        Ok(())
+    }
+
+    /// LD A, (DE)
+    #[cfg_attr(target_arch = "arm", link_section = ".data")]
+    pub fn handle_ld_a_de(cpu: &mut Sm83, _data: u32) -> Result<(), InstructionError> {
+        cpu.registers.a = cpu.bus_read(cpu.registers.de())?;
+        Ok(())
+    }
+
+    /// LD (HL+), A
+    #[cfg_attr(target_arch = "arm", link_section = ".data")]
+    pub fn handle_ld_hli_a(cpu: &mut Sm83, _data: u32) -> Result<(), InstructionError> {
+        let addr = cpu.registers.hl();
+        cpu.bus_write(addr, cpu.registers.a)?;
+        cpu.registers.set_hl(addr.wrapping_add(1));
+        Ok(())
+    }
+
+    /// LD (HL-), A
+    #[cfg_attr(target_arch = "arm", link_section = ".data")]
+    pub fn handle_ld_hld_a(cpu: &mut Sm83, _data: u32) -> Result<(), InstructionError> {
+        let addr = cpu.registers.hl();
+        cpu.bus_write(addr, cpu.registers.a)?;
+        cpu.registers.set_hl(addr.wrapping_sub(1));
+        Ok(())
+    }
+
+    /// LD A, (HL+)
+    #[cfg_attr(target_arch = "arm", link_section = ".data")]
+    pub fn handle_ld_a_hli(cpu: &mut Sm83, _data: u32) -> Result<(), InstructionError> {
+        let addr = cpu.registers.hl();
+        cpu.registers.a = cpu.bus_read(addr)?;
+        cpu.registers.set_hl(addr.wrapping_add(1));
+        Ok(())
+    }
+
+    /// LD A, (HL-)
+    #[cfg_attr(target_arch = "arm", link_section = ".data")]
+    pub fn handle_ld_a_hld(cpu: &mut Sm83, _data: u32) -> Result<(), InstructionError> {
+        let addr = cpu.registers.hl();
+        cpu.registers.a = cpu.bus_read(addr)?;
+        cpu.registers.set_hl(addr.wrapping_sub(1));
+        Ok(())
+    }
+
+    /// LD (nn), A
+    #[cfg_attr(target_arch = "arm", link_section = ".data")]
+    pub fn handle_ld_nn_a(cpu: &mut Sm83, _data: u32) -> Result<(), InstructionError> {
+        let lo = cpu.read_next_pc()? as u16;
+        let hi = cpu.read_next_pc()? as u16;
+        let addr = (hi << 8) | lo;
+        cpu.bus_write(addr, cpu.registers.a)?;
+        Ok(())
+    }
+
+    /// LD A, (nn)
+    #[cfg_attr(target_arch = "arm", link_section = ".data")]
+    pub fn handle_ld_a_nn(cpu: &mut Sm83, _data: u32) -> Result<(), InstructionError> {
+        let lo = cpu.read_next_pc()? as u16;
+        let hi = cpu.read_next_pc()? as u16;
+        let addr = (hi << 8) | lo;
+        cpu.registers.a = cpu.bus_read(addr)?;
+        Ok(())
+    }
+
+    /// LDH (n), A
+    #[cfg_attr(target_arch = "arm", link_section = ".data")]
+    pub fn handle_ldh_n_a(cpu: &mut Sm83, _data: u32) -> Result<(), InstructionError> {
+        let offset = cpu.read_next_pc()? as u16;
+        cpu.bus_write(0xFF00 | offset, cpu.registers.a)?;
+        Ok(())
+    }
+
+    /// LDH A, (n)
+    #[cfg_attr(target_arch = "arm", link_section = ".data")]
+    pub fn handle_ldh_a_n(cpu: &mut Sm83, _data: u32) -> Result<(), InstructionError> {
+        let offset = cpu.read_next_pc()? as u16;
+        cpu.registers.a = cpu.bus_read(0xFF00 | offset)?;
+        Ok(())
+    }
+
+    /// LD (C), A  — 0xE2
+    #[cfg_attr(target_arch = "arm", link_section = ".data")]
+    pub fn handle_ld_c_a(cpu: &mut Sm83, _data: u32) -> Result<(), InstructionError> {
+        let addr = 0xFF00 | (cpu.registers.c as u16);
+        cpu.bus_write(addr, cpu.registers.a)?;
+        Ok(())
+    }
+
+    /// LD A, (C)  — 0xF2
+    #[cfg_attr(target_arch = "arm", link_section = ".data")]
+    pub fn handle_ld_a_c(cpu: &mut Sm83, _data: u32) -> Result<(), InstructionError> {
+        let addr = 0xFF00 | (cpu.registers.c as u16);
+        cpu.registers.a = cpu.bus_read(addr)?;
+        Ok(())
+    }
+
+    // ── PUSH / POP ────────────────────────────────────────────────────────────
+
+    /// data = pack1(r16_arg, cycles)
+    #[cfg_attr(target_arch = "arm", link_section = ".data")]
+    pub fn handle_push16(cpu: &mut Sm83, data: u32) -> Result<(), InstructionError> {
+        let val = cpu.resolve_r16(arg::unpack_arg0(data))?;
+        cpu.tick_cycle(); // internal
+        cpu.registers.sp = cpu.registers.sp.wrapping_sub(1);
+        cpu.bus_write(cpu.registers.sp, (val >> 8) as u8)?;
+        cpu.registers.sp = cpu.registers.sp.wrapping_sub(1);
+        cpu.bus_write(cpu.registers.sp, (val & 0xFF) as u8)?;
+        Ok(())
+    }
+
+    #[cfg_attr(target_arch = "arm", link_section = ".data")]
+    pub fn handle_pop16(cpu: &mut Sm83, data: u32) -> Result<(), InstructionError> {
+        let lo = cpu.bus_read(cpu.registers.sp)? as u16;
+        cpu.registers.sp = cpu.registers.sp.wrapping_add(1);
+        let hi = cpu.bus_read(cpu.registers.sp)? as u16;
+        cpu.registers.sp = cpu.registers.sp.wrapping_add(1);
+        cpu.set_r16(arg::unpack_arg0(data), (hi << 8) | lo)?;
+        Ok(())
+    }
+
+    // ── Jumps ─────────────────────────────────────────────────────────────────
+
+    /// JP nn — unconditional absolute jump
+    #[cfg_attr(target_arch = "arm", link_section = ".data")]
+    pub fn handle_jp_nn(cpu: &mut Sm83, _data: u32) -> Result<(), InstructionError> {
+        let lo = cpu.read_next_pc()? as u16;
+        let hi = cpu.read_next_pc()? as u16;
+        cpu.registers.pc = (hi << 8) | lo;
+        cpu.tick_cycle(); // internal — load new PC
+        Ok(())
+    }
+
+    /// JP HL — jump to address in HL
+    #[cfg_attr(target_arch = "arm", link_section = ".data")]
+    pub fn handle_jp_hl(cpu: &mut Sm83, _data: u32) -> Result<(), InstructionError> {
+        cpu.registers.pc = cpu.registers.hl();
+        Ok(())
+    }
+
+    /// JR e — unconditional relative jump
+    #[cfg_attr(target_arch = "arm", link_section = ".data")]
+    pub fn handle_jr(cpu: &mut Sm83, _data: u32) -> Result<(), InstructionError> {
+        let offset = cpu.read_next_pc()? as i8 as i16;
+        cpu.registers.pc = cpu.registers.pc.wrapping_add(offset as u16);
+        cpu.tick_cycle(); // internal — apply offset
+        Ok(())
+    }
+
+    /// JP cc, nn — data = pack_cc(cond, cycles_taken, cycles_not_taken)
+    #[cfg_attr(target_arch = "arm", link_section = ".data")]
+    pub fn handle_jp_cc(cpu: &mut Sm83, data: u32) -> Result<(), InstructionError> {
+        let lo = cpu.read_next_pc()? as u16;
+        let hi = cpu.read_next_pc()? as u16;
+        let target = (hi << 8) | lo;
+        if cpu.check_cond_u8(arg::unpack_arg0(data)) {
+            cpu.registers.pc = target;
+            cpu.tick_cycle(); // internal — branch taken
+        }
+        Ok(())
+    }
+
+    /// JR cc, e — data = pack_cc(cond, cycles_taken, cycles_not_taken)
+    #[cfg_attr(target_arch = "arm", link_section = ".data")]
+    pub fn handle_jr_cc(cpu: &mut Sm83, data: u32) -> Result<(), InstructionError> {
+        let offset = cpu.read_next_pc()? as i8 as i16;
+        if cpu.check_cond_u8(arg::unpack_arg0(data)) {
+            cpu.registers.pc = cpu.registers.pc.wrapping_add(offset as u16);
+            cpu.tick_cycle(); // internal — branch taken
+        }
+        Ok(())
+    }
+
+    // ── Calls / Returns ───────────────────────────────────────────────────────
+
+    /// CALL nn
+    #[cfg_attr(target_arch = "arm", link_section = ".data")]
+    pub fn handle_call(cpu: &mut Sm83, _data: u32) -> Result<(), InstructionError> {
+        let lo = cpu.read_next_pc()? as u16;
+        let hi = cpu.read_next_pc()? as u16;
+        let target = (hi << 8) | lo;
+        cpu.tick_cycle(); // internal
+        cpu.push_pc()?;
+        cpu.registers.pc = target;
+        Ok(())
+    }
+
+    /// CALL cc, nn — data = pack_cc(cond, cycles_taken, cycles_not_taken)
+    #[cfg_attr(target_arch = "arm", link_section = ".data")]
+    pub fn handle_call_cc(cpu: &mut Sm83, data: u32) -> Result<(), InstructionError> {
+        let lo = cpu.read_next_pc()? as u16;
+        let hi = cpu.read_next_pc()? as u16;
+        let target = (hi << 8) | lo;
+        if cpu.check_cond_u8(arg::unpack_arg0(data)) {
+            cpu.tick_cycle(); // internal
+            cpu.push_pc()?;
+            cpu.registers.pc = target;
+        }
+        Ok(())
+    }
+
+    /// RET
+    #[cfg_attr(target_arch = "arm", link_section = ".data")]
+    pub fn handle_ret(cpu: &mut Sm83, _data: u32) -> Result<(), InstructionError> {
+        cpu.registers.pc = cpu.pop_pc()?;
+        cpu.tick_cycle(); // internal
+        Ok(())
+    }
+
+    /// RETI
+    #[cfg_attr(target_arch = "arm", link_section = ".data")]
+    pub fn handle_reti(cpu: &mut Sm83, _data: u32) -> Result<(), InstructionError> {
+        cpu.registers.pc = cpu.pop_pc()?;
+        cpu.tick_cycle(); // internal
+        cpu.ime = ImeState::Enabled;
+        Ok(())
+    }
+
+    /// RET cc — data = pack_cc(cond, cycles_taken, cycles_not_taken)
+    #[cfg_attr(target_arch = "arm", link_section = ".data")]
+    pub fn handle_ret_cc(cpu: &mut Sm83, data: u32) -> Result<(), InstructionError> {
+        cpu.tick_cycle(); // internal — condition evaluation
+        if cpu.check_cond_u8(arg::unpack_arg0(data)) {
+            cpu.registers.pc = cpu.pop_pc()?;
+            cpu.tick_cycle(); // internal
+        }
+        Ok(())
+    }
+
+    /// RST n — data = pack1(vector, cycles) where vector is the target address (0x00,0x08,...0x38)
+    #[cfg_attr(target_arch = "arm", link_section = ".data")]
+    pub fn handle_rst(cpu: &mut Sm83, data: u32) -> Result<(), InstructionError> {
+        let vector = arg::unpack_arg0(data) as u16;
+        cpu.tick_cycle(); // internal
+        cpu.push_pc()?;
+        cpu.registers.pc = vector;
+        Ok(())
+    }
+
+    // ── CB-prefixed handlers ───────────────────────────────────────────────────
+
+    /// Read the r8/memory target identified by the CB target encoding (0=B..5=L,6=(HL),7=A).
+    #[cfg_attr(target_arch = "arm", link_section = ".data")]
+    fn resolve_cb_target(&mut self, tgt: u8) -> Result<u8, InstructionError> {
+        Ok(match tgt {
+            arg::B      => self.registers.b,
+            arg::C      => self.registers.c,
+            arg::D      => self.registers.d,
+            arg::E      => self.registers.e,
+            arg::H      => self.registers.h,
+            arg::L      => self.registers.l,
+            arg::MEM_HL => self.bus_read(self.registers.hl())?,
+            arg::A      => self.registers.a,
+            _           => return Err(InstructionError::Failed("bad cb target".into())),
+        })
+    }
+
+    /// Write to the r8/memory target identified by the CB target encoding.
+    #[cfg_attr(target_arch = "arm", link_section = ".data")]
+    fn write_cb_target_u8(&mut self, tgt: u8, val: u8) -> Result<(), InstructionError> {
+        match tgt {
+            arg::B      => self.registers.b = val,
+            arg::C      => self.registers.c = val,
+            arg::D      => self.registers.d = val,
+            arg::E      => self.registers.e = val,
+            arg::H      => self.registers.h = val,
+            arg::L      => self.registers.l = val,
+            arg::MEM_HL => self.bus_write(self.registers.hl(), val)?,
+            arg::A      => self.registers.a = val,
+            _           => return Err(InstructionError::Failed("bad cb target write".into())),
+        }
+        Ok(())
+    }
+
+    /// CB shift/rotate — data = pack2(target, shift_op, cycles)
+    #[cfg_attr(target_arch = "arm", link_section = ".data")]
+    pub fn handle_cb_shift(cpu: &mut Sm83, data: u32) -> Result<(), InstructionError> {
+        use super::operations::cb::*;
+        let tgt    = arg::unpack_arg0(data);
+        let op     = arg::unpack_arg1(data);
+        let val    = cpu.resolve_cb_target(tgt)?;
+        let carry  = cpu.registers.f.contains(Flags::C);
+        let (result, flags) = match op {
+            arg::RLC  => rlc_u8(val),
+            arg::RRC  => rrc_u8(val),
+            arg::RL   => rl_u8(val, carry),
+            arg::RR   => rr_u8(val, carry),
+            arg::SLA  => sla_u8(val),
+            arg::SRA  => sra_u8(val),
+            arg::SWAP => swap_u8(val),
+            arg::SRL  => srl_u8(val),
+            _ => return Err(InstructionError::Failed("bad cb shift op".into())),
+        };
+        cpu.registers.f = flags;
+        cpu.write_cb_target_u8(tgt, result)?;
+        Ok(())
+    }
+
+    /// CB BIT b, r — data = pack2(target, bit, cycles)
+    #[cfg_attr(target_arch = "arm", link_section = ".data")]
+    pub fn handle_cb_bit(cpu: &mut Sm83, data: u32) -> Result<(), InstructionError> {
+        use super::operations::cb::bit_u8;
+        let tgt = arg::unpack_arg0(data);
+        let bit = arg::unpack_arg1(data);
+        let val = cpu.resolve_cb_target(tgt)?;
+        cpu.registers.f = bit_u8(val, bit, cpu.registers.f);
+        Ok(())
+    }
+
+    /// CB RES b, r — data = pack2(target, bit, cycles)
+    #[cfg_attr(target_arch = "arm", link_section = ".data")]
+    pub fn handle_cb_res(cpu: &mut Sm83, data: u32) -> Result<(), InstructionError> {
+        use super::operations::cb::res_u8;
+        let tgt = arg::unpack_arg0(data);
+        let bit = arg::unpack_arg1(data);
+        let val = cpu.resolve_cb_target(tgt)?;
+        let result = res_u8(val, bit);
+        cpu.write_cb_target_u8(tgt, result)?;
+        Ok(())
+    }
+
+    /// CB SET b, r — data = pack2(target, bit, cycles)
+    #[cfg_attr(target_arch = "arm", link_section = ".data")]
+    pub fn handle_cb_set(cpu: &mut Sm83, data: u32) -> Result<(), InstructionError> {
+        use super::operations::cb::set_u8;
+        let tgt = arg::unpack_arg0(data);
+        let bit = arg::unpack_arg1(data);
+        let val = cpu.resolve_cb_target(tgt)?;
+        let result = set_u8(val, bit);
+        cpu.write_cb_target_u8(tgt, result)?;
+        Ok(())
+    }
 }
 
 impl Cpu for Sm83 {
@@ -911,16 +1630,15 @@ impl Sm83 {
 
         // Opcode fetch is the first M-cycle (via bus_read inside read_next_pc)
         let opcode = self.read_next_pc()?;
-        // Arc::clone releases the borrow of self.opcodes before execute() needs
-        // &mut self.  The atomic increment is ~10 cycles vs ~50 000 cycles for
-        // the previous Box::new() per instruction.
-        let op = if opcode == 0xCB {
+        // Flat function-pointer dispatch: copy 8 bytes out of the table, borrow
+        // released immediately — no Arc clone, no vtable, no atomics.
+        let entry = if opcode == 0xCB {
             let cb_opcode = self.read_next_pc()?;
-            self.opcodes.get_cb(cb_opcode)?
+            self.opcodes.flat[256 + cb_opcode as usize]
         } else {
-            self.opcodes.get(opcode)?
+            self.opcodes.flat[opcode as usize]
         };
-        op.execute(self)?;
+        (entry.handler)(self, entry.data)?;
 
         // Peripherals and bus events are already advanced per M-cycle
         // inside bus_read/bus_write/tick_cycle — no bulk advance needed.
@@ -1487,16 +2205,13 @@ impl Instructions for Sm83 {
 mod tests {
     use super::*;
     use alloc::{boxed::Box, vec, vec::Vec};
-    use crate::cpu::instructions::opcodes::OpCodeDecoder;
     use crate::cpu::registers::Flags;
 
     use crate::memory::memory::GameBoyMemory;
 
     pub fn make_test_cpu(rom_data: Vec<u8>) -> Sm83 {
         let memory: Box<GameBoyMemory> = Box::new(GameBoyMemory::with_rom(rom_data));
-        let decoder = Box::new(OpCodeDecoder::new());
-
-        Sm83::new(memory, decoder)
+        Sm83::new(memory)
     }
 
     pub fn make_test_cpu_with_memory(
@@ -1505,8 +2220,7 @@ mod tests {
     ) -> Sm83 {
         let mut mem = GameBoyMemory::with_rom(rom_data);
         setup(&mut mem);
-        let decoder = Box::new(OpCodeDecoder::new());
-        Sm83::new(Box::new(mem), decoder)
+        Sm83::new(Box::new(mem))
     }
 
     /// Add a constant to the accumulator register and expect the register's value to be the
@@ -1567,9 +2281,8 @@ mod tests {
     #[test]
     fn test_add8_invalid_opcode() {
         let memory: Box<GameBoyMemory> = Box::new(GameBoyMemory::new());
-        let decoder = Box::new(OpCodeDecoder::new());
 
-        let mut cpu: Box<dyn Instructions> = Box::new(Sm83::new(memory, decoder));
+        let mut cpu: Box<dyn Instructions> = Box::new(Sm83::new(memory));
         assert!(cpu
             .add8(&Add8 {
                 operand: Operand::Imm16,
@@ -1662,9 +2375,8 @@ mod tests {
     #[test]
     fn test_add16_invalid_opcode() {
         let memory: Box<GameBoyMemory> = Box::new(GameBoyMemory::new());
-        let decoder = Box::new(OpCodeDecoder::new());
 
-        let mut cpu: Box<dyn Instructions> = Box::new(Sm83::new(memory, decoder));
+        let mut cpu: Box<dyn Instructions> = Box::new(Sm83::new(memory));
         assert!(cpu
             .add16(&Add16 {
                 operand: Operand::Imm8,
@@ -1685,9 +2397,8 @@ mod tests {
     #[test]
     fn test_add_sp16_invalid_opcode() {
         let memory: Box<GameBoyMemory> = Box::new(GameBoyMemory::new());
-        let decoder = Box::new(OpCodeDecoder::new());
 
-        let mut cpu: Box<dyn Instructions> = Box::new(Sm83::new(memory, decoder));
+        let mut cpu: Box<dyn Instructions> = Box::new(Sm83::new(memory));
         assert!(cpu
             .add_sp16(&AddSP16 {
                 operand: Operand::Imm8,
@@ -1820,9 +2531,8 @@ mod tests {
     #[test]
     fn test_adc_invalid_operand() {
         let memory: Box<GameBoyMemory> = Box::new(GameBoyMemory::new());
-        let decoder = Box::new(OpCodeDecoder::new());
 
-        let mut cpu: Box<dyn Instructions> = Box::new(Sm83::new(memory, decoder));
+        let mut cpu: Box<dyn Instructions> = Box::new(Sm83::new(memory));
         assert!(cpu
             .adc(&Adc {
                 operand: Operand::Register16(Register16::BC),
@@ -2022,8 +2732,7 @@ mod tests {
         // After tick 1 (LD (HL),A): memory[0xC000]=0xCD, cycles=8
         // After tick 2 (LD A,(HL)): A=0xCD, cycles=8
         let memory = GameBoyMemory::with_rom(vec![0x77, 0x7E]);
-        let decoder = Box::new(OpCodeDecoder::new());
-        let mut cpu = Sm83::new(Box::new(memory), decoder).with_registers(Registers {
+        let mut cpu = Sm83::new(Box::new(memory)).with_registers(Registers {
             a: 0xCD,
             h: 0xC0,
             l: 0x00,
@@ -2065,8 +2774,7 @@ mod tests {
     #[test]
     fn test_ld8_mem_hl_imm8() {
         let memory = GameBoyMemory::with_rom(vec![0x36, 0x99, 0x7E]);
-        let decoder = Box::new(OpCodeDecoder::new());
-        let mut cpu = Sm83::new(Box::new(memory), decoder).with_registers(Registers {
+        let mut cpu = Sm83::new(Box::new(memory)).with_registers(Registers {
             h: 0xC0,
             l: 0x00,
             ..Default::default()
@@ -2094,8 +2802,7 @@ mod tests {
         // Pre-populate the memory location HL will point to
         memory.write(0xC010, 0x0F).unwrap();
 
-        let decoder = Box::new(OpCodeDecoder::new());
-        let mut cpu = Sm83::new(Box::new(memory), decoder).with_registers(Registers {
+        let mut cpu = Sm83::new(Box::new(memory)).with_registers(Registers {
             a: 0x01,
             h: 0xC0,
             l: 0x10,
@@ -2891,8 +3598,7 @@ mod tests {
     fn test_inc8_mem_hl() {
         let mut memory = GameBoyMemory::with_rom(vec![0x34, 0x7E]);
         memory.write(0xC000, 0x07).unwrap();
-        let decoder = Box::new(OpCodeDecoder::new());
-        let mut cpu = Sm83::new(Box::new(memory), decoder).with_registers(Registers {
+        let mut cpu = Sm83::new(Box::new(memory)).with_registers(Registers {
             h: 0xC0,
             l: 0x00,
             ..Default::default()
@@ -2916,8 +3622,7 @@ mod tests {
     fn test_dec8_mem_hl() {
         let mut memory = GameBoyMemory::with_rom(vec![0x35, 0x7E]);
         memory.write(0xC000, 0x07).unwrap();
-        let decoder = Box::new(OpCodeDecoder::new());
-        let mut cpu = Sm83::new(Box::new(memory), decoder).with_registers(Registers {
+        let mut cpu = Sm83::new(Box::new(memory)).with_registers(Registers {
             h: 0xC0,
             l: 0x00,
             ..Default::default()

--- a/core/tests/battery_save.rs
+++ b/core/tests/battery_save.rs
@@ -2,7 +2,6 @@
 
 mod common;
 
-use rustyboy_core::cpu::instructions::opcodes::OpCodeDecoder;
 use rustyboy_core::cpu::registers::{Flags, Registers};
 use rustyboy_core::cpu::sm83::Sm83;
 use rustyboy_core::memory::memory::GameBoyMemory;
@@ -23,8 +22,7 @@ fn make_rom(cart_type: u8, rom_size_code: u8, ram_size_code: u8) -> Vec<u8> {
 /// Create a fresh Sm83 with DMG post-boot register state.
 fn make_emulator(rom: Vec<u8>) -> Sm83 {
     let memory = Box::new(GameBoyMemory::with_rom(rom));
-    let decoder = Box::new(OpCodeDecoder::new());
-    Sm83::new(memory, decoder)
+    Sm83::new(memory)
         .with_registers(Registers {
             a: 0x01,
             f: Flags::from_bits_truncate(0xB0),

--- a/core/tests/common/mod.rs
+++ b/core/tests/common/mod.rs
@@ -2,7 +2,6 @@
 #![allow(dead_code)]
 
 use rustyboy_core::cpu::cpu::Cpu;
-use rustyboy_core::cpu::instructions::opcodes::OpCodeDecoder;
 use rustyboy_core::cpu::registers::Registers;
 use rustyboy_core::cpu::sm83::Sm83;
 use rustyboy_core::memory::memory::GameBoyMemory;
@@ -27,8 +26,7 @@ pub fn load_rom(path: &str) -> Vec<u8> {
 pub fn run_blargg_rom(path: &str) -> String {
     let rom_data = load_rom(path);
     let memory = Box::new(GameBoyMemory::with_rom(rom_data));
-    let decoder = Box::new(OpCodeDecoder::new());
-    let mut cpu = Sm83::new(memory, decoder).with_registers(Registers {
+    let mut cpu = Sm83::new(memory).with_registers(Registers {
         pc: 0x0100,
         sp: 0xFFFE,
         ..Default::default()
@@ -71,8 +69,7 @@ pub fn assert_blargg_passed(path: &str, name: &str) {
 pub fn run_blargg_mem_rom(path: &str) -> String {
     let rom_data = load_rom(path);
     let memory = Box::new(GameBoyMemory::with_rom(rom_data));
-    let decoder = Box::new(OpCodeDecoder::new());
-    let mut cpu = Sm83::new(memory, decoder).with_registers(Registers {
+    let mut cpu = Sm83::new(memory).with_registers(Registers {
         pc: 0x0100,
         sp: 0xFFFE,
         ..Default::default()
@@ -128,8 +125,7 @@ pub fn assert_blargg_mem_passed(path: &str, name: &str) {
 pub fn run_mooneye_rom(path: &str) -> MooneyeResult {
     let rom_data = load_rom(path);
     let memory = Box::new(GameBoyMemory::with_rom(rom_data));
-    let decoder = Box::new(OpCodeDecoder::new());
-    let mut cpu = Sm83::new(memory, decoder).with_registers(Registers {
+    let mut cpu = Sm83::new(memory).with_registers(Registers {
         pc: 0x0100,
         sp: 0xFFFE,
         ..Default::default()
@@ -199,8 +195,7 @@ pub fn assert_mooneye_passed(path: &str, name: &str) {
 pub fn run_rom_frames(path: &str, frames: u32) -> Vec<u8> {
     let rom_data = load_rom(path);
     let memory = Box::new(GameBoyMemory::with_rom(rom_data));
-    let decoder = Box::new(OpCodeDecoder::new());
-    let mut cpu = Sm83::new(memory, decoder).with_registers(Registers {
+    let mut cpu = Sm83::new(memory).with_registers(Registers {
         pc: 0x0100,
         sp: 0xFFFE,
         ..Default::default()

--- a/core/tests/dkl2_lcdc_trace.rs
+++ b/core/tests/dkl2_lcdc_trace.rs
@@ -4,7 +4,6 @@
 mod common;
 
 use rustyboy_core::cpu::cpu::Cpu;
-use rustyboy_core::cpu::instructions::opcodes::OpCodeDecoder;
 use rustyboy_core::cpu::peripheral::joypad::Button;
 use rustyboy_core::cpu::registers::{Flags, Registers};
 use rustyboy_core::cpu::sm83::Sm83;
@@ -24,8 +23,7 @@ fn build_cpu() -> Sm83 {
     let rom_path = "/home/vbonduro/roms/extracted/Donkey Kong Land 2 (USA, Europe) (SGB Enhanced).gb";
     let rom_data = std::fs::read(rom_path).expect("DKL2 ROM not found");
     let memory = Box::new(GameBoyMemory::with_rom(rom_data));
-    let decoder = Box::new(OpCodeDecoder::new());
-    Sm83::new(memory, decoder)
+    Sm83::new(memory)
         .with_registers(Registers {
             a: 0x01,
             f: Flags::from_bits_truncate(0xB0),

--- a/core/tests/save_state.rs
+++ b/core/tests/save_state.rs
@@ -3,7 +3,6 @@
 mod common;
 
 use rustyboy_core::cpu::cpu::Cpu;
-use rustyboy_core::cpu::instructions::opcodes::OpCodeDecoder;
 use rustyboy_core::cpu::registers::{Flags, Registers};
 use rustyboy_core::cpu::sm83::Sm83;
 use rustyboy_core::cpu::save_state::SaveState;
@@ -25,8 +24,7 @@ fn make_rom(cart_type: u8, rom_size_code: u8, ram_size_code: u8) -> Vec<u8> {
 /// Create a fresh Sm83 with DMG post-boot register state.
 fn make_emulator(rom: Vec<u8>) -> Sm83 {
     let memory = Box::new(GameBoyMemory::with_rom(rom));
-    let decoder = Box::new(OpCodeDecoder::new());
-    Sm83::new(memory, decoder)
+    Sm83::new(memory)
         .with_registers(Registers {
             a: 0x01,
             f: Flags::from_bits_truncate(0xB0),

--- a/docs/dispatch-refactor.md
+++ b/docs/dispatch-refactor.md
@@ -1,0 +1,207 @@
+# Opcode Dispatch Refactor — Flat Function Pointer Table
+
+## Problem
+
+The current dispatch path per instruction:
+
+1. `opcodes.get(opcode)` → `Arc::clone` (atomic fetch-add on Cortex-M33)
+2. `op.execute(self)` → vtable call → `OpCode::execute()` → `cpu.method()` → second vtable call
+3. `op` drops → atomic fetch-sub + conditional free check
+
+Two atomic RMWs and two vtable-indirect calls per instruction, every M-cycle.
+Profiling shows decode/dispatch at **450 M Pico cycles / 60 frames (48.3% of total)**.
+
+## Solution — Option B: `(fn_ptr, u32)` Table
+
+Replace `Vec<Option<Arc<dyn OpCode>>>` with a `[OpcodeEntry; 256]` flat array.
+
+```
+OpcodeEntry { handler: fn(&mut Sm83, u32) -> Result<u8, InstructionError>, data: u32 }
+```
+
+`OpcodeEntry` is `Copy` (two words). Copying it out of the array drops the borrow on
+`self.opcodes` immediately — no `Arc`, no `unsafe`, no raw pointers needed.
+
+Tick dispatch shrinks to:
+
+```rust
+let entry = self.opcodes.main[opcode as usize]; // 8-byte copy, borrow released
+(entry.handler)(self, entry.data)?;             // one indirect call, no vtable
+```
+
+~30–45 handler functions replace the two-vtable chain. Each handler is a method on
+`Sm83` that takes `&mut self` and a packed `u32` argument word.
+
+## Data Word Layout
+
+```
+bits [7:0]   = arg0  (operand, condition, CB op, etc.)
+bits [15:8]  = arg1  (dst operand for LD, bit index for CB, 0 otherwise)
+bits [23:16] = cycles_taken
+bits [31:24] = cycles_not_taken (conditional insns only; 0 for unconditional)
+```
+
+Helper constructors (all `const fn`):
+
+```rust
+const fn pack0(cy: u8) -> u32 { (cy as u32) << 16 }
+const fn pack1(a0: u8, cy: u8) -> u32 { a0 as u32 | ((cy as u32) << 16) }
+const fn pack2(a0: u8, a1: u8, cy: u8) -> u32 { a0 as u32 | ((a1 as u32) << 8) | ((cy as u32) << 16) }
+const fn pack_cc(cond: u8, cy_t: u8, cy_f: u8) -> u32 { cond as u32 | ((cy_t as u32) << 16) | ((cy_f as u32) << 24) }
+```
+
+## Flat Operand Encoding (`arg` module)
+
+All operands are encoded as `u8` constants in `core/src/cpu/instructions/arg.rs`:
+
+```rust
+// 8-bit register targets (also used as CB targets, same order as SM83 CB encoding)
+pub const B:      u8 = 0;
+pub const C:      u8 = 1;
+pub const D:      u8 = 2;
+pub const E:      u8 = 3;
+pub const H:      u8 = 4;
+pub const L:      u8 = 5;
+pub const MEM_HL: u8 = 6;  // (HL) memory — matches SM83 r8 encoding slot 6
+pub const A:      u8 = 7;
+
+// 8-bit immediate / signed
+pub const IMM8:  u8 = 8;
+pub const IMMS8: u8 = 9;
+
+// 16-bit registers
+pub const BC: u8 = 10;
+pub const DE: u8 = 11;
+pub const HL: u8 = 12;
+pub const SP: u8 = 13;
+pub const AF: u8 = 14;
+
+// Conditions
+pub const NZ: u8 = 0;
+pub const Z:  u8 = 1;
+pub const NC: u8 = 2;
+pub const CC: u8 = 3;  // named CC to avoid clash with Flags::C
+
+// CB shift/rotate ops (packed into bits [7:3] of data when target is in bits [2:0])
+pub const RLC:  u8 = 0;
+pub const RRC:  u8 = 1;
+pub const RL:   u8 = 2;
+pub const RR:   u8 = 3;
+pub const SLA:  u8 = 4;
+pub const SRA:  u8 = 5;
+pub const SWAP: u8 = 6;
+pub const SRL:  u8 = 7;
+
+// Rotate-accumulator ops (RLCA/RRCA/RLA/RRA)
+pub const RLCA: u8 = 0;
+pub const RRCA: u8 = 1;
+pub const RLA:  u8 = 2;
+pub const RRA:  u8 = 3;
+```
+
+## Handler Families
+
+Each handler is a method on `Sm83` and referenced as `Sm83::handle_*` in the table.
+All carry `#[cfg_attr(target_arch = "arm", link_section = ".data")]`.
+
+### ALU (add8 / adc / sub8 / sbc8 / cp8 / and8 / or8 / xor8)
+
+`data = pack1(r8_arg, cycles)`
+
+One handler per ALU op. `arg0` decoded by `resolve_r8(arg)` helper:
+
+```rust
+fn resolve_r8(&mut self, arg: u8) -> Result<u8, InstructionError> {
+    Ok(match arg {
+        arg::B      => self.registers.b,
+        arg::C      => self.registers.c,
+        arg::D      => self.registers.d,
+        arg::E      => self.registers.e,
+        arg::H      => self.registers.h,
+        arg::L      => self.registers.l,
+        arg::MEM_HL => self.bus_read(self.registers.hl())?,
+        arg::A      => self.registers.a,
+        arg::IMM8   => self.read_next_pc()?,
+        _           => return Err(InstructionError::Failed("bad r8 arg".into())),
+    })
+}
+```
+
+### LD r8, r8 / LD r8, imm8 / LD r8, (HL) / LD (HL), r8
+
+`data = pack2(dst_arg, src_arg, cycles)`
+
+`handle_ld8` reads src via `resolve_r8(arg1)`, writes dst via `set_r8(arg0, val)`.
+
+`set_r8` is the inverse of `resolve_r8` (no memory write for IMM8 destination).
+
+### INC/DEC r8, INC/DEC r16, ADD HL r16, PUSH/POP
+
+Straightforward; operand in `arg0`, cycles in bits [23:16].
+
+`resolve_r16(arg)` and `set_r16(arg, val)` mirror the r8 helpers but for 16-bit pairs.
+
+### Conditional jumps / calls / returns
+
+`data = pack_cc(cond, cycles_taken, cycles_not_taken)`
+
+Handler checks `self.check_condition_u8(arg0)`, ticks one extra internal cycle if taken,
+returns `cycles_taken` or `cycles_not_taken` from bits [23:16] / [31:24].
+
+### Misc (NOP/HALT/STOP/DAA/CPL/SCF/CCF/DI/EI)
+
+Each is its own handler or shares `handle_misc` with op encoded in `arg0`. Since these
+are zero/one arg and fairly unique, individual handlers are clearest.
+
+### Ld16 variants (17 distinct ops)
+
+Most get their own small handler. `handle_ld16_rr_imm16` shares one handler with r16
+encoded in `arg0`.
+
+### CB prefix
+
+CB table uses four handler families:
+- `handle_cb_shift` — RLC/RRC/RL/RR/SLA/SRA/SWAP/SRL
+  `data = pack2(target, shift_op, cycles)`
+- `handle_cb_bit` — BIT b, r
+  `data = pack2(target, bit, cycles)`
+- `handle_cb_res` — RES b, r
+  `data = pack2(target, bit, cycles)`
+- `handle_cb_set` — SET b, r
+  `data = pack2(target, bit, cycles)`
+
+`target` follows the SM83 CB encoding: 0=B,1=C,2=D,3=E,4=H,5=L,6=(HL),7=A.
+
+`resolve_cb_target` / `write_cb_target_u8` helpers read/write register or (HL) memory.
+
+## Files Changed
+
+| File | Change |
+|---|---|
+| `core/src/cpu/instructions/arg.rs` | **New** — flat operand constants + pack helpers |
+| `core/src/cpu/instructions/mod.rs` | Add `pub mod arg` |
+| `core/src/cpu/instructions/opcodes.rs` | Add `OpcodeEntry`, `Handler`, `OpCodeTable::new()` with explicit 512-entry table |
+| `core/src/cpu/sm83.rs` | Add `handle_*` methods + `resolve_r8/r16/cb_target` helpers; update `tick_impl`; remove decoder param from `new()` |
+| `core/src/cpu/cpu.rs` | Remove `DecoderError` from `CpuError` if unused |
+| `core/tests/common/mod.rs` | Remove decoder arg from `Sm83::new()` calls |
+| `core/tests/*.rs` | Remove decoder arg |
+| `platform/pico2w/src/main.rs` | Remove decoder arg |
+| `platform/web/client/src/lib.rs` | Remove decoder arg |
+
+## Invariants to Preserve
+
+- `OpCodeDecoder` and the full `Decoder` / `OpCode` / `Instructions` trait chain remain
+  intact — they are still used by `FakeCpu` unit tests for each instruction family.
+- All existing integration tests (blargg, mooneye, dmg_acid2, etc.) must continue to pass.
+- `#[cfg(feature = "perf")]` instrumentation in `tick_impl` is unchanged.
+- `#[cfg(feature = "trace")]` hook is unchanged.
+- `.data` section placement attributes on all hot-path methods are preserved.
+
+## Expected Impact
+
+Eliminates per-instruction:
+- 2× atomic RMW (Arc clone/drop)
+- 2× vtable-indirect function call
+- 1× heap reference dereference
+
+Projected savings: ~200–300 M Pico cycles / 60 frames (~22–32% of total runtime).

--- a/platform/pico2w/src/main.rs
+++ b/platform/pico2w/src/main.rs
@@ -25,7 +25,6 @@ use embedded_sdmmc::{SdCard, VolumeManager};
 use {defmt_rtt as _, panic_probe as _};
 
 use rustyboy_core::cpu::cpu::Cpu;
-use rustyboy_core::cpu::instructions::opcodes::OpCodeDecoder;
 use rustyboy_core::cpu::peripheral::joypad::Button;
 use rustyboy_core::cpu::registers::{Flags, Registers};
 use rustyboy_core::cpu::sm83::Sm83;
@@ -159,8 +158,7 @@ async fn main(_spawner: Spawner) {
     };
 
     let memory = GameBoyMemory::with_cartridge(alloc::boxed::Box::new(cart));
-    let decoder = alloc::boxed::Box::new(OpCodeDecoder::new());
-    let mut cpu = Sm83::new(alloc::boxed::Box::new(memory), decoder)
+    let mut cpu = Sm83::new(alloc::boxed::Box::new(memory))
         .with_registers(Registers {
             a: 0x01,
             f: Flags::from_bits_truncate(0xB0),

--- a/platform/web/client/src/lib.rs
+++ b/platform/web/client/src/lib.rs
@@ -3,7 +3,6 @@ use wasm_bindgen::prelude::*;
 use rustyboy_core::{
     cpu::{
         cpu::Cpu,
-        instructions::opcodes::OpCodeDecoder,
         peripheral::joypad::Button,
         registers::{Flags, Registers},
         save_state::SaveState,
@@ -36,9 +35,8 @@ impl EmulatorHandle {
     #[wasm_bindgen(constructor)]
     pub fn new(rom: Vec<u8>) -> EmulatorHandle {
         let memory = GameBoyMemory::with_rom(rom);
-        let decoder = Box::new(OpCodeDecoder::new());
         // Start at 0x100 with DMG post-boot-ROM state (skips boot ROM).
-        let cpu = Sm83::new(Box::new(memory), decoder)
+        let cpu = Sm83::new(Box::new(memory))
             .with_registers(Registers {
                 a: 0x01, f: Flags::from_bits_truncate(0xB0),
                 b: 0x00, c: 0x13,


### PR DESCRIPTION
## Summary

- Replaces the `Arc<dyn OpCode>` + double-vtable opcode dispatch with a flat `[OpcodeEntry; 512]` function pointer table (main opcodes at [0..255], CB-prefix at [256..511])
- Each entry is `OpcodeEntry { handler: fn(&mut Sm83, u32), data: u32 }` — a `Copy` 8-byte struct. Copying it out of the table drops the borrow on `self.opcodes` immediately, so no `unsafe` or raw pointers are needed
- Adds `arg.rs` with flat operand constants and `pack0`/`pack1`/`pack2`/`pack_cc` helpers for encoding operands into the `u32` data word
- Removes `opcode_decoder` parameter from `Sm83::new()` — the table is built directly

## Measured impact

~44M Pico cycles / 60 frames saved on decode/dispatch (930M → 879M total, ~5.5%). Not enough to change visible fps on its own — the display SPI path currently dominates wall-clock time — but eliminates the Arc atomics and vtable indirection as a foundation for further hot-path work. See `docs/dispatch-refactor.md` for full analysis.

## Test plan

- [x] All 766 core tests pass (`cargo test`)
- [x] Flashed to Pico2W with `--features perf`, measured baseline numbers
- [x] Existing `Instructions` trait, `OpCodeDecoder`, and `FakeCpu` test infrastructure preserved unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)