### PR TITLE
Pre-scale display framebuffer and profile render path (Phase A+B)

### DIFF
--- a/docs/display-dma-plan.md
+++ b/docs/display-dma-plan.md
@@ -1,0 +1,214 @@
+# Display DMA Implementation Plan
+
+## Goal
+
+Hide the ILI9341 SPI frame transfer behind emulation work using async DMA, eliminating the
+largest single wall-clock bottleneck. Target: ~58 fps at 250 MHz (up from ~9 fps).
+
+## Context
+
+From the performance-roadmap baseline (Tetris, 250 MHz):
+
+| Bucket | Time / 60 frames | % of wall clock |
+|---|---|---|
+| Emulation | 3.52 s | 53% |
+| Display + other | 3.15 s | 47% |
+| **Total** | **6.67 s** | **100%** |
+
+The display path currently blocks Core 0 for the full SPI transfer. `fill_scaled_frame` runs
+51,840 iterator steps of multiply/divide + palette lookup while the CPU waits on SPI — Core 0
+does both the pixel math and the bus stall simultaneously. This makes ~13 ms of hardware-limited
+SPI time appear as much more wall-clock cost.
+
+## Design decisions
+
+**DMA on Core 0, not Core 1.** A second Cortex-M33 at 250 MHz is a compute resource. Spending
+it to replace what a DMA controller does for free wastes it and prevents future use for APU or
+instruction-level tick batching (roadmap priorities 2 and 5). The only advantage of Core 1 would
+be avoiding the mipidsi async transition; that transition is scoped to one method in `hw.rs` and
+is not worth the trade-off.
+
+**Keep mipidsi for the splash.** The splash runs once and its timing doesn't matter. Only the
+game-loop hot path bypasses mipidsi.
+
+**Single pre-scaled u16 buffer.** Pre-scaling is fast (~0.5 ms) and DMA takes ~13 ms. A single
+103 KB buffer suffices: Core 0 starts the DMA future, runs emulation (~16.7 ms), pre-scales the
+next frame, then awaits the DMA future (which is already done). No double-buffering needed.
+
+**DMA_CH1 for display.** Audio I2S already uses DMA_CH0 via PIO. SPI1 display gets DMA_CH1.
+
+---
+
+## Phase A — Profile the display path
+
+**Goal:** measure the split between SPI transfer time and iterator/scaling overhead inside
+`render_game_only`, so we know which of Phase B and C matters more.
+
+**What to do:**
+
+Add DWT instrumentation around the `render_game_only` call in `main.rs` under the existing
+`#[cfg(feature = "perf")]` gate. The `perf` module already exposes `read_dwt` primitives — add
+a `render` counter alongside the existing emulation sub-breakdown counters and log it in the
+same 60-frame summary.
+
+**Expected outcome:** either the iterator overhead dominates (Phase B has large standalone
+impact) or the raw SPI time dominates (skip straight to Phase C).
+
+---
+
+## Phase B — Pre-scaled framebuffer
+
+**Goal:** decouple per-pixel CPU work from SPI timing. Effective even with blocking SPI; also
+required for Phase C.
+
+**What to do:**
+
+1. Add to `display/mod.rs`:
+   ```rust
+   pub fn scale_to_rgb565(src: &[u8; 23040], dst: &mut [u16; 51840]) {
+       for i in 0..(240 * 216) {
+           let sx = (i % 240) * 2 / 3;
+           let sy = (i / 240) * 2 / 3;
+           let idx = src[sy * 160 + sx];
+           dst[i] = dmg_color(idx).into_storage().to_be();
+       }
+   }
+   ```
+   Keep the existing `fill_scaled_frame` path for host tests. Update `render_game_only` to
+   accept `&[u16; 51840]` alongside the existing `&[u8; 23040]` overload (or add a new method).
+
+2. Allocate the buffer at startup via `Box::leak`:
+   ```rust
+   let frame_buf: &'static mut [u16; 51840] =
+       Box::leak(Box::new([0u16; 51840]));
+   ```
+   This avoids reducing the static heap size and keeps the heap intact for ROM/CPU allocations.
+
+3. Replace `hw_disp.inner.render_game_only(cpu.framebuffer())` with:
+   ```rust
+   scale_to_rgb565(cpu.framebuffer(), frame_buf);
+   hw_disp.inner.render_game_only_scaled(frame_buf);
+   ```
+   `render_game_only_scaled` calls `fill_contiguous` with the pre-computed u16 slice — one
+   HAL call for the whole frame, no per-pixel iterator.
+
+**Expected outcome:** iterator overhead eliminated. Measure again under `perf` to confirm.
+
+---
+
+## Phase C — Async DMA transfer
+
+**Goal:** start the SPI transfer at VBlank and run emulation concurrently, hiding the ~13 ms
+transfer behind the ~16.7 ms emulation window.
+
+### Step 1 — Switch SPI1 to async mode
+
+In `display/hw.rs`, replace:
+```rust
+// before
+use embassy_rp::spi::{Blocking, Config as SpiConfig, Spi};
+let spi = Spi::new_blocking_txonly(spi1, clk, mosi, cfg);
+```
+with:
+```rust
+// after
+use embassy_rp::spi::{Async, Config as SpiConfig, Spi};
+use embassy_rp::peripherals::DMA_CH1;
+let spi = Spi::new_txonly(spi1, clk, mosi, dma_ch1, cfg);
+```
+
+Update `HwDisplay::new()` to accept a `Peri<'d, DMA_CH1>` parameter.
+
+Add `DMA_CH1` to the interrupt binding in `main.rs`:
+```rust
+bind_interrupts!(struct Irqs {
+    PIO0_IRQ_0 => PioIrqHandler<PIO0>;
+    DMA_IRQ_0  => dma::InterruptHandler<DMA_CH0>;
+    DMA_IRQ_1  => dma::InterruptHandler<DMA_CH1>;
+});
+```
+
+**Note:** `Spi<Async>` implements `embedded_hal_async::spi::SpiBus`, not the blocking
+`embedded_hal::spi::SpiBus` that `display-interface-spi 0.5` expects. The splash animation
+still calls mipidsi drawing primitives. Verify at compile time whether `mipidsi 0.8` accepts
+an async SPI via `ExclusiveDevice<Spi<Async>, ...>`. If not, the splash must be ported to raw
+commands (see Step 2), or driven via a blocking spin wrapper around the async SPI.
+
+### Step 2 — Add `send_frame_raw()`
+
+Add a method to `HwDisplay` that bypasses mipidsi for the hot path and drives the ILI9341
+window protocol directly:
+
+```rust
+pub async fn send_frame_raw(&mut self, buf: &[u16; 51840]) {
+    // Set column address: 0..239
+    self.write_command(0x2A, &[0x00, 0x00, 0x00, 0xEF]);
+    // Set row address: 52..267  (Y_OFFSET = 52, SCALED_H = 216)
+    self.write_command(0x2B, &[0x00, 0x34, 0x01, 0x0B]);
+    // Begin memory write
+    self.write_command(0x2C, &[]);
+    // DMA transfer — assert DC high (data), blast 103,680 bytes
+    self.dc.set_high();
+    self.spi_dev.write(bytemuck::cast_slice(buf)).await.ok();
+}
+```
+
+`write_command` sends one command byte (DC low) followed by optional parameter bytes (DC high),
+using the existing CS/DC GPIO pins. The exact byte values come from the ILI9341 datasheet
+(CASET/PASET column/row window registers).
+
+### Step 3 — Wire the game loop
+
+Replace the blocking render call with the overlapped DMA pattern:
+
+```rust
+loop {
+    // Start DMA transfer of the pre-scaled frame buffer (returns immediately).
+    let disp_future = hw_disp.send_frame_raw(frame_buf);
+
+    // Run one full Game Boy frame while DMA is in flight.
+    let frame_start = cpu.cycle_counter();
+    while cpu.cycle_counter().wrapping_sub(frame_start) < CYCLES_PER_FRAME {
+        let _ = cpu.tick();
+    }
+
+    // Handle input, fill audio back-buffer.
+    // ...
+
+    // Pre-scale next frame into the buffer (fast, ~0.5 ms).
+    scale_to_rgb565(cpu.framebuffer(), frame_buf);
+
+    // Await DMA — should already be complete; this is just the join point.
+    disp_future.await;
+
+    watchdog.feed(...);
+}
+```
+
+This is structurally identical to how the audio DMA future is handled today.
+
+---
+
+## Expected outcome
+
+At 250 MHz:
+
+| | Time / frame | fps |
+|---|---|---|
+| Baseline (current) | ~111 ms | ~9 |
+| After Phase B | ~30 ms (est.) | ~33 |
+| After Phase C | ~17 ms (emulation dominates) | ~58 |
+
+The display transfer (~13 ms) is fully hidden behind the emulation window (~16.7 ms). The
+remaining gap to 60 fps is emulation cost alone, which is addressed by roadmap priorities 2–5.
+
+---
+
+## Files touched
+
+| File | Change |
+|---|---|
+| `src/display/mod.rs` | Add `scale_to_rgb565`, `render_game_only_scaled` |
+| `src/display/hw.rs` | Switch to async SPI, add `send_frame_raw`, CS/DC raw access |
+| `src/main.rs` | DMA_CH1 binding, `Box::leak` buffer, game loop restructure |
+| `src/perf.rs` | Phase A: render DWT counter |

--- a/docs/performance-roadmap.md
+++ b/docs/performance-roadmap.md
@@ -1,0 +1,148 @@
+# Performance Roadmap
+
+## Current state — post dispatch-refactor baseline
+
+ROM: Tetris, Pico2W @ 250 MHz.
+
+### Wall-clock breakdown (fps = 9)
+
+| Bucket | Time / 60 frames | % of wall clock |
+|---|---|---|
+| Emulation (DWT) | 3.52 s (879M cycles) | 53% |
+| Display + other | 3.15 s | 47% |
+| **Total** | **6.67 s** | **100%** |
+
+Target: 1.00 s / 60 frames (60 fps).  
+Required speedup: **6.7×**.
+
+### Emulation sub-breakdown (879M cycles)
+
+| Component | Cycles | % of emulation |
+|---|---|---|
+| decode / dispatch | 406M | 46% |
+| apu | 205M | 23% |
+| ppu | 160M | 18% |
+| mem_write | 54M | 6% |
+| mem_read | 29M | 3% |
+| timer | 26M | 3% |
+
+### Hard ceiling without touching display
+
+Even if emulation cost were zero, the display/other overhead alone gives:
+
+60 ÷ 3.15 s = **~19 fps maximum**
+
+Both tracks (emulation and display) must be attacked together to reach 60 fps.
+
+---
+
+## Priority 1 — Async display transfer
+
+**Expected impact: largest single lever, potentially 2–3× fps gain**
+
+The display currently blocks the CPU for ~13 ms per frame (240×216 × 2 bytes over
+62.5 MHz SPI), plus unknown software-scaling overhead. The game loop sits idle
+waiting for this transfer to complete.
+
+### What to do
+
+1. **Profile the display path** — add DWT instrumentation around `render_game_only`
+   to separate the SPI transfer time from the software scaler (1.5× pixel iterator).
+
+2. **DMA-backed SPI transfer** — `embassy-rp` supports async DMA SPI writes. Start
+   the transfer at VBlank, let emulation run for the next frame concurrently, await
+   completion only if the next VBlank arrives before the DMA finishes. This hides
+   the transfer latency almost entirely behind emulation work.
+
+3. **Pre-scale into a u16 framebuffer** — instead of running the 1.5× scale iterator
+   inside the SPI callback, maintain a `[u16; 240 * 216]` front buffer that is updated
+   once per VBlank. The DMA transfer then reads directly from this buffer with no
+   per-pixel CPU work during the transfer.
+
+---
+
+## Priority 2 — APU cycle batching
+
+**Expected impact: ~80–100M cycles saved (~9–11% of total emulation)**
+
+`advance_apu` is called on every M-cycle (~1.05M times/second). The APU already
+implements skip-ahead arithmetic for frequency timers, so it handles large cycle
+batches correctly.
+
+### What to do
+
+Add a `pending_apu_cycles: u16` accumulator to `Sm83`. Increment it instead of
+calling `apu.tick()` on every `tick_cycle`. Flush via `apu.tick(pending, ...)` at:
+- End of each instruction (in `tick_impl`, before the interrupt check)
+- Before any APU register write (the `tick_cycle_to_t3` path already handles
+  T-cycle precision for writes — flush before entering that path)
+
+This reduces APU tick call frequency from ~1M/s to ~350K/s (once per instruction
+on average), cutting function-call overhead by ~3× while the skip-ahead arithmetic
+absorbs the larger cycle batches.
+
+---
+
+## Priority 3 — PPU `build_stat` cache
+
+**Expected impact: ~20M cycles saved (~2% of total emulation)**
+
+`build_stat` recomputes the STAT register and STAT interrupt edge on every M-cycle
+(~1M times/second). The result only changes when LY changes (154×/frame), the PPU
+mode changes (~4×/scanline), or the game writes to STAT.
+
+### What to do
+
+Add `stat_cache: u8` and `stat_line_cache: bool` fields to `PpuPeripheral`.  
+Set a `stat_dirty: bool` flag when:
+- `self.ly` changes
+- `self.mode` changes  
+- A new `input.stat` differs from the previous call's stat
+
+In `build_stat`, return the cached value if `!stat_dirty`. Reset the flag after
+recomputing. This drops 99%+ of `build_stat` calls to a single branch.
+
+---
+
+## Priority 4 — `pending_bus_events` fixed-size array
+
+**Expected impact: small, reduces mem_write overhead**
+
+`pending_bus_events: Vec<BusEvent>` does a bounds-check + capacity-check on every
+I/O write. Since at most one I/O write can be pending per M-cycle before
+`route_bus_events` drains it, the queue never exceeds a handful of entries.
+
+### What to do
+
+Replace `Vec<BusEvent>` with `[BusEvent; 4]` + `len: usize`. Eliminates the heap
+indirection and capacity check on the write hot path.
+
+---
+
+## Priority 5 — `decode` remainder (longer term)
+
+After the above changes, decode/dispatch will still sit at ~350–400M cycles. The
+remaining cost is dominated by:
+
+- `read_next_pc` → `bus_read` → `tick_cycle` → `advance_peripherals` on every
+  opcode fetch and operand byte — this is inherently sequential and hard to batch
+- `resolve_r8` match per operand fetch
+
+Further gains here would require either:
+- **Instruction-level batching**: run N M-cycles of peripheral advance at the end
+  of each instruction rather than one per bus access (changes timing semantics,
+  needs careful correctness validation against blargg/mooneye)
+- **ROM read fast path**: detect that the PC is in ROM (0x0000–0x7FFF) and bypass
+  the full `bus_read` path for opcode fetches, since ROM reads have no side effects
+
+---
+
+## Summary table
+
+| # | Change | Est. savings | Effort | Unblocks |
+|---|---|---|---|---|
+| 1 | Async DMA display | ~2–3× fps | Medium | 60 fps ceiling |
+| 2 | APU cycle batching | ~80–100M cycles | Small | — |
+| 3 | PPU build_stat cache | ~20M cycles | Small | — |
+| 4 | Fixed pending_bus_events | small | Trivial | — |
+| 5 | Instruction-level tick batching | ~100M+ cycles | Large | — |

--- a/platform/pico2w/src/display/mod.rs
+++ b/platform/pico2w/src/display/mod.rs
@@ -17,7 +17,7 @@ pub mod fb;
 use embedded_graphics::draw_target::DrawTarget;
 use embedded_graphics::geometry::{Dimensions, Point, Size};
 use embedded_graphics::pixelcolor::Rgb565;
-use embedded_graphics::prelude::RgbColor;
+use embedded_graphics::prelude::{IntoStorage, RgbColor};
 use embedded_graphics::primitives::Rectangle;
 
 // ---------------------------------------------------------------------------
@@ -63,6 +63,21 @@ pub struct Display<D> {
     inner: D,
 }
 
+/// Pre-scale a Game Boy framebuffer (160×144, palette indices) to 240×216 Rgb565.
+///
+/// Stores raw `u16` Rgb565 storage values. Pass the result to
+/// [`Display::render_game_only_scaled`] or, in Phase C, directly to DMA.
+pub fn scale_to_rgb565(src: &[u8; 23040], dst: &mut [u16; 51840]) {
+    for sy in 0..216usize {
+        let gy = sy * 2 / 3;
+        let src_row = &src[gy * 160..(gy + 1) * 160];
+        let dst_row = &mut dst[sy * 240..(sy + 1) * 240];
+        for sx in 0..240usize {
+            dst_row[sx] = dmg_color(src_row[sx * 2 / 3]).into_storage();
+        }
+    }
+}
+
 impl<D: DrawTarget<Color = Rgb565> + Dimensions> Display<D> {
     pub fn from_draw_target(inner: D) -> Self {
         Self { inner }
@@ -96,6 +111,19 @@ impl<D: DrawTarget<Color = Rgb565> + Dimensions> Display<D> {
     /// top/bottom bars. Call [`draw_letterbox_bars`] once before the game loop.
     pub fn render_game_only(&mut self, fb: &[u8; 23040]) {
         self.fill_scaled_frame(fb);
+    }
+
+    /// Render a pre-scaled 240×216 frame from a [`scale_to_rgb565`] buffer.
+    ///
+    /// Eliminates per-pixel scaling work during the SPI transfer. The buffer
+    /// holds raw `Rgb565` storage values produced by [`scale_to_rgb565`].
+    pub fn render_game_only_scaled(&mut self, buf: &[u16; 51840]) {
+        use embedded_graphics::pixelcolor::raw::RawU16;
+        let rect = Rectangle::new(
+            Point::new(0, Y_OFFSET),
+            Size::new(SCALED_W as u32, SCALED_H as u32),
+        );
+        let _ = self.inner.fill_contiguous(&rect, buf.iter().map(|&v| Rgb565::from(RawU16::new(v))));
     }
 
     fn fill_bar(&mut self, y: i32, height: i32, color: Rgb565) {

--- a/platform/pico2w/src/main.rs
+++ b/platform/pico2w/src/main.rs
@@ -32,6 +32,7 @@ use rustyboy_core::cpu::sm83::Sm83;
 use rustyboy_core::memory::{GameBoyMemory, StreamingCartridge};
 use rustyboy_pico2w::audio::{AudioBuffers, SAMPLE_RATE};
 use rustyboy_pico2w::display::hw::HwDisplay;
+use rustyboy_pico2w::display::scale_to_rgb565;
 use rustyboy_pico2w::flash_rom::{
     new_onboard_flash, probe_staged_rom, stage_rom_from_reader, FlashRomReader,
 };
@@ -70,6 +71,14 @@ async fn main(_spawner: Spawner) {
         static mut HEAP_MEM: [MaybeUninit<u8>; HEAP_SIZE] = [MaybeUninit::uninit(); HEAP_SIZE];
         unsafe { HEAP.init(core::ptr::addr_of!(HEAP_MEM) as usize, HEAP_SIZE) }
     }
+
+    // Allocate the pre-scaled display frame buffer from the heap so it does not
+    // live in .bss and eat into the stack guard region.
+    let frame_buf: &'static mut [u16; 51840] = {
+        let layout = core::alloc::Layout::new::<[u16; 51840]>();
+        let ptr = unsafe { alloc::alloc::alloc_zeroed(layout) } as *mut [u16; 51840];
+        unsafe { alloc::boxed::Box::leak(alloc::boxed::Box::from_raw(ptr)) }
+    };
 
     let p = {
         use embassy_rp::clocks::ClockConfig;
@@ -236,8 +245,19 @@ async fn main(_spawner: Spawner) {
             warn!("menu combo triggered");
         }
 
-        // Render the game area.  Letterbox bars are static and not repainted.
-        hw_disp.inner.render_game_only(cpu.framebuffer());
+        // Pre-scale into the static buffer then push to display.
+        // Letterbox bars are static and not repainted.
+        #[cfg(feature = "perf")]
+        let scale_start = perf::perf_cycle_read();
+        scale_to_rgb565(cpu.framebuffer(), frame_buf);
+        #[cfg(feature = "perf")]
+        tracker.record_scale(perf::perf_cycle_read().wrapping_sub(scale_start));
+
+        #[cfg(feature = "perf")]
+        let render_start = perf::perf_cycle_read();
+        hw_disp.inner.render_game_only_scaled(frame_buf);
+        #[cfg(feature = "perf")]
+        tracker.record_render(perf::perf_cycle_read().wrapping_sub(render_start));
 
         // Convert APU f32 output into I2S-packed u32 words for the next DMA.
         let samples = cpu.drain_audio_samples();

--- a/platform/pico2w/src/perf.rs
+++ b/platform/pico2w/src/perf.rs
@@ -7,6 +7,10 @@ use rustyboy_core::cpu::sm83::Sm83;
 pub struct PerfTracker {
     frame_count: u32,
     window_start: Instant,
+    #[cfg(feature = "perf")]
+    scale_cycles: u64,
+    #[cfg(feature = "perf")]
+    render_cycles: u64,
 }
 
 impl PerfTracker {
@@ -14,7 +18,23 @@ impl PerfTracker {
         Self {
             frame_count: 0,
             window_start: Instant::now(),
+            #[cfg(feature = "perf")]
+            scale_cycles: 0,
+            #[cfg(feature = "perf")]
+            render_cycles: 0,
         }
+    }
+
+    /// Accumulate DWT cycles spent in `scale_to_rgb565` for one frame.
+    #[cfg(feature = "perf")]
+    pub fn record_scale(&mut self, cycles: u32) {
+        self.scale_cycles += cycles as u64;
+    }
+
+    /// Accumulate DWT cycles spent in `render_game_only_scaled` for one frame.
+    #[cfg(feature = "perf")]
+    pub fn record_render(&mut self, cycles: u32) {
+        self.render_cycles += cycles as u64;
     }
 
     pub fn tick(&mut self, cpu: &mut Sm83) {
@@ -48,6 +68,18 @@ impl PerfTracker {
                 "apu breakdown — frame_seq={} pulse={} wave={} noise={} mix={}",
                 ap.frame_seq, ap.pulse, ap.wave, ap.noise, ap.mix
             );
+
+            // At 250 MHz, divide cycles by 250_000 to get milliseconds.
+            let display_total = self.scale_cycles + self.render_cycles;
+            info!(
+                "display/60f — {}ms total (scale={}ms fill={}ms) avg {}ms/frame",
+                display_total / 250_000,
+                self.scale_cycles / 250_000,
+                self.render_cycles / 250_000,
+                display_total / 250_000 / 60,
+            );
+            self.scale_cycles = 0;
+            self.render_cycles = 0;
         }
 
         // Suppress unused-variable warning when only `fps` (not `perf`) is enabled.


### PR DESCRIPTION
## Summary

- **Phase A**: Added DWT instrumentation to `perf.rs` measuring scale and fill steps separately. Profiling showed display costs 46ms/frame — ~13ms raw SPI and ~33ms iterator overhead from the per-pixel 1.5× scale math running inside `fill_contiguous`.
- **Phase B**: Added `scale_to_rgb565` free function and `render_game_only_scaled` method to pre-scale the 160×144 GB framebuffer into a `[u16; 51840]` buffer once per VBlank, eliminating the per-pixel scaling math during the SPI transfer. Display drops from 46ms → 37ms/frame (8–10 fps vs 7).
- **Bug found**: A `static mut FRAME_BUF` in BSS reduced stack headroom from ~192KB to ~89KB, causing a stack overflow during ROM loading that corrupted `CLOCKS.sys` and panicked in `PioI2sOut::new`. Fixed by heap-allocating the buffer via `alloc_zeroed` + `Box::leak`.
- **Plan doc**: Added `docs/display-dma-plan.md` capturing the full Phase A→C design rationale (DMA on Core 0, not Core 1).

## What's next (Phase C)

The `fill_contiguous` step is still 33.7ms/frame because mipidsi's `U16BEIter` path issues 32-pixel chunked SPI writes. Phase C will bypass this entirely: switch SPI1 to async DMA mode (`DMA_CH1`), add `send_frame_raw()` that issues CASET/PASET/RAMWR then DMA-blasts the pre-scaled buffer, and overlap the transfer with emulation. Expected: ~15fps.

## Test plan

- [x] Built release with `--features perf` — no warnings
- [x] Flashed to Pico 2W — boots clean, no panic
- [x] Verified `display/60f` log shows `scale=222ms fill=2020ms` (37ms/frame avg)
- [x] Confirmed fps 8–10 (up from 7 in Phase A baseline)
- [x] Verified stack headroom restored to ~192KB (`_stack_end = 0x20050A4C`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)