### PR TITLE
Add DMA-driven Pico 2W display path

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2723,6 +2723,7 @@ dependencies = [
 name = "rustyboy-pico2w"
 version = "0.1.0"
 dependencies = [
+ "bytemuck",
  "cortex-m",
  "cortex-m-rt",
  "defmt",

--- a/core/src/cpu/perf.rs
+++ b/core/src/cpu/perf.rs
@@ -1,11 +1,22 @@
-// Read the cycle counter. Implementation is provided by the platform crate.
-// On pico2w this reads the ARM DWT CYCCNT register.
-// With LTO the call inlines to a single register read at zero extra cost.
+// Read the cycle counter. Bare-metal platforms provide the implementation,
+// while host builds use a cheap monotonic fallback so tests and coverage can
+// link with `perf` enabled.
+#[cfg(target_os = "none")]
 extern "C" {
     fn perf_cycle_read() -> u32;
 }
 
+#[cfg(target_os = "none")]
 #[inline(always)]
 pub fn cyccnt() -> u32 {
     unsafe { perf_cycle_read() }
+}
+
+#[cfg(not(target_os = "none"))]
+#[inline(always)]
+pub fn cyccnt() -> u32 {
+    use core::sync::atomic::{AtomicU32, Ordering};
+
+    static HOST_CYCLE_COUNTER: AtomicU32 = AtomicU32::new(0);
+    HOST_CYCLE_COUNTER.fetch_add(1, Ordering::Relaxed)
 }

--- a/platform/pico2w/Cargo.toml
+++ b/platform/pico2w/Cargo.toml
@@ -19,6 +19,8 @@ oc-266 = []
 fps = []
 # Enable all profiling: implies fps and enables core APU cycle counters.
 perf = ["fps", "rustyboy-core/perf"]
+# Enable stack sentinel / collision detection instrumentation.
+stack-probe = []
 
 # ---------------------------------------------------------------------------
 # Cross-platform dependencies (compile on any target, including host tests)
@@ -67,3 +69,4 @@ embedded-sdmmc = "0.9.0"
 mipidsi = "0.8"
 display-interface-spi = "0.5"
 embedded-hal-bus = "0.1"
+bytemuck = { version = "1", default-features = false }

--- a/platform/pico2w/src/display/hw.rs
+++ b/platform/pico2w/src/display/hw.rs
@@ -96,6 +96,15 @@ impl<'d> HwDisplay<'d> {
 // Sent MSB-first over SPI: [0x08, 0xC4] → ILI9341 decodes R=1 G=6 B=4. ✓
 const C3_BE: [u8; 2] = [0x08, 0xC4];
 const BLACK_BE: [u8; 2] = [0x00, 0x00];
+const DISPLAY_X_END: u16 = 239;
+const DISPLAY_Y_END: u16 = 319;
+const GAME_Y_START: u16 = 52;
+const GAME_Y_END: u16 = 267;
+const TOP_BAR_Y_END: u16 = GAME_Y_START - 1;
+const BOTTOM_BAR_Y_START: u16 = GAME_Y_END + 1;
+const DISPLAY_ROW_PIXELS: usize = 240;
+const LETTERBOX_ROWS: usize = 52;
+const ROW_BYTES: usize = DISPLAY_ROW_PIXELS * 2;
 
 pub struct GameDisplay<'d> {
     spi: Spi<'d, SPI1, Async>,
@@ -160,15 +169,15 @@ impl<'d> GameDisplay<'d> {
         info!("display: drawing letterbox bars");
 
         // Top bar: rows 0..51, colour C3
-        self.set_window(0, 0, 239, 51).await;
+        self.set_window(0, 0, DISPLAY_X_END, TOP_BAR_Y_END).await;
         self.write_command(0x2C, &[]).await;
-        self.fill_rect_raw(52 * 240, &C3_BE).await;
+        self.fill_rect_raw(LETTERBOX_ROWS * DISPLAY_ROW_PIXELS, &C3_BE).await;
         info!("display: top bar done");
 
         // Bottom bar: rows 268..319, colour black
-        self.set_window(0, 268, 239, 319).await;
+        self.set_window(0, BOTTOM_BAR_Y_START, DISPLAY_X_END, DISPLAY_Y_END).await;
         self.write_command(0x2C, &[]).await;
-        self.fill_rect_raw(52 * 240, &BLACK_BE).await;
+        self.fill_rect_raw(LETTERBOX_ROWS * DISPLAY_ROW_PIXELS, &BLACK_BE).await;
         info!("display: letterbox bars done");
     }
 
@@ -178,8 +187,7 @@ impl<'d> GameDisplay<'d> {
     /// [`super::scale_to_rgb565`]. Returns a future; `.await` it after doing
     /// other work to overlap the ~13 ms transfer with emulation.
     pub async fn send_frame_raw(&mut self, buf: &[u16; 51840]) {
-        // CASET 0..239 / PASET 52..267 (Y_OFFSET=52, 52+216-1=267=0x010B)
-        self.set_window(0, 52, 239, 267).await;
+        self.set_window(0, GAME_Y_START, DISPLAY_X_END, GAME_Y_END).await;
         self.write_command(0x2C, &[]).await;
 
         self.dc.set_high();
@@ -212,14 +220,14 @@ impl<'d> GameDisplay<'d> {
 
     async fn fill_rect_raw(&mut self, n_pixels: usize, pixel_be: &[u8; 2]) {
         // Send 240 pixels (480 bytes) per row to keep the stack usage bounded.
-        let mut row = [0u8; 480];
+        let mut row = [0u8; ROW_BYTES];
         let mut i = 0;
-        while i < 480 {
+        while i < ROW_BYTES {
             row[i]     = pixel_be[0];
             row[i + 1] = pixel_be[1];
             i += 2;
         }
-        let n_rows = n_pixels / 240;
+        let n_rows = n_pixels / DISPLAY_ROW_PIXELS;
         self.dc.set_high();
         self.cs.set_low();
         for _ in 0..n_rows {

--- a/platform/pico2w/src/display/hw.rs
+++ b/platform/pico2w/src/display/hw.rs
@@ -4,10 +4,11 @@
 //! for the embedded target — host builds and tests use [`super::fb::FbDisplay`]
 //! instead.
 
-use defmt::info;
+use defmt::{info, warn};
 use embassy_rp::gpio::{Level, Output};
-use embassy_rp::peripherals::{PIN_10, PIN_11, PIN_12, PIN_13, PIN_8, PIN_9, SPI1};
-use embassy_rp::spi::{Blocking, Config as SpiConfig, Spi};
+use embassy_rp::peripherals::{DMA_CH1, PIN_10, PIN_11, PIN_12, PIN_13, PIN_8, PIN_9, SPI1};
+use embassy_rp::spi::{Async, Blocking, Config as SpiConfig, Spi};
+use embassy_rp::{dma, interrupt};
 use embassy_rp::Peri;
 
 use display_interface_spi::SPIInterface;
@@ -83,5 +84,147 @@ impl<'d> HwDisplay<'d> {
             frame += 1;
             embassy_time::Timer::after(embassy_time::Duration::from_millis(16)).await;
         }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// GameDisplay — async SPI with raw ILI9341 protocol for the hot path
+// ---------------------------------------------------------------------------
+
+// C3 (darkest DMG palette colour, #081820) in big-endian RGB565 bytes.
+// Rgb565::new(1, 6, 4).into_storage() = 0x08C4; swap_bytes → 0xC408.
+// Sent MSB-first over SPI: [0x08, 0xC4] → ILI9341 decodes R=1 G=6 B=4. ✓
+const C3_BE: [u8; 2] = [0x08, 0xC4];
+const BLACK_BE: [u8; 2] = [0x00, 0x00];
+
+pub struct GameDisplay<'d> {
+    spi: Spi<'d, SPI1, Async>,
+    cs: Output<'d>,
+    dc: Output<'d>,
+    _rst: Output<'d>,
+    _bl: Output<'d>,
+}
+
+impl<'d> GameDisplay<'d> {
+    /// Initialise async SPI for the game loop after `HwDisplay` has been dropped.
+    ///
+    /// # Safety
+    /// `HwDisplay` must have been fully dropped before calling this so that SPI1
+    /// and all display GPIO pins are free to be re-claimed.
+    pub unsafe fn new_after_splash(
+        clk: Peri<'d, PIN_10>,
+        mosi: Peri<'d, PIN_11>,
+        cs_pin: Peri<'d, PIN_9>,
+        dc_pin: Peri<'d, PIN_8>,
+        rst_pin: Peri<'d, PIN_12>,
+        bl_pin: Peri<'d, PIN_13>,
+        spi1: Peri<'d, SPI1>,
+        dma: Peri<'d, DMA_CH1>,
+        irqs: impl interrupt::typelevel::Binding<
+            interrupt::typelevel::DMA_IRQ_0,
+            dma::InterruptHandler<DMA_CH1>,
+        > + 'd,
+    ) -> Self {
+        // The DMA_IRQ_0 ISR now calls BOTH InterruptHandler<DMA_CH0> and
+        // InterruptHandler<DMA_CH1> unconditionally (combined bind_interrupts!).
+        // CH1's on_interrupt panics if ctrl_trig.ahb_error() is set. Clear any
+        // stale error/pending-interrupt state before Spi::new_txonly enables
+        // the CH1 interrupt in INTE0.
+        let ahb_err = rp_pac::DMA.ch(1).ctrl_trig().read().ahb_error();
+        if ahb_err {
+            warn!("DMA CH1 ahb_error set before init — aborting to clear");
+            // Write bit 1 to CHAN_ABORT to trigger a CH1 abort.
+            rp_pac::DMA.chan_abort().write_value(rp_pac::dma::regs::ChanAbort(1u32 << 1));
+            while rp_pac::DMA.chan_abort().read().chan_abort() & (1u16 << 1) != 0 {}
+        }
+        // Clear any pending CH1 interrupt flag in INTS0 (W1C: write 1 to clear).
+        rp_pac::DMA.ints(0).write_value(1u32 << 1);
+
+        let mut cfg = SpiConfig::default();
+        cfg.frequency = 62_500_000;
+
+        let spi = Spi::new_txonly(spi1, clk, mosi, dma, irqs, cfg);
+        let cs = Output::new(cs_pin, Level::High);
+        let dc = Output::new(dc_pin, Level::Low);
+        let rst = Output::new(rst_pin, Level::High);
+        let bl = Output::new(bl_pin, Level::High);
+
+        info!("display: async SPI re-initialised for game loop");
+        Self { spi, cs, dc, _rst: rst, _bl: bl }
+    }
+
+    /// Paint the static letterbox bars (top C3, bottom black) once before the
+    /// game loop. The bars are never repainted — `send_frame_raw` only touches
+    /// the 240×216 game area.
+    pub async fn draw_letterbox_bars(&mut self) {
+        info!("display: drawing letterbox bars");
+
+        // Top bar: rows 0..51, colour C3
+        self.set_window(0, 0, 239, 51).await;
+        self.write_command(0x2C, &[]).await;
+        self.fill_rect_raw(52 * 240, &C3_BE).await;
+        info!("display: top bar done");
+
+        // Bottom bar: rows 268..319, colour black
+        self.set_window(0, 268, 239, 319).await;
+        self.write_command(0x2C, &[]).await;
+        self.fill_rect_raw(52 * 240, &BLACK_BE).await;
+        info!("display: letterbox bars done");
+    }
+
+    /// Transfer a pre-scaled 240×216 frame to the display via async DMA.
+    ///
+    /// `buf` must contain big-endian RGB565 values as produced by
+    /// [`super::scale_to_rgb565`]. Returns a future; `.await` it after doing
+    /// other work to overlap the ~13 ms transfer with emulation.
+    pub async fn send_frame_raw(&mut self, buf: &[u16; 51840]) {
+        // CASET 0..239 / PASET 52..267 (Y_OFFSET=52, 52+216-1=267=0x010B)
+        self.set_window(0, 52, 239, 267).await;
+        self.write_command(0x2C, &[]).await;
+
+        self.dc.set_high();
+        self.cs.set_low();
+        // buf stores big-endian u16s; cast to bytes gives the correct SPI byte order.
+        self.spi.write(bytemuck::cast_slice(buf)).await.ok();
+        self.cs.set_high();
+    }
+
+    // --- helpers ---
+
+    async fn set_window(&mut self, x0: u16, y0: u16, x1: u16, y1: u16) {
+        let x_params = [(x0 >> 8) as u8, x0 as u8, (x1 >> 8) as u8, x1 as u8];
+        self.write_command(0x2A, &x_params).await;
+        let y_params = [(y0 >> 8) as u8, y0 as u8, (y1 >> 8) as u8, y1 as u8];
+        self.write_command(0x2B, &y_params).await;
+    }
+
+    async fn write_command(&mut self, cmd: u8, params: &[u8]) {
+        let cmd_buf = [cmd];
+        self.cs.set_low();
+        self.dc.set_low();
+        self.spi.write(&cmd_buf).await.ok();
+        if !params.is_empty() {
+            self.dc.set_high();
+            self.spi.write(params).await.ok();
+        }
+        self.cs.set_high();
+    }
+
+    async fn fill_rect_raw(&mut self, n_pixels: usize, pixel_be: &[u8; 2]) {
+        // Send 240 pixels (480 bytes) per row to keep the stack usage bounded.
+        let mut row = [0u8; 480];
+        let mut i = 0;
+        while i < 480 {
+            row[i]     = pixel_be[0];
+            row[i + 1] = pixel_be[1];
+            i += 2;
+        }
+        let n_rows = n_pixels / 240;
+        self.dc.set_high();
+        self.cs.set_low();
+        for _ in 0..n_rows {
+            self.spi.write(&row).await.ok();
+        }
+        self.cs.set_high();
     }
 }

--- a/platform/pico2w/src/display/mod.rs
+++ b/platform/pico2w/src/display/mod.rs
@@ -73,7 +73,9 @@ pub fn scale_to_rgb565(src: &[u8; 23040], dst: &mut [u16; 51840]) {
         let src_row = &src[gy * 160..(gy + 1) * 160];
         let dst_row = &mut dst[sy * 240..(sy + 1) * 240];
         for sx in 0..240usize {
-            dst_row[sx] = dmg_color(src_row[sx * 2 / 3]).into_storage();
+            // Store big-endian so bytemuck::cast_slice in send_frame_raw gives
+            // the correct SPI byte order without an extra copy.
+            dst_row[sx] = dmg_color(src_row[sx * 2 / 3]).into_storage().swap_bytes();
         }
     }
 }
@@ -123,7 +125,9 @@ impl<D: DrawTarget<Color = Rgb565> + Dimensions> Display<D> {
             Point::new(0, Y_OFFSET),
             Size::new(SCALED_W as u32, SCALED_H as u32),
         );
-        let _ = self.inner.fill_contiguous(&rect, buf.iter().map(|&v| Rgb565::from(RawU16::new(v))));
+        // buf stores big-endian u16s; swap back to native-endian before handing
+        // to mipidsi, which handles its own byte ordering.
+        let _ = self.inner.fill_contiguous(&rect, buf.iter().map(|&v| Rgb565::from(RawU16::new(v.swap_bytes()))));
     }
 
     fn fill_bar(&mut self, y: i32, height: i32, color: Rgb565) {

--- a/platform/pico2w/src/flash_rom.rs
+++ b/platform/pico2w/src/flash_rom.rs
@@ -1,10 +1,13 @@
 use core::fmt::Debug;
 
+use defmt::info;
 use embassy_rp::flash::{Blocking, Error as FlashError, Flash, ERASE_SIZE};
 use embassy_rp::peripherals::FLASH;
 use embassy_rp::Peri;
 
 use rustyboy_core::memory::RomReader;
+
+use crate::stack_probe;
 
 pub const FLASH_CAPACITY_BYTES: usize = 4 * 1024 * 1024;
 pub const FIRMWARE_SLOT_BYTES: usize = 512 * 1024;
@@ -63,9 +66,23 @@ impl RomReader for FlashRomReader<'_> {
             return Err(FlashRomReadError::OutOfBounds);
         }
 
+        let offset = (ROM_DATA_OFFSET + bank * ROM_BANK_BYTES) as u32;
+        let log_stack = stack_probe::read_bank_logging_enabled();
+        if log_stack {
+            info!("read_bank {}: offset=0x{:x}", bank, offset);
+        }
         self.flash
-            .blocking_read((ROM_DATA_OFFSET + bank * ROM_BANK_BYTES) as u32, buf)
+            .blocking_read(offset, buf)
             .map_err(|_| FlashRomReadError::OutOfBounds)?;
+        if log_stack {
+            info!(
+                "read_bank {}: done, cart_type=0x{:x} ram_size_code=0x{:x}",
+                bank,
+                buf[0x0147],
+                buf[0x0149]
+            );
+            stack_probe::log_read_bank_stack(bank);
+        }
 
         Ok(())
     }

--- a/platform/pico2w/src/flash_rom.rs
+++ b/platform/pico2w/src/flash_rom.rs
@@ -1,13 +1,10 @@
 use core::fmt::Debug;
 
-use defmt::info;
 use embassy_rp::flash::{Blocking, Error as FlashError, Flash, ERASE_SIZE};
 use embassy_rp::peripherals::FLASH;
 use embassy_rp::Peri;
 
 use rustyboy_core::memory::RomReader;
-
-use crate::stack_probe;
 
 pub const FLASH_CAPACITY_BYTES: usize = 4 * 1024 * 1024;
 pub const FIRMWARE_SLOT_BYTES: usize = 512 * 1024;
@@ -66,23 +63,9 @@ impl RomReader for FlashRomReader<'_> {
             return Err(FlashRomReadError::OutOfBounds);
         }
 
-        let offset = (ROM_DATA_OFFSET + bank * ROM_BANK_BYTES) as u32;
-        let log_stack = stack_probe::read_bank_logging_enabled();
-        if log_stack {
-            info!("read_bank {}: offset=0x{:x}", bank, offset);
-        }
         self.flash
-            .blocking_read(offset, buf)
+            .blocking_read((ROM_DATA_OFFSET + bank * ROM_BANK_BYTES) as u32, buf)
             .map_err(|_| FlashRomReadError::OutOfBounds)?;
-        if log_stack {
-            info!(
-                "read_bank {}: done, cart_type=0x{:x} ram_size_code=0x{:x}",
-                bank,
-                buf[0x0147],
-                buf[0x0149]
-            );
-            stack_probe::log_read_bank_stack(bank);
-        }
 
         Ok(())
     }

--- a/platform/pico2w/src/lib.rs
+++ b/platform/pico2w/src/lib.rs
@@ -8,3 +8,5 @@ pub mod flash_rom;
 pub mod input;
 #[cfg(target_arch = "arm")]
 pub mod sd;
+#[cfg(target_arch = "arm")]
+pub mod stack_probe;

--- a/platform/pico2w/src/main.rs
+++ b/platform/pico2w/src/main.rs
@@ -132,12 +132,10 @@ async fn main(_spawner: Spawner) {
         p.SPI1, p.PIN_10, p.PIN_11, p.PIN_9, p.PIN_8, p.PIN_12, p.PIN_13,
     );
     stack_probe::paint();
-    stack_probe::log("before splash");
     info!("starting splash");
     hw_disp.splash().await;
     drop(hw_disp); // release SPI1 and all display pins for re-use as async SPI
     stack_probe::paint();
-    stack_probe::log("before cart");
 
     // GP21=Up  GP22=Down  GP26=Left  GP27=Right
     // GP0=A    GP1=B      GP2=Start  GP3=Select
@@ -203,7 +201,6 @@ async fn main(_spawner: Spawner) {
             }
         }
     };
-    stack_probe::log("after cart");
 
     info!("building GameBoyMemory");
     let memory = GameBoyMemory::with_cartridge(alloc::boxed::Box::new(cart));
@@ -224,7 +221,6 @@ async fn main(_spawner: Spawner) {
             sp: 0xFFFE,
         })
         .with_dmg_state();
-    stack_probe::log("after cpu init");
     info!("ROM loaded, starting peripheral init");
 
     // I2S audio: GP14=BCLK  GP15=LRCLK  GP16=DIN  GP17=SD_MODE (MAX98357A).
@@ -249,7 +245,6 @@ async fn main(_spawner: Spawner) {
     i2s.start();
 
     stack_probe::paint();
-    stack_probe::log("before display dma init");
 
     // Re-initialise SPI1 as async for DMA-driven display transfers.
     // SAFETY: hw_disp was dropped above, SPI1 and all display pins are free.
@@ -264,7 +259,6 @@ async fn main(_spawner: Spawner) {
     };
     // Draw the static letterbox bars that the game loop never repaints.
     game_disp.draw_letterbox_bars().await;
-    stack_probe::log("after display dma init");
 
     info!("entering game loop");
 

--- a/platform/pico2w/src/main.rs
+++ b/platform/pico2w/src/main.rs
@@ -2,6 +2,18 @@
 #![no_main]
 extern crate alloc;
 
+// Capture the stacked exception frame so we can log the exact faulting PC.
+use core::future::Future;
+use core::task::{Context, Poll, RawWaker, RawWakerVTable, Waker};
+
+use cortex_m_rt::ExceptionFrame;
+#[cortex_m_rt::exception]
+unsafe fn HardFault(ef: &ExceptionFrame) -> ! {
+    defmt::error!("HardFault: PC=0x{:08x} LR=0x{:08x} PSR=0x{:08x}",
+        ef.pc(), ef.lr(), ef.xpsr());
+    loop {}
+}
+
 #[cfg(feature = "fps")]
 mod perf;
 
@@ -13,7 +25,7 @@ static HEAP: Heap = Heap::empty();
 use defmt::{error, info, warn};
 use embassy_executor::Spawner;
 use embassy_rp::gpio::{Level, Output};
-use embassy_rp::peripherals::{DMA_CH0, PIO0};
+use embassy_rp::peripherals::{DMA_CH0, DMA_CH1, PIN_10, PIN_11, PIN_12, PIN_13, PIN_8, PIN_9, PIO0, SPI1};
 use embassy_rp::pio::{InterruptHandler as PioIrqHandler, Pio};
 use embassy_rp::pio_programs::i2s::{PioI2sOut, PioI2sOutProgram};
 use embassy_rp::spi::{self, Spi};
@@ -31,13 +43,14 @@ use rustyboy_core::cpu::registers::{Flags, Registers};
 use rustyboy_core::cpu::sm83::Sm83;
 use rustyboy_core::memory::{GameBoyMemory, StreamingCartridge};
 use rustyboy_pico2w::audio::{AudioBuffers, SAMPLE_RATE};
-use rustyboy_pico2w::display::hw::HwDisplay;
+use rustyboy_pico2w::display::hw::{GameDisplay, HwDisplay};
 use rustyboy_pico2w::display::scale_to_rgb565;
 use rustyboy_pico2w::flash_rom::{
     new_onboard_flash, probe_staged_rom, stage_rom_from_reader, FlashRomReader,
 };
 use rustyboy_pico2w::input::{ButtonState, InputHandler};
 use rustyboy_pico2w::sd::{DummyClock, SdRomReader};
+use rustyboy_pico2w::stack_probe;
 
 #[cfg(feature = "oc-266")]
 const TARGET_SYS_HZ: u32 = 266_000_000;
@@ -52,7 +65,7 @@ const CYCLES_PER_FRAME: u64 = 70_224;
 
 bind_interrupts!(struct Irqs {
     PIO0_IRQ_0 => PioIrqHandler<PIO0>;
-    DMA_IRQ_0  => dma::InterruptHandler<DMA_CH0>;
+    DMA_IRQ_0  => dma::InterruptHandler<DMA_CH0>, dma::InterruptHandler<DMA_CH1>;
 });
 
 #[unsafe(link_section = ".bi_entries")]
@@ -63,11 +76,28 @@ pub static PICOTOOL_ENTRIES: [embassy_rp::binary_info::EntryAddr; 3] = [
     embassy_rp::binary_info::rp_program_build_attribute!(),
 ];
 
+unsafe fn noop_waker_clone(_: *const ()) -> RawWaker {
+    RawWaker::new(core::ptr::null(), &NOOP_WAKER_VTABLE)
+}
+
+unsafe fn noop_waker(_: *const ()) {}
+
+static NOOP_WAKER_VTABLE: RawWakerVTable =
+    RawWakerVTable::new(noop_waker_clone, noop_waker, noop_waker, noop_waker);
+
+fn poll_once<F: Future>(future: core::pin::Pin<&mut F>) -> bool {
+    let waker = unsafe { Waker::from_raw(RawWaker::new(core::ptr::null(), &NOOP_WAKER_VTABLE)) };
+    let mut cx = Context::from_waker(&waker);
+    matches!(future.poll(&mut cx), Poll::Ready(_))
+}
+
 #[embassy_executor::main]
 async fn main(_spawner: Spawner) {
     {
         use core::mem::MaybeUninit;
-        const HEAP_SIZE: usize = 256 * 1024;
+        // Reserve less heap so the main task and splash path have real stack
+        // headroom instead of growing down into HEAP_MEM.
+        const HEAP_SIZE: usize = 192 * 1024;
         static mut HEAP_MEM: [MaybeUninit<u8>; HEAP_SIZE] = [MaybeUninit::uninit(); HEAP_SIZE];
         unsafe { HEAP.init(core::ptr::addr_of!(HEAP_MEM) as usize, HEAP_SIZE) }
     }
@@ -101,7 +131,13 @@ async fn main(_spawner: Spawner) {
     let mut hw_disp = HwDisplay::new(
         p.SPI1, p.PIN_10, p.PIN_11, p.PIN_9, p.PIN_8, p.PIN_12, p.PIN_13,
     );
+    stack_probe::paint();
+    stack_probe::log("before splash");
+    info!("starting splash");
     hw_disp.splash().await;
+    drop(hw_disp); // release SPI1 and all display pins for re-use as async SPI
+    stack_probe::paint();
+    stack_probe::log("before cart");
 
     // GP21=Up  GP22=Down  GP26=Left  GP27=Right
     // GP0=A    GP1=B      GP2=Start  GP3=Select
@@ -157,6 +193,7 @@ async fn main(_spawner: Spawner) {
         info
     };
 
+    info!("building StreamingCartridge");
     let cart = match StreamingCartridge::new(FlashRomReader::new(onboard_flash, flash_info)) {
         Ok(c) => c,
         Err(e) => {
@@ -166,9 +203,13 @@ async fn main(_spawner: Spawner) {
             }
         }
     };
+    stack_probe::log("after cart");
 
+    info!("building GameBoyMemory");
     let memory = GameBoyMemory::with_cartridge(alloc::boxed::Box::new(cart));
+    info!("building OpCodeDecoder");
     let decoder = alloc::boxed::Box::new(OpCodeDecoder::new());
+    info!("building Sm83 CPU");
     let mut cpu = Sm83::new(alloc::boxed::Box::new(memory), decoder)
         .with_registers(Registers {
             a: 0x01,
@@ -183,7 +224,8 @@ async fn main(_spawner: Spawner) {
             sp: 0xFFFE,
         })
         .with_dmg_state();
-    info!("ROM loaded, entering game loop");
+    stack_probe::log("after cpu init");
+    info!("ROM loaded, starting peripheral init");
 
     // I2S audio: GP14=BCLK  GP15=LRCLK  GP16=DIN  GP17=SD_MODE (MAX98357A).
     // Drive SD_MODE high to enable the amplifier.
@@ -206,8 +248,25 @@ async fn main(_spawner: Spawner) {
     );
     i2s.start();
 
-    // Draw static letterbox bars once; game loop only repaints the 240×216 area.
-    hw_disp.inner.draw_letterbox_bars();
+    stack_probe::paint();
+    stack_probe::log("before display dma init");
+
+    // Re-initialise SPI1 as async for DMA-driven display transfers.
+    // SAFETY: hw_disp was dropped above, SPI1 and all display pins are free.
+    let mut game_disp = unsafe {
+        GameDisplay::new_after_splash(
+            PIN_10::steal(), PIN_11::steal(),
+            PIN_9::steal(),  PIN_8::steal(),
+            PIN_12::steal(), PIN_13::steal(),
+            SPI1::steal(),   p.DMA_CH1,
+            Irqs,
+        )
+    };
+    // Draw the static letterbox bars that the game loop never repaints.
+    game_disp.draw_letterbox_bars().await;
+    stack_probe::log("after display dma init");
+
+    info!("entering game loop");
 
     #[cfg(feature = "perf")]
     perf::init_dwt();
@@ -219,12 +278,27 @@ async fn main(_spawner: Spawner) {
     let mut tracker = perf::PerfTracker::new();
 
     loop {
-        // Start DMA transfer of last frame's audio output while we fill the
-        // other buffer from the current frame's APU samples.
-        let (front_buf, back_buf) = audio_buffers.front_back_buffers();
-        let dma_future = i2s.write(front_buf);
+        stack_probe::check_current_sp("game loop");
 
-        // Run exactly one Game Boy frame (70 224 T-cycles ≈ 16.74 ms).
+        // Pre-scale current frame into the buffer (~0.5 ms).
+        #[cfg(feature = "perf")]
+        let scale_start = perf::perf_cycle_read();
+        scale_to_rgb565(cpu.framebuffer(), frame_buf);
+        #[cfg(feature = "perf")]
+        tracker.record_scale(perf::perf_cycle_read().wrapping_sub(scale_start));
+
+        // Poll once to arm the DMA in hardware before we start emulating.
+        // The future remains pending while the transfer runs in the background.
+        let mut disp_future = core::pin::pin!(game_disp.send_frame_raw(frame_buf));
+        let _ = poll_once(disp_future.as_mut());
+
+        // Start audio DMA for the front buffer concurrently.
+        let (front_buf, back_buf) = audio_buffers.front_back_buffers();
+        let mut audio_future = core::pin::pin!(i2s.write(front_buf));
+        let _ = poll_once(audio_future.as_mut());
+
+        // Run exactly one Game Boy frame (~16.74 ms).
+        // Both DMAs run while the CPU emulates — display finishes at ~13 ms.
         let frame_start = cpu.cycle_counter();
         while cpu.cycle_counter().wrapping_sub(frame_start) < CYCLES_PER_FRAME {
             let _ = cpu.tick();
@@ -245,26 +319,21 @@ async fn main(_spawner: Spawner) {
             warn!("menu combo triggered");
         }
 
-        // Pre-scale into the static buffer then push to display.
-        // Letterbox bars are static and not repainted.
-        #[cfg(feature = "perf")]
-        let scale_start = perf::perf_cycle_read();
-        scale_to_rgb565(cpu.framebuffer(), frame_buf);
-        #[cfg(feature = "perf")]
-        tracker.record_scale(perf::perf_cycle_read().wrapping_sub(scale_start));
-
-        #[cfg(feature = "perf")]
-        let render_start = perf::perf_cycle_read();
-        hw_disp.inner.render_game_only_scaled(frame_buf);
-        #[cfg(feature = "perf")]
-        tracker.record_render(perf::perf_cycle_read().wrapping_sub(render_start));
-
-        // Convert APU f32 output into I2S-packed u32 words for the next DMA.
+        // Fill audio back-buffer from APU output.
         let samples = cpu.drain_audio_samples();
         audio_buffers.queue_next_frame(&samples, back_buf);
 
-        // Await DMA completion — this naturally paces the loop to ~59.7 fps.
-        dma_future.await;
+        // Await display DMA — should already be done (~13 ms < ~16.7 ms emulation).
+        // record_render captures the residual wait; ~0 ms confirms Phase C is working.
+        #[cfg(feature = "perf")]
+        let render_start = perf::perf_cycle_read();
+        disp_future.as_mut().await;
+        #[cfg(feature = "perf")]
+        tracker.record_render(perf::perf_cycle_read().wrapping_sub(render_start));
+
+        // Await audio DMA — paces the loop to ~59.7 fps.
+        audio_future.as_mut().await;
+
         watchdog.feed(Duration::from_millis(5_000));
 
         #[cfg(feature = "fps")]

--- a/platform/pico2w/src/stack_probe.rs
+++ b/platform/pico2w/src/stack_probe.rs
@@ -4,41 +4,18 @@ mod imp {
     use core::sync::atomic::{AtomicBool, Ordering};
 
     use cortex_m::register::{control, msp, psp};
-    use defmt::{info, panic, warn};
+    use defmt::{panic, warn};
 
     const STACK_SENTINEL: u8 = 0xA5;
     const PAINT_SAFETY_MARGIN_BYTES: usize = 512;
     const LOW_HEADROOM_WARN_BYTES: usize = 16 * 1024;
     const COLLISION_GUARD_BYTES: usize = 4 * 1024;
 
-    static READ_BANK_STACK_LOGGING: AtomicBool = AtomicBool::new(false);
     static LOW_HEADROOM_WARNED: AtomicBool = AtomicBool::new(false);
 
     unsafe extern "C" {
         static __sheap: u8;
         static _stack_start: u8;
-    }
-
-    #[derive(Clone, Copy)]
-    pub struct StackUsage {
-        pub current_sp: usize,
-        pub current_msp: usize,
-        pub current_psp: usize,
-        pub thread_uses_psp: bool,
-        pub bottom: usize,
-        pub top: usize,
-        pub untouched_bytes: usize,
-        pub peak_used_bytes: usize,
-    }
-
-    impl StackUsage {
-        pub fn budget_bytes(&self) -> usize {
-            self.top - self.bottom
-        }
-
-        pub fn headroom_bytes(&self) -> usize {
-            self.untouched_bytes
-        }
     }
 
     #[derive(Clone, Copy)]
@@ -52,24 +29,27 @@ mod imp {
         unsafe { (&__sheap as *const u8 as usize, &_stack_start as *const u8 as usize) }
     }
 
-    fn active_thread_sp() -> (usize, usize, usize, bool) {
+    fn active_thread_sp() -> usize {
         let msp = msp::read() as usize;
         let psp = psp::read() as usize;
-        let thread_uses_psp = control::read().spsel().is_psp();
-        let current_sp = if thread_uses_psp { psp } else { msp };
-        (current_sp, msp, psp, thread_uses_psp)
+        if control::read().spsel().is_psp() {
+            psp
+        } else {
+            msp
+        }
     }
 
     fn current_state() -> CurrentStackState {
         let (bottom, _) = bounds();
-        let (current_sp, _, _, _) = active_thread_sp();
-        CurrentStackState { current_sp, bottom }
+        CurrentStackState {
+            current_sp: active_thread_sp(),
+            bottom,
+        }
     }
 
     pub fn paint() {
         let (bottom, top) = bounds();
-        let (current_sp, _, _, _) = active_thread_sp();
-        let paint_end = current_sp
+        let paint_end = active_thread_sp()
             .saturating_sub(PAINT_SAFETY_MARGIN_BYTES)
             .clamp(bottom, top);
         let len = paint_end.saturating_sub(bottom);
@@ -81,47 +61,6 @@ mod imp {
         unsafe {
             ptr::write_bytes(bottom as *mut u8, STACK_SENTINEL, len);
         }
-    }
-
-    pub fn snapshot() -> StackUsage {
-        let (bottom, top) = bounds();
-        let (current_sp, current_msp, current_psp, thread_uses_psp) = active_thread_sp();
-        let mut probe = bottom;
-        while probe < top {
-            let byte = unsafe { ptr::read_volatile(probe as *const u8) };
-            if byte != STACK_SENTINEL {
-                break;
-            }
-            probe += 1;
-        }
-
-        let untouched_bytes = probe - bottom;
-        StackUsage {
-            current_sp,
-            current_msp,
-            current_psp,
-            thread_uses_psp,
-            bottom,
-            top,
-            untouched_bytes,
-            peak_used_bytes: (top - bottom).saturating_sub(untouched_bytes),
-        }
-    }
-
-    pub fn log(label: &'static str) {
-        let usage = snapshot();
-        info!(
-            "stack {}: sp=0x{:08x} msp=0x{:08x} psp=0x{:08x} using_psp={} budget={}B peak={}B headroom={}B bottom=0x{:08x}",
-            label,
-            usage.current_sp,
-            usage.current_msp,
-            usage.current_psp,
-            usage.thread_uses_psp,
-            usage.budget_bytes(),
-            usage.peak_used_bytes,
-            usage.headroom_bytes(),
-            usage.bottom,
-        );
     }
 
     pub fn check_current_sp(label: &'static str) {
@@ -150,49 +89,13 @@ mod imp {
             );
         }
     }
-
-    pub fn log_read_bank_stack(bank: usize) {
-        let usage = snapshot();
-        info!(
-            "read_bank {} stack: sp=0x{:08x} peak={}B headroom={}B",
-            bank,
-            usage.current_sp,
-            usage.peak_used_bytes,
-            usage.headroom_bytes(),
-        );
-    }
-
-    pub fn set_read_bank_logging(enabled: bool) {
-        READ_BANK_STACK_LOGGING.store(enabled, Ordering::Relaxed);
-    }
-
-    pub fn read_bank_logging_enabled() -> bool {
-        READ_BANK_STACK_LOGGING.load(Ordering::Relaxed)
-    }
 }
 
 #[cfg(not(feature = "stack-probe"))]
 mod imp {
     pub fn paint() {}
 
-    pub fn log(_label: &'static str) {}
-
     pub fn check_current_sp(_label: &'static str) {}
-
-    pub fn log_read_bank_stack(_bank: usize) {}
-
-    pub fn set_read_bank_logging(_enabled: bool) {}
-
-    pub fn read_bank_logging_enabled() -> bool {
-        false
-    }
 }
 
-pub use imp::{
-    check_current_sp,
-    log,
-    log_read_bank_stack,
-    paint,
-    read_bank_logging_enabled,
-    set_read_bank_logging,
-};
+pub use imp::{check_current_sp, paint};

--- a/platform/pico2w/src/stack_probe.rs
+++ b/platform/pico2w/src/stack_probe.rs
@@ -1,0 +1,198 @@
+#[cfg(feature = "stack-probe")]
+mod imp {
+    use core::ptr;
+    use core::sync::atomic::{AtomicBool, Ordering};
+
+    use cortex_m::register::{control, msp, psp};
+    use defmt::{info, panic, warn};
+
+    const STACK_SENTINEL: u8 = 0xA5;
+    const PAINT_SAFETY_MARGIN_BYTES: usize = 512;
+    const LOW_HEADROOM_WARN_BYTES: usize = 16 * 1024;
+    const COLLISION_GUARD_BYTES: usize = 4 * 1024;
+
+    static READ_BANK_STACK_LOGGING: AtomicBool = AtomicBool::new(false);
+    static LOW_HEADROOM_WARNED: AtomicBool = AtomicBool::new(false);
+
+    unsafe extern "C" {
+        static __sheap: u8;
+        static _stack_start: u8;
+    }
+
+    #[derive(Clone, Copy)]
+    pub struct StackUsage {
+        pub current_sp: usize,
+        pub current_msp: usize,
+        pub current_psp: usize,
+        pub thread_uses_psp: bool,
+        pub bottom: usize,
+        pub top: usize,
+        pub untouched_bytes: usize,
+        pub peak_used_bytes: usize,
+    }
+
+    impl StackUsage {
+        pub fn budget_bytes(&self) -> usize {
+            self.top - self.bottom
+        }
+
+        pub fn headroom_bytes(&self) -> usize {
+            self.untouched_bytes
+        }
+    }
+
+    #[derive(Clone, Copy)]
+    struct CurrentStackState {
+        current_sp: usize,
+        bottom: usize,
+    }
+
+    #[inline]
+    fn bounds() -> (usize, usize) {
+        unsafe { (&__sheap as *const u8 as usize, &_stack_start as *const u8 as usize) }
+    }
+
+    fn active_thread_sp() -> (usize, usize, usize, bool) {
+        let msp = msp::read() as usize;
+        let psp = psp::read() as usize;
+        let thread_uses_psp = control::read().spsel().is_psp();
+        let current_sp = if thread_uses_psp { psp } else { msp };
+        (current_sp, msp, psp, thread_uses_psp)
+    }
+
+    fn current_state() -> CurrentStackState {
+        let (bottom, _) = bounds();
+        let (current_sp, _, _, _) = active_thread_sp();
+        CurrentStackState { current_sp, bottom }
+    }
+
+    pub fn paint() {
+        let (bottom, top) = bounds();
+        let (current_sp, _, _, _) = active_thread_sp();
+        let paint_end = current_sp
+            .saturating_sub(PAINT_SAFETY_MARGIN_BYTES)
+            .clamp(bottom, top);
+        let len = paint_end.saturating_sub(bottom);
+
+        if len == 0 {
+            return;
+        }
+
+        unsafe {
+            ptr::write_bytes(bottom as *mut u8, STACK_SENTINEL, len);
+        }
+    }
+
+    pub fn snapshot() -> StackUsage {
+        let (bottom, top) = bounds();
+        let (current_sp, current_msp, current_psp, thread_uses_psp) = active_thread_sp();
+        let mut probe = bottom;
+        while probe < top {
+            let byte = unsafe { ptr::read_volatile(probe as *const u8) };
+            if byte != STACK_SENTINEL {
+                break;
+            }
+            probe += 1;
+        }
+
+        let untouched_bytes = probe - bottom;
+        StackUsage {
+            current_sp,
+            current_msp,
+            current_psp,
+            thread_uses_psp,
+            bottom,
+            top,
+            untouched_bytes,
+            peak_used_bytes: (top - bottom).saturating_sub(untouched_bytes),
+        }
+    }
+
+    pub fn log(label: &'static str) {
+        let usage = snapshot();
+        info!(
+            "stack {}: sp=0x{:08x} msp=0x{:08x} psp=0x{:08x} using_psp={} budget={}B peak={}B headroom={}B bottom=0x{:08x}",
+            label,
+            usage.current_sp,
+            usage.current_msp,
+            usage.current_psp,
+            usage.thread_uses_psp,
+            usage.budget_bytes(),
+            usage.peak_used_bytes,
+            usage.headroom_bytes(),
+            usage.bottom,
+        );
+    }
+
+    pub fn check_current_sp(label: &'static str) {
+        let state = current_state();
+        let current_margin = state.current_sp.saturating_sub(state.bottom);
+
+        if current_margin <= COLLISION_GUARD_BYTES {
+            panic!(
+                "stack collision risk {}: sp=0x{:08x} bottom=0x{:08x} margin={}B",
+                label,
+                state.current_sp,
+                state.bottom,
+                current_margin,
+            );
+        }
+
+        if current_margin <= LOW_HEADROOM_WARN_BYTES
+            && !LOW_HEADROOM_WARNED.swap(true, Ordering::Relaxed)
+        {
+            warn!(
+                "stack low headroom {}: sp=0x{:08x} bottom=0x{:08x} margin={}B",
+                label,
+                state.current_sp,
+                state.bottom,
+                current_margin,
+            );
+        }
+    }
+
+    pub fn log_read_bank_stack(bank: usize) {
+        let usage = snapshot();
+        info!(
+            "read_bank {} stack: sp=0x{:08x} peak={}B headroom={}B",
+            bank,
+            usage.current_sp,
+            usage.peak_used_bytes,
+            usage.headroom_bytes(),
+        );
+    }
+
+    pub fn set_read_bank_logging(enabled: bool) {
+        READ_BANK_STACK_LOGGING.store(enabled, Ordering::Relaxed);
+    }
+
+    pub fn read_bank_logging_enabled() -> bool {
+        READ_BANK_STACK_LOGGING.load(Ordering::Relaxed)
+    }
+}
+
+#[cfg(not(feature = "stack-probe"))]
+mod imp {
+    pub fn paint() {}
+
+    pub fn log(_label: &'static str) {}
+
+    pub fn check_current_sp(_label: &'static str) {}
+
+    pub fn log_read_bank_stack(_bank: usize) {}
+
+    pub fn set_read_bank_logging(_enabled: bool) {}
+
+    pub fn read_bank_logging_enabled() -> bool {
+        false
+    }
+}
+
+pub use imp::{
+    check_current_sp,
+    log,
+    log_read_bank_stack,
+    paint,
+    read_bank_logging_enabled,
+    set_read_bank_logging,
+};


### PR DESCRIPTION
## Summary
- add an async SPI/DMA display path for the Pico 2W game loop using raw ILI9341 transfers
- fix the startup hard fault by reducing heap reservation, moving the scaled frame buffer off .bss, and adding an optional stack-probe feature for collision diagnostics
- kick the display and audio DMA futures once before emulation so the transfer actually overlaps the CPU frame, and keep the RGB565 buffer in big-endian DMA-ready form

## Validation
- cargo build --release
- cargo build --release --features stack-probe
- cargo build --release --features perf
- cargo test-host --target-dir /tmp/rustyboy-pico2w-host-target
- probe-rs run --chip RP235x on hardware to verify splash, ROM load, DMA display init, and game-loop entry
- perf on hardware: display/60f improved from 1173ms total (fill 949ms) to about 238ms total (fill 1ms), with fps around 12-15 in the current ROM workload