### PR TITLE
Add PPU STAT cache experiment and refresh perf roadmap

### DIFF
--- a/core/src/cpu/peripheral/ppu.rs
+++ b/core/src/cpu/peripheral/ppu.rs
@@ -104,7 +104,9 @@ pub struct PpuPeripheral {
     ly: u8,
     mode: PpuMode,
     window_line_counter: u8,
-    prev_stat_line: bool,
+    stat_cache: u8,
+    stat_line_cache: bool,
+    stat_dirty: bool,
     framebuffer: [u8; FRAMEBUFFER_SIZE],
     /// Raw BG/window color indices (0-3) for the current scanline, used for sprite priority.
     bg_color_indices: [u8; SCREEN_WIDTH],
@@ -119,7 +121,9 @@ impl PpuPeripheral {
             ly: 0,
             mode: PpuMode::OamScan,
             window_line_counter: 0,
-            prev_stat_line: false,
+            stat_cache: 0,
+            stat_line_cache: false,
+            stat_dirty: true,
             framebuffer: [0u8; FRAMEBUFFER_SIZE],
             bg_color_indices: [0u8; SCREEN_WIDTH],
             #[cfg(feature = "perf")]
@@ -152,6 +156,9 @@ impl PpuPeripheral {
         self.ly = state.ly;
         self.mode = state.mode;
         self.window_line_counter = state.window_line_counter;
+        self.stat_cache = 0;
+        self.stat_line_cache = false;
+        self.stat_dirty = true;
     }
 
     /// Advance the PPU by `cycles` T-cycles.
@@ -191,28 +198,28 @@ impl PpuPeripheral {
 
             match self.mode {
                 PpuMode::OamScan => {
-                    self.mode = PpuMode::PixelTransfer;
+                    self.set_mode(PpuMode::PixelTransfer);
                 }
                 PpuMode::PixelTransfer => {
-                    self.mode = PpuMode::HBlank;
+                    self.set_mode(PpuMode::HBlank);
                     self.render_scanline(&input);
                 }
                 PpuMode::HBlank => {
                     self.dot = 0;
-                    self.ly += 1;
+                    self.set_ly(self.ly + 1);
                     if self.ly >= VISIBLE_SCANLINES {
-                        self.mode = PpuMode::VBlank;
+                        self.set_mode(PpuMode::VBlank);
                         vblank_interrupt = true;
                     } else {
-                        self.mode = PpuMode::OamScan;
+                        self.set_mode(PpuMode::OamScan);
                     }
                 }
                 PpuMode::VBlank => {
                     self.dot = 0;
-                    self.ly += 1;
+                    self.set_ly(self.ly + 1);
                     if self.ly >= TOTAL_SCANLINES {
-                        self.ly = 0;
-                        self.mode = PpuMode::OamScan;
+                        self.set_ly(0);
+                        self.set_mode(PpuMode::OamScan);
                         self.window_line_counter = 0;
                     }
                 }
@@ -223,7 +230,12 @@ impl PpuPeripheral {
         let t0 = crate::cpu::perf::cyccnt();
         let (stat, stat_interrupt) = self.build_stat(&input);
         #[cfg(feature = "perf")]
-        { self.perf_profile.build_stat = self.perf_profile.build_stat.wrapping_add(crate::cpu::perf::cyccnt().wrapping_sub(t0)); }
+        {
+            self.perf_profile.build_stat = self
+                .perf_profile
+                .build_stat
+                .wrapping_add(crate::cpu::perf::cyccnt().wrapping_sub(t0));
+        }
 
         PpuOutput {
             ly: self.ly,
@@ -235,24 +247,28 @@ impl PpuPeripheral {
 
     /// Reset LY to 0 (triggered by CPU write to LY register).
     pub fn reset_ly(&mut self) {
-        self.ly = 0;
+        self.set_ly(0);
     }
 
     /// Build the STAT register value and detect STAT interrupt rising edge.
     #[cfg_attr(target_arch = "arm", link_section = ".data")]
     fn build_stat(&mut self, input: &PpuInput) -> (u8, bool) {
+        if !self.stat_dirty && (self.stat_cache & 0x78) == (input.stat & 0x78) {
+            return (self.stat_cache, false);
+        }
+
         let lyc_match = self.ly == input.lyc;
-        let stat = (input.stat & 0x78)
-            | if lyc_match { 0x04 } else { 0x00 }
-            | (self.mode as u8);
+        let stat = (input.stat & 0x78) | if lyc_match { 0x04 } else { 0x00 } | (self.mode as u8);
 
         let stat_line = (lyc_match && (input.stat & 0x40 != 0))
             || (self.mode == PpuMode::HBlank && (input.stat & 0x08 != 0))
             || (self.mode == PpuMode::VBlank && (input.stat & 0x10 != 0))
             || (self.mode == PpuMode::OamScan && (input.stat & 0x20 != 0));
 
-        let interrupt = stat_line && !self.prev_stat_line;
-        self.prev_stat_line = stat_line;
+        let interrupt = stat_line && !self.stat_line_cache;
+        self.stat_cache = stat;
+        self.stat_line_cache = stat_line;
+        self.stat_dirty = false;
 
         (stat, interrupt)
     }
@@ -264,7 +280,24 @@ impl PpuPeripheral {
         self.ly = 0;
         self.mode = PpuMode::HBlank;
         self.window_line_counter = 0;
-        self.prev_stat_line = false;
+        self.stat_line_cache = false;
+        self.stat_dirty = true;
+    }
+
+    #[inline]
+    fn set_ly(&mut self, ly: u8) {
+        if self.ly != ly {
+            self.ly = ly;
+            self.stat_dirty = true;
+        }
+    }
+
+    #[inline]
+    fn set_mode(&mut self, mode: PpuMode) {
+        if self.mode != mode {
+            self.mode = mode;
+            self.stat_dirty = true;
+        }
     }
 
     #[cfg_attr(target_arch = "arm", link_section = ".data")]
@@ -282,7 +315,12 @@ impl PpuPeripheral {
             let t0 = crate::cpu::perf::cyccnt();
             self.render_bg_scanline(input, lcdc, row_start);
             #[cfg(feature = "perf")]
-            { self.perf_profile.render_bg = self.perf_profile.render_bg.wrapping_add(crate::cpu::perf::cyccnt().wrapping_sub(t0)); }
+            {
+                self.perf_profile.render_bg = self
+                    .perf_profile
+                    .render_bg
+                    .wrapping_add(crate::cpu::perf::cyccnt().wrapping_sub(t0));
+            }
         } else {
             for x in 0..SCREEN_WIDTH {
                 self.framebuffer[row_start + x] = 0;
@@ -295,7 +333,12 @@ impl PpuPeripheral {
             let t0 = crate::cpu::perf::cyccnt();
             self.render_window_scanline(input, lcdc, row_start);
             #[cfg(feature = "perf")]
-            { self.perf_profile.render_window = self.perf_profile.render_window.wrapping_add(crate::cpu::perf::cyccnt().wrapping_sub(t0)); }
+            {
+                self.perf_profile.render_window = self
+                    .perf_profile
+                    .render_window
+                    .wrapping_add(crate::cpu::perf::cyccnt().wrapping_sub(t0));
+            }
         }
 
         if lcdc.obj_enabled() {
@@ -303,13 +346,22 @@ impl PpuPeripheral {
             let t0 = crate::cpu::perf::cyccnt();
             self.render_sprite_scanline(input, lcdc, row_start);
             #[cfg(feature = "perf")]
-            { self.perf_profile.render_sprites = self.perf_profile.render_sprites.wrapping_add(crate::cpu::perf::cyccnt().wrapping_sub(t0)); }
+            {
+                self.perf_profile.render_sprites = self
+                    .perf_profile
+                    .render_sprites
+                    .wrapping_add(crate::cpu::perf::cyccnt().wrapping_sub(t0));
+            }
         }
     }
 
     #[cfg_attr(target_arch = "arm", link_section = ".data")]
     fn render_bg_scanline(&mut self, input: &PpuInput, lcdc: Lcdc, row_start: usize) {
-        let tilemap_base: usize = if lcdc.bg_tilemap_high() { 0x1C00 } else { 0x1800 };
+        let tilemap_base: usize = if lcdc.bg_tilemap_high() {
+            0x1C00
+        } else {
+            0x1800
+        };
         let y = input.scy.wrapping_add(self.ly);
         let tile_row = (y / 8) as usize;
         let fine_y = (y % 8) as usize;
@@ -344,12 +396,20 @@ impl PpuPeripheral {
             return;
         }
 
-        let tilemap_base: usize = if lcdc.window_tilemap_high() { 0x1C00 } else { 0x1800 };
+        let tilemap_base: usize = if lcdc.window_tilemap_high() {
+            0x1C00
+        } else {
+            0x1800
+        };
         let win_y = self.window_line_counter as usize;
         let tile_row = win_y / 8;
         let fine_y = win_y % 8;
 
-        let screen_x_start = if input.wx < 7 { 0 } else { (input.wx - 7) as usize };
+        let screen_x_start = if input.wx < 7 {
+            0
+        } else {
+            (input.wx - 7) as usize
+        };
 
         let mut current_tile_col = usize::MAX;
         let mut lo = 0u8;
@@ -436,7 +496,11 @@ impl PpuPeripheral {
         let y_flip = attrs & 0x40 != 0;
         let x_flip = attrs & 0x20 != 0;
         let bg_priority = attrs & 0x80 != 0;
-        let palette = if attrs & 0x10 != 0 { input.obp1 } else { input.obp0 };
+        let palette = if attrs & 0x10 != 0 {
+            input.obp1
+        } else {
+            input.obp0
+        };
 
         let mut row_in_sprite = (ly - sprite_y_pos) as u8;
         let tile_index = if lcdc.obj_tall() {
@@ -482,7 +546,6 @@ impl PpuPeripheral {
         }
     }
 }
-
 
 /// Decode a single pixel from a 2bpp tile row.
 #[cfg_attr(target_arch = "arm", link_section = ".data")]
@@ -538,20 +601,23 @@ mod tests {
         };
         // Tick one at a time to get correct mode transitions
         for _ in 0..dots {
-            let o = ppu.tick(1, PpuInput {
-                lcdc: input.lcdc,
-                stat: input.stat,
-                scy: input.scy,
-                scx: input.scx,
-                lyc: input.lyc,
-                bgp: input.bgp,
-                obp0: input.obp0,
-                obp1: input.obp1,
-                wy: input.wy,
-                wx: input.wx,
-                vram: input.vram,
-                oam: input.oam,
-            });
+            let o = ppu.tick(
+                1,
+                PpuInput {
+                    lcdc: input.lcdc,
+                    stat: input.stat,
+                    scy: input.scy,
+                    scx: input.scx,
+                    lyc: input.lyc,
+                    bgp: input.bgp,
+                    obp0: input.obp0,
+                    obp1: input.obp1,
+                    wy: input.wy,
+                    wx: input.wx,
+                    vram: input.vram,
+                    oam: input.oam,
+                },
+            );
             if o.vblank_interrupt {
                 output.vblank_interrupt = true;
             }
@@ -584,7 +650,11 @@ mod tests {
         assert_eq!(output.ly, 0);
 
         // After 204 more dots (456 total): transition to next scanline
-        let output = tick_dots(&mut ppu, (DOTS_PER_SCANLINE - OAM_SCAN_DOTS - PIXEL_TRANSFER_DOTS) as u32, &input);
+        let output = tick_dots(
+            &mut ppu,
+            (DOTS_PER_SCANLINE - OAM_SCAN_DOTS - PIXEL_TRANSFER_DOTS) as u32,
+            &input,
+        );
         assert_eq!(ppu.mode, PpuMode::OamScan);
         assert_eq!(output.ly, 1);
     }
@@ -597,7 +667,11 @@ mod tests {
         let input = default_input(&vram, &oam);
 
         // Tick through 144 scanlines
-        let output = tick_dots(&mut ppu, VISIBLE_SCANLINES as u32 * DOTS_PER_SCANLINE as u32, &input);
+        let output = tick_dots(
+            &mut ppu,
+            VISIBLE_SCANLINES as u32 * DOTS_PER_SCANLINE as u32,
+            &input,
+        );
         assert_eq!(ppu.mode, PpuMode::VBlank);
         assert_eq!(output.ly, 144);
         assert!(output.vblank_interrupt);
@@ -611,7 +685,11 @@ mod tests {
         let input = default_input(&vram, &oam);
 
         // Full frame: 154 scanlines
-        let output = tick_dots(&mut ppu, TOTAL_SCANLINES as u32 * DOTS_PER_SCANLINE as u32, &input);
+        let output = tick_dots(
+            &mut ppu,
+            TOTAL_SCANLINES as u32 * DOTS_PER_SCANLINE as u32,
+            &input,
+        );
         assert_eq!(ppu.mode, PpuMode::OamScan);
         assert_eq!(output.ly, 0);
     }
@@ -837,6 +915,28 @@ mod tests {
         assert!(output.stat_interrupt);
 
         // Subsequent ticks in same mode should NOT re-fire
+        let output = tick_dots(&mut ppu, 1, &input);
+        assert!(!output.stat_interrupt);
+    }
+
+    #[test]
+    fn test_stat_write_invalidates_cached_line_state() {
+        let vram = [0u8; 0x2000];
+        let oam = [0u8; 0xA0];
+        let mut ppu = PpuPeripheral::new();
+        let mut input = default_input(&vram, &oam);
+
+        // Prime the cache while mode 2 is active but the interrupt is disabled.
+        let output = tick_dots(&mut ppu, 1, &input);
+        assert_eq!(output.stat & 0x03, 2);
+        assert!(!output.stat_interrupt);
+
+        // Enabling mode-2 STAT in the same mode should still raise the edge once.
+        input.stat = 0x20;
+        let output = tick_dots(&mut ppu, 1, &input);
+        assert!(output.stat_interrupt);
+
+        // Further ticks in the same mode should remain quiet.
         let output = tick_dots(&mut ppu, 1, &input);
         assert!(!output.stat_interrupt);
     }

--- a/docs/performance-roadmap.md
+++ b/docs/performance-roadmap.md
@@ -1,91 +1,80 @@
 # Performance Roadmap
 
-## Current state — post dispatch-refactor baseline
+## Current state — post display DMA + APU batching
 
 ROM: Tetris, Pico2W @ 250 MHz.
 
-### Wall-clock breakdown (fps = 9)
+Latest `perf` build measurement:
+
+```
+fps: 12
+cycles/60f — total=1087658401 ppu=226370324 timer=17928846 apu=88093231 cpu_exec=755266000 (mem_r=29927803 mem_w=226325431 decode=499012766)
+ppu breakdown — bg=43526449 window=95196 sprites=8074787 stat=30854900
+apu breakdown — frame_seq=312708 pulse=17766610 wave=6626594 noise=6414055 mix=12869944
+display/60f — 238ms total (scale=236ms fill=1ms) avg 3ms/frame
+```
+
+### Updated breakdown (60 frames, `perf` build)
 
 | Bucket | Time / 60 frames | % of wall clock |
 |---|---|---|
-| Emulation (DWT) | 3.52 s (879M cycles) | 53% |
-| Display + other | 3.15 s | 47% |
-| **Total** | **6.67 s** | **100%** |
+| Emulation (DWT) | 4.35 s (1088M cycles) | dominant |
+| Display scaler + residual wait | 0.24 s | small |
+| **Total** | **~5.02 s** | **100%** |
 
 Target: 1.00 s / 60 frames (60 fps).  
-Required speedup: **6.7×**.
+Required speedup from current `perf` run: **~5×**.
 
-### Emulation sub-breakdown (879M cycles)
+### Emulation sub-breakdown (1088M cycles)
 
 | Component | Cycles | % of emulation |
 |---|---|---|
-| decode / dispatch | 406M | 46% |
-| apu | 205M | 23% |
-| ppu | 160M | 18% |
-| mem_write | 54M | 6% |
+| decode / dispatch | 499M | 46% |
+| mem_write | 226M | 21% |
+| ppu | 226M | 21% |
+| apu | 88M | 8% |
 | mem_read | 29M | 3% |
-| timer | 26M | 3% |
+| timer | 18M | 2% |
 
-### Hard ceiling without touching display
+### What changed
 
-Even if emulation cost were zero, the display/other overhead alone gives:
+- Async display DMA is working: residual display wait is `1ms / 60f`, so the
+  SPI transfer is no longer the main limiter.
+- Pre-scaling is now the only notable display cost at `236ms / 60f`
+  (`~3.9ms/frame`).
+- APU batching is working: APU cost fell from `~205M` cycles to `~88M`.
 
-60 ÷ 3.15 s = **~19 fps maximum**
+### New hotspot order
 
-Both tracks (emulation and display) must be attacked together to reach 60 fps.
-
----
-
-## Priority 1 — Async display transfer
-
-**Expected impact: largest single lever, potentially 2–3× fps gain**
-
-The display currently blocks the CPU for ~13 ms per frame (240×216 × 2 bytes over
-62.5 MHz SPI), plus unknown software-scaling overhead. The game loop sits idle
-waiting for this transfer to complete.
-
-### What to do
-
-1. **Profile the display path** — add DWT instrumentation around `render_game_only`
-   to separate the SPI transfer time from the software scaler (1.5× pixel iterator).
-
-2. **DMA-backed SPI transfer** — `embassy-rp` supports async DMA SPI writes. Start
-   the transfer at VBlank, let emulation run for the next frame concurrently, await
-   completion only if the next VBlank arrives before the DMA finishes. This hides
-   the transfer latency almost entirely behind emulation work.
-
-3. **Pre-scale into a u16 framebuffer** — instead of running the 1.5× scale iterator
-   inside the SPI callback, maintain a `[u16; 240 * 216]` front buffer that is updated
-   once per VBlank. The DMA transfer then reads directly from this buffer with no
-   per-pixel CPU work during the transfer.
+1. `decode / dispatch` at `499M`
+2. `mem_write` at `226M`
+3. `ppu` at `226M`, with `build_stat = 30.9M`
 
 ---
 
-## Priority 2 — APU cycle batching
+## Completed — Async display transfer
 
-**Expected impact: ~80–100M cycles saved (~9–11% of total emulation)**
+**Status: done**
 
-`advance_apu` is called on every M-cycle (~1.05M times/second). The APU already
-implements skip-ahead arithmetic for frequency timers, so it handles large cycle
-batches correctly.
-
-### What to do
-
-Add a `pending_apu_cycles: u16` accumulator to `Sm83`. Increment it instead of
-calling `apu.tick()` on every `tick_cycle`. Flush via `apu.tick(pending, ...)` at:
-- End of each instruction (in `tick_impl`, before the interrupt check)
-- Before any APU register write (the `tick_cycle_to_t3` path already handles
-  T-cycle precision for writes — flush before entering that path)
-
-This reduces APU tick call frequency from ~1M/s to ~350K/s (once per instruction
-on average), cutting function-call overhead by ~3× while the skip-ahead arithmetic
-absorbs the larger cycle batches.
+- DMA-backed SPI transfer overlaps with emulation successfully.
+- Static letterbox bars are no longer repainted every frame.
+- Remaining display work, if needed later, is reducing scaler cost rather than
+  fixing transfer latency.
 
 ---
 
-## Priority 3 — PPU `build_stat` cache
+## Completed — APU cycle batching
 
-**Expected impact: ~20M cycles saved (~2% of total emulation)**
+**Status: done**
+
+- Batched APU ticking reduced APU cost from `~205M` cycles to `~88M`.
+- No longer a top-three hotspot for this ROM/profile.
+
+---
+
+## Priority 1 — PPU `build_stat` cache
+
+**Expected impact: ~25–30M cycles saved (~2–3% of total emulation)**
 
 `build_stat` recomputes the STAT register and STAT interrupt edge on every M-cycle
 (~1M times/second). The result only changes when LY changes (154×/frame), the PPU
@@ -104,9 +93,27 @@ recomputing. This drops 99%+ of `build_stat` calls to a single branch.
 
 ---
 
-## Priority 4 — `pending_bus_events` fixed-size array
+## Priority 2 — Split `mem_write` before optimizing it
 
-**Expected impact: small, reduces mem_write overhead**
+**Expected impact: diagnostic; determines the real next hot path**
+
+`mem_write` is now `226M` cycles, much larger than the old baseline. That is too
+large to attribute solely to `Vec` push overhead in `pending_bus_events`.
+
+### What to do
+
+Add separate perf counters around:
+- `memory.write_io` / `memory.write_fast`
+- enqueueing `pending_bus_events`
+- `route_bus_events` / `handle_bus_event`
+
+This tells us whether the cost is queue management, event fan-out, or raw IO writes.
+
+---
+
+## Priority 3 — `pending_bus_events` fixed-size array
+
+**Expected impact: small-to-moderate, only if queueing is a real slice of `mem_write`**
 
 `pending_bus_events: Vec<BusEvent>` does a bounds-check + capacity-check on every
 I/O write. Since at most one I/O write can be pending per M-cycle before
@@ -119,7 +126,7 @@ indirection and capacity check on the write hot path.
 
 ---
 
-## Priority 5 — `decode` remainder (longer term)
+## Priority 4 — `decode` remainder (longer term)
 
 After the above changes, decode/dispatch will still sit at ~350–400M cycles. The
 remaining cost is dominated by:
@@ -141,8 +148,9 @@ Further gains here would require either:
 
 | # | Change | Est. savings | Effort | Unblocks |
 |---|---|---|---|---|
-| 1 | Async DMA display | ~2–3× fps | Medium | 60 fps ceiling |
-| 2 | APU cycle batching | ~80–100M cycles | Small | — |
-| 3 | PPU build_stat cache | ~20M cycles | Small | — |
-| 4 | Fixed pending_bus_events | small | Trivial | — |
-| 5 | Instruction-level tick batching | ~100M+ cycles | Large | — |
+| done | Async DMA display | large | Medium | 60 fps ceiling |
+| done | APU cycle batching | ~117M cycles observed | Small | — |
+| 1 | PPU build_stat cache | ~25–30M cycles | Small | — |
+| 2 | Split mem_write perf counters | diagnostic | Small | mem_write direction |
+| 3 | Fixed pending_bus_events | small-to-moderate | Trivial | — |
+| 4 | ROM opcode-fetch fast path / decode follow-up | large | Medium | decode direction |


### PR DESCRIPTION
## Summary
- add a cached STAT fast path in the PPU with dirty invalidation on LY/mode changes and STAT control-bit updates
- add a regression test covering STAT enable writes while staying in the same mode
- refresh the performance roadmap with the post-display/post-APU profile and reprioritize the next investigation

## Validation
- cargo check
- cargo test -p rustyboy-core --target x86_64-unknown-linux-gnu test_stat_ -- --nocapture
- cargo run --release --features perf

## Perf Notes
Previous sample:
- fps: 12
- total: 1087658401
- mem_write: 226325431
- ppu.build_stat: 30854900

New steady samples after flashing this branch:
- fps: 13, total: 1016715445, mem_write: 167413832, ppu.build_stat: 33051411
- fps: 14, total: 984323678, mem_write: 139665515, ppu.build_stat: 33062838

Overall frame cost improved, but build_stat itself did not show the expected drop in perf mode. My current read is that build_stat is already tiny enough that call/profiling overhead and extra cache bookkeeping dominate, so the next best move is to split mem_write perf counters before assuming the queue optimization is the real win.