### PR TITLE
Optimize Pico ROM banking with direct XIP cartridge

### DIFF
--- a/core/src/cpu/perf.rs
+++ b/core/src/cpu/perf.rs
@@ -1,6 +1,166 @@
 // Read the cycle counter. Bare-metal platforms provide the implementation,
 // while host builds use a cheap monotonic fallback so tests and coverage can
 // link with `perf` enabled.
+#[cfg(feature = "perf")]
+/// Per-component DWT cycle accumulator. Drained each time `Sm83::take_perf_profile` is called.
+/// `cpu` = `total` − `ppu` − `timer` − `apu` (instruction fetch/decode/execute overhead).
+#[derive(Default)]
+pub struct Sm83PerfProfile {
+    pub ppu: u32,
+    pub timer: u32,
+    pub apu: u32,
+    pub total: u32,
+    /// Time spent in memory reads (read_fast) inside bus_read, excluding tick overhead.
+    pub mem_read: u32,
+    /// Time spent in memory writes (write_fast/write_io) inside bus_write, excluding tick overhead.
+    pub mem_write: u32,
+    /// Time spent in direct `memory.write_fast(...)` calls from bus_write.
+    pub mem_write_fast: u32,
+    /// Time spent in `write_fast` for ROM/MBC control writes (0x0000-0x7FFF).
+    pub mem_write_fast_rom: u32,
+    /// Time spent in `write_fast` for ROM control writes at 0x0000-0x1FFF.
+    pub mem_write_fast_rom_0000_1fff: u32,
+    /// Time spent in `write_fast` for ROM control writes at 0x2000-0x3FFF.
+    pub mem_write_fast_rom_2000_3fff: u32,
+    /// Time spent in `write_fast` for ROM control writes at 0x4000-0x5FFF.
+    pub mem_write_fast_rom_4000_5fff: u32,
+    /// Time spent in `write_fast` for ROM control writes at 0x6000-0x7FFF.
+    pub mem_write_fast_rom_6000_7fff: u32,
+    /// Time spent in `write_fast` for external RAM / cartridge RAM writes (0xA000-0xBFFF).
+    pub mem_write_fast_eram: u32,
+    /// Time spent in `write_fast` for VRAM writes (0x8000-0x9FFF).
+    pub mem_write_fast_vram: u32,
+    /// Time spent in `write_fast` for WRAM writes (0xC000-0xDFFF).
+    pub mem_write_fast_wram: u32,
+    /// Time spent in `write_fast` for OAM writes (0xFE00-0xFE9F).
+    pub mem_write_fast_oam: u32,
+    /// Time spent in `write_fast` for HRAM writes (0xFF80-0xFFFE).
+    pub mem_write_fast_hram: u32,
+    /// Time spent in `write_fast` for unmapped / ignored writes.
+    pub mem_write_fast_unmapped: u32,
+    /// Time spent in direct `memory.write_io(...)` calls from bus_write.
+    pub mem_write_io: u32,
+    /// Time spent enqueueing `pending_bus_events` from bus_write.
+    pub mem_write_enqueue: u32,
+    /// Time spent draining and handling queued bus events on the next M-cycle.
+    pub mem_write_route: u32,
+}
+
+#[cfg(feature = "perf")]
+#[derive(Default)]
+pub(crate) struct Sm83PerfRecorder {
+    profile: Sm83PerfProfile,
+}
+
+#[cfg(feature = "perf")]
+impl Sm83PerfRecorder {
+    #[inline]
+    pub(crate) fn take_profile(&mut self) -> Sm83PerfProfile {
+        core::mem::take(&mut self.profile)
+    }
+
+    #[inline]
+    pub(crate) fn record_mem_read(&mut self, dt: u32) {
+        self.profile.mem_read = self.profile.mem_read.wrapping_add(dt);
+    }
+
+    #[inline]
+    pub(crate) fn record_mem_write(&mut self, dt: u32) {
+        self.profile.mem_write = self.profile.mem_write.wrapping_add(dt);
+    }
+
+    #[inline]
+    pub(crate) fn record_mem_write_fast(&mut self, addr: u16, dt: u32) {
+        self.profile.mem_write_fast = self.profile.mem_write_fast.wrapping_add(dt);
+        match addr {
+            0x0000..=0x7FFF => {
+                self.profile.mem_write_fast_rom = self.profile.mem_write_fast_rom.wrapping_add(dt);
+                match addr {
+                    0x0000..=0x1FFF => {
+                        self.profile.mem_write_fast_rom_0000_1fff = self
+                            .profile
+                            .mem_write_fast_rom_0000_1fff
+                            .wrapping_add(dt);
+                    }
+                    0x2000..=0x3FFF => {
+                        self.profile.mem_write_fast_rom_2000_3fff = self
+                            .profile
+                            .mem_write_fast_rom_2000_3fff
+                            .wrapping_add(dt);
+                    }
+                    0x4000..=0x5FFF => {
+                        self.profile.mem_write_fast_rom_4000_5fff = self
+                            .profile
+                            .mem_write_fast_rom_4000_5fff
+                            .wrapping_add(dt);
+                    }
+                    0x6000..=0x7FFF => {
+                        self.profile.mem_write_fast_rom_6000_7fff = self
+                            .profile
+                            .mem_write_fast_rom_6000_7fff
+                            .wrapping_add(dt);
+                    }
+                    _ => {}
+                }
+            }
+            0x8000..=0x9FFF => {
+                self.profile.mem_write_fast_vram = self.profile.mem_write_fast_vram.wrapping_add(dt);
+            }
+            0xA000..=0xBFFF => {
+                self.profile.mem_write_fast_eram = self.profile.mem_write_fast_eram.wrapping_add(dt);
+            }
+            0xC000..=0xDFFF => {
+                self.profile.mem_write_fast_wram = self.profile.mem_write_fast_wram.wrapping_add(dt);
+            }
+            0xFE00..=0xFE9F => {
+                self.profile.mem_write_fast_oam = self.profile.mem_write_fast_oam.wrapping_add(dt);
+            }
+            0xFF80..=0xFFFE => {
+                self.profile.mem_write_fast_hram = self.profile.mem_write_fast_hram.wrapping_add(dt);
+            }
+            _ => {
+                self.profile.mem_write_fast_unmapped =
+                    self.profile.mem_write_fast_unmapped.wrapping_add(dt);
+            }
+        }
+    }
+
+    #[inline]
+    pub(crate) fn record_mem_write_io(&mut self, dt: u32) {
+        self.profile.mem_write_io = self.profile.mem_write_io.wrapping_add(dt);
+    }
+
+    #[inline]
+    pub(crate) fn record_mem_write_enqueue(&mut self, dt: u32) {
+        self.profile.mem_write_enqueue = self.profile.mem_write_enqueue.wrapping_add(dt);
+    }
+
+    #[inline]
+    pub(crate) fn record_mem_write_route(&mut self, dt: u32) {
+        self.profile.mem_write_route = self.profile.mem_write_route.wrapping_add(dt);
+    }
+
+    #[inline]
+    pub(crate) fn record_ppu(&mut self, dt: u32) {
+        self.profile.ppu = self.profile.ppu.wrapping_add(dt);
+    }
+
+    #[inline]
+    pub(crate) fn record_timer(&mut self, dt: u32) {
+        self.profile.timer = self.profile.timer.wrapping_add(dt);
+    }
+
+    #[inline]
+    pub(crate) fn record_apu(&mut self, dt: u32) {
+        self.profile.apu = self.profile.apu.wrapping_add(dt);
+    }
+
+    #[inline]
+    pub(crate) fn record_total(&mut self, dt: u32) {
+        self.profile.total = self.profile.total.wrapping_add(dt);
+    }
+}
+
 #[cfg(target_os = "none")]
 extern "C" {
     fn perf_cycle_read() -> u32;
@@ -19,4 +179,34 @@ pub fn cyccnt() -> u32 {
 
     static HOST_CYCLE_COUNTER: AtomicU32 = AtomicU32::new(0);
     HOST_CYCLE_COUNTER.fetch_add(1, Ordering::Relaxed)
+}
+
+#[cfg(all(feature = "perf", test))]
+mod tests {
+    use super::{Sm83PerfProfile, Sm83PerfRecorder};
+
+    #[test]
+    fn record_mem_write_fast_tracks_regions() {
+        let mut perf = Sm83PerfRecorder::default();
+        perf.record_mem_write_fast(0x2000, 3);
+        perf.record_mem_write_fast(0xC123, 5);
+
+        let profile = perf.take_profile();
+        assert_eq!(profile.mem_write_fast, 8);
+        assert_eq!(profile.mem_write_fast_rom, 3);
+        assert_eq!(profile.mem_write_fast_rom_2000_3fff, 3);
+        assert_eq!(profile.mem_write_fast_wram, 5);
+    }
+
+    #[test]
+    fn take_profile_drains_counters() {
+        let mut perf = Sm83PerfRecorder::default();
+        perf.record_total(7);
+
+        let first = perf.take_profile();
+        let second = perf.take_profile();
+
+        assert_eq!(first.total, 7);
+        assert_eq!(second.total, Sm83PerfProfile::default().total);
+    }
 }

--- a/core/src/cpu/sm83.rs
+++ b/core/src/cpu/sm83.rs
@@ -43,10 +43,14 @@ use super::peripheral::ppu::{
 use super::peripheral::timer::{
     TimerInput, TimerPeripheral, DIV_ADDR, TIMA_ADDR, TIMER_INTERRUPT_BIT, TMA_ADDR, TAC_ADDR,
 };
+#[cfg(feature = "perf")]
+use super::perf::{cyccnt, Sm83PerfRecorder};
 use super::registers::{Flags, Registers};
 use super::save_state::{CpuState, SaveState};
 
 use crate::memory::memory::{BusEvent, Error as MemoryError, GameBoyMemory, Memory as MemoryBus};
+#[cfg(feature = "perf")]
+pub use super::perf::Sm83PerfProfile;
 
 impl From<MemoryError> for InstructionError {
     fn from(error: MemoryError) -> Self {
@@ -144,51 +148,6 @@ impl Sm83Cache {
     }
 }
 
-/// Per-component DWT cycle accumulator. Drained each time `take_perf_profile` is called.
-/// `cpu` = `total` − `ppu` − `timer` − `apu` (instruction fetch/decode/execute overhead).
-#[cfg(feature = "perf")]
-#[derive(Default)]
-pub struct Sm83PerfProfile {
-    pub ppu: u32,
-    pub timer: u32,
-    pub apu: u32,
-    pub total: u32,
-    /// Time spent in memory reads (read_fast) inside bus_read, excluding tick overhead.
-    pub mem_read: u32,
-    /// Time spent in memory writes (write_fast/write_io) inside bus_write, excluding tick overhead.
-    pub mem_write: u32,
-    /// Time spent in direct `memory.write_fast(...)` calls from bus_write.
-    pub mem_write_fast: u32,
-    /// Time spent in `write_fast` for ROM/MBC control writes (0x0000-0x7FFF).
-    pub mem_write_fast_rom: u32,
-    /// Time spent in `write_fast` for ROM control writes at 0x0000-0x1FFF.
-    pub mem_write_fast_rom_0000_1fff: u32,
-    /// Time spent in `write_fast` for ROM control writes at 0x2000-0x3FFF.
-    pub mem_write_fast_rom_2000_3fff: u32,
-    /// Time spent in `write_fast` for ROM control writes at 0x4000-0x5FFF.
-    pub mem_write_fast_rom_4000_5fff: u32,
-    /// Time spent in `write_fast` for ROM control writes at 0x6000-0x7FFF.
-    pub mem_write_fast_rom_6000_7fff: u32,
-    /// Time spent in `write_fast` for external RAM / cartridge RAM writes (0xA000-0xBFFF).
-    pub mem_write_fast_eram: u32,
-    /// Time spent in `write_fast` for VRAM writes (0x8000-0x9FFF).
-    pub mem_write_fast_vram: u32,
-    /// Time spent in `write_fast` for WRAM writes (0xC000-0xDFFF).
-    pub mem_write_fast_wram: u32,
-    /// Time spent in `write_fast` for OAM writes (0xFE00-0xFE9F).
-    pub mem_write_fast_oam: u32,
-    /// Time spent in `write_fast` for HRAM writes (0xFF80-0xFFFE).
-    pub mem_write_fast_hram: u32,
-    /// Time spent in `write_fast` for unmapped / ignored writes.
-    pub mem_write_fast_unmapped: u32,
-    /// Time spent in direct `memory.write_io(...)` calls from bus_write.
-    pub mem_write_io: u32,
-    /// Time spent enqueueing `pending_bus_events` from bus_write.
-    pub mem_write_enqueue: u32,
-    /// Time spent draining and handling queued bus events on the next M-cycle.
-    pub mem_write_route: u32,
-}
-
 #[derive(Default)]
 struct PendingApuCycles {
     cycles: u16,
@@ -243,7 +202,7 @@ pub struct Sm83 {
     #[cfg(feature = "trace")]
     trace_hook: Option<Box<dyn FnMut(TraceEvent<'_>)>>,
     #[cfg(feature = "perf")]
-    perf: Sm83PerfProfile,
+    perf: Sm83PerfRecorder,
 }
 
 /// State for an in-progress OAM DMA transfer.
@@ -278,7 +237,7 @@ impl Sm83 {
             #[cfg(feature = "trace")]
             trace_hook: None,
             #[cfg(feature = "perf")]
-            perf: Sm83PerfProfile::default(),
+            perf: Sm83PerfRecorder::default(),
         };
         // Seed JOYP with no buttons pressed (all lines high).
         sm83.memory.write_io(JOYP_ADDR, sm83.joypad.read());
@@ -368,7 +327,7 @@ impl Sm83 {
 
     #[cfg(feature = "perf")]
     pub fn take_perf_profile(&mut self) -> Sm83PerfProfile {
-        core::mem::take(&mut self.perf)
+        self.perf.take_profile()
     }
 
     #[cfg(feature = "perf")]
@@ -472,10 +431,12 @@ impl Sm83 {
         }
         self.tick_cycle();
         #[cfg(feature = "perf")]
-        let t0 = crate::cpu::perf::cyccnt();
+        let t0 = cyccnt();
         let value = self.memory.read_fast(addr);
         #[cfg(feature = "perf")]
-        { self.perf.mem_read = self.perf.mem_read.wrapping_add(crate::cpu::perf::cyccnt().wrapping_sub(t0)); }
+        {
+            self.perf.record_mem_read(cyccnt().wrapping_sub(t0));
+        }
         Ok(value)
     }
 
@@ -502,108 +463,46 @@ impl Sm83 {
         }
         self.tick_cycle();
         #[cfg(feature = "perf")]
-        let t0 = crate::cpu::perf::cyccnt();
+        let t0 = cyccnt();
         let result = match addr {
             0xFF00..=0xFF7F | 0xFFFF => {
                 #[cfg(feature = "perf")]
-                let t_io = crate::cpu::perf::cyccnt();
+                let t_io = cyccnt();
                 self.memory.write_io(addr, value);
                 #[cfg(feature = "perf")]
                 {
-                    self.perf.mem_write_io = self
-                        .perf
-                        .mem_write_io
-                        .wrapping_add(crate::cpu::perf::cyccnt().wrapping_sub(t_io));
+                    self.perf.record_mem_write_io(cyccnt().wrapping_sub(t_io));
                 }
 
                 #[cfg(feature = "perf")]
-                let t_enqueue = crate::cpu::perf::cyccnt();
+                let t_enqueue = cyccnt();
                 self.pending_bus_events.push(BusEvent {
                     address: addr,
                     value,
                 });
                 #[cfg(feature = "perf")]
                 {
-                    self.perf.mem_write_enqueue = self
-                        .perf
-                        .mem_write_enqueue
-                        .wrapping_add(crate::cpu::perf::cyccnt().wrapping_sub(t_enqueue));
+                    self.perf.record_mem_write_enqueue(cyccnt().wrapping_sub(t_enqueue));
                 }
                 Ok(())
             }
             0xE000..=0xFDFF => Err(MemoryError::ReadOnly(addr)),
             _ => {
                 #[cfg(feature = "perf")]
-                let t_fast = crate::cpu::perf::cyccnt();
+                let t_fast = cyccnt();
                 self.memory.write_fast(addr, value);
                 #[cfg(feature = "perf")]
                 {
-                    let dt = crate::cpu::perf::cyccnt().wrapping_sub(t_fast);
-                    self.perf.mem_write_fast = self.perf.mem_write_fast.wrapping_add(dt);
-                    self.record_mem_write_fast_region(addr, dt);
+                    self.perf.record_mem_write_fast(addr, cyccnt().wrapping_sub(t_fast));
                 }
                 Ok(())
             }
         };
         #[cfg(feature = "perf")]
-        { self.perf.mem_write = self.perf.mem_write.wrapping_add(crate::cpu::perf::cyccnt().wrapping_sub(t0)); }
-        result
-    }
-
-    #[cfg(feature = "perf")]
-    #[inline]
-    fn record_mem_write_fast_region(&mut self, addr: u16, dt: u32) {
-        match addr {
-            0x0000..=0x7FFF => {
-                self.perf.mem_write_fast_rom = self.perf.mem_write_fast_rom.wrapping_add(dt);
-                match addr {
-                    0x0000..=0x1FFF => {
-                        self.perf.mem_write_fast_rom_0000_1fff = self
-                            .perf
-                            .mem_write_fast_rom_0000_1fff
-                            .wrapping_add(dt);
-                    }
-                    0x2000..=0x3FFF => {
-                        self.perf.mem_write_fast_rom_2000_3fff = self
-                            .perf
-                            .mem_write_fast_rom_2000_3fff
-                            .wrapping_add(dt);
-                    }
-                    0x4000..=0x5FFF => {
-                        self.perf.mem_write_fast_rom_4000_5fff = self
-                            .perf
-                            .mem_write_fast_rom_4000_5fff
-                            .wrapping_add(dt);
-                    }
-                    0x6000..=0x7FFF => {
-                        self.perf.mem_write_fast_rom_6000_7fff = self
-                            .perf
-                            .mem_write_fast_rom_6000_7fff
-                            .wrapping_add(dt);
-                    }
-                    _ => {}
-                }
-            }
-            0x8000..=0x9FFF => {
-                self.perf.mem_write_fast_vram = self.perf.mem_write_fast_vram.wrapping_add(dt);
-            }
-            0xA000..=0xBFFF => {
-                self.perf.mem_write_fast_eram = self.perf.mem_write_fast_eram.wrapping_add(dt);
-            }
-            0xC000..=0xDFFF => {
-                self.perf.mem_write_fast_wram = self.perf.mem_write_fast_wram.wrapping_add(dt);
-            }
-            0xFE00..=0xFE9F => {
-                self.perf.mem_write_fast_oam = self.perf.mem_write_fast_oam.wrapping_add(dt);
-            }
-            0xFF80..=0xFFFE => {
-                self.perf.mem_write_fast_hram = self.perf.mem_write_fast_hram.wrapping_add(dt);
-            }
-            _ => {
-                self.perf.mem_write_fast_unmapped =
-                    self.perf.mem_write_fast_unmapped.wrapping_add(dt);
-            }
+        {
+            self.perf.record_mem_write(cyccnt().wrapping_sub(t0));
         }
+        result
     }
 
     /// Advance peripherals by one M-cycle (4 T-cycles) without a bus access.
@@ -720,7 +619,7 @@ impl Sm83 {
         }
 
         #[cfg(feature = "perf")]
-        let t0 = crate::cpu::perf::cyccnt();
+        let t0 = cyccnt();
         // Index-based loop: BusEvent is Copy, so each `e` is copied out before
         // handle_bus_event borrows &mut self, avoiding a borrow conflict.
         for i in 0..self.pending_bus_events.len() {
@@ -730,10 +629,7 @@ impl Sm83 {
         self.pending_bus_events.clear();
         #[cfg(feature = "perf")]
         {
-            self.perf.mem_write_route = self
-                .perf
-                .mem_write_route
-                .wrapping_add(crate::cpu::perf::cyccnt().wrapping_sub(t0));
+            self.perf.record_mem_write_route(cyccnt().wrapping_sub(t0));
         }
     }
 
@@ -802,7 +698,7 @@ impl Sm83 {
     #[cfg_attr(target_arch = "arm", link_section = ".data")]
     fn advance_ppu(&mut self, cycles: u16) {
         #[cfg(feature = "perf")]
-        let t0 = crate::cpu::perf::cyccnt();
+        let t0 = cyccnt();
         let output = self.ppu.tick(
             cycles,
             PpuInput {
@@ -841,15 +737,14 @@ impl Sm83 {
         }
         #[cfg(feature = "perf")]
         {
-            let dt = crate::cpu::perf::cyccnt().wrapping_sub(t0);
-            self.perf.ppu = self.perf.ppu.wrapping_add(dt);
+            self.perf.record_ppu(cyccnt().wrapping_sub(t0));
         }
     }
 
     #[cfg_attr(target_arch = "arm", link_section = ".data")]
     fn advance_timer(&mut self, cycles: u16) {
         #[cfg(feature = "perf")]
-        let t0 = crate::cpu::perf::cyccnt();
+        let t0 = cyccnt();
         let output = self.timer.tick(
             cycles,
             TimerInput {
@@ -872,8 +767,7 @@ impl Sm83 {
         }
         #[cfg(feature = "perf")]
         {
-            let dt = crate::cpu::perf::cyccnt().wrapping_sub(t0);
-            self.perf.timer = self.perf.timer.wrapping_add(dt);
+            self.perf.record_timer(cyccnt().wrapping_sub(t0));
         }
     }
 
@@ -894,7 +788,7 @@ impl Sm83 {
     #[cfg_attr(target_arch = "arm", link_section = ".data")]
     fn tick_apu(&mut self, cycles: u16) {
         #[cfg(feature = "perf")]
-        let t0 = crate::cpu::perf::cyccnt();
+        let t0 = cyccnt();
         let output = self.apu.tick(cycles, self.timer.internal_counter());
         if output.nr52 != self.cache.nr52 {
             self.cache.nr52 = output.nr52;
@@ -902,8 +796,7 @@ impl Sm83 {
         }
         #[cfg(feature = "perf")]
         {
-            let dt = crate::cpu::perf::cyccnt().wrapping_sub(t0);
-            self.perf.apu = self.perf.apu.wrapping_add(dt);
+            self.perf.record_apu(cyccnt().wrapping_sub(t0));
         }
     }
 
@@ -1087,12 +980,11 @@ impl Cpu for Sm83 {
     #[cfg_attr(target_arch = "arm", link_section = ".data")]
     fn tick(&mut self) -> Result<u8, CpuError> {
         #[cfg(feature = "perf")]
-        let tick_t0 = crate::cpu::perf::cyccnt();
+        let tick_t0 = cyccnt();
         let result = self.tick_impl();
         #[cfg(feature = "perf")]
         {
-            let dt = crate::cpu::perf::cyccnt().wrapping_sub(tick_t0);
-            self.perf.total = self.perf.total.wrapping_add(dt);
+            self.perf.record_total(cyccnt().wrapping_sub(tick_t0));
         }
         result
     }

--- a/core/src/cpu/sm83.rs
+++ b/core/src/cpu/sm83.rs
@@ -157,6 +157,36 @@ pub struct Sm83PerfProfile {
     pub mem_read: u32,
     /// Time spent in memory writes (write_fast/write_io) inside bus_write, excluding tick overhead.
     pub mem_write: u32,
+    /// Time spent in direct `memory.write_fast(...)` calls from bus_write.
+    pub mem_write_fast: u32,
+    /// Time spent in `write_fast` for ROM/MBC control writes (0x0000-0x7FFF).
+    pub mem_write_fast_rom: u32,
+    /// Time spent in `write_fast` for ROM control writes at 0x0000-0x1FFF.
+    pub mem_write_fast_rom_0000_1fff: u32,
+    /// Time spent in `write_fast` for ROM control writes at 0x2000-0x3FFF.
+    pub mem_write_fast_rom_2000_3fff: u32,
+    /// Time spent in `write_fast` for ROM control writes at 0x4000-0x5FFF.
+    pub mem_write_fast_rom_4000_5fff: u32,
+    /// Time spent in `write_fast` for ROM control writes at 0x6000-0x7FFF.
+    pub mem_write_fast_rom_6000_7fff: u32,
+    /// Time spent in `write_fast` for external RAM / cartridge RAM writes (0xA000-0xBFFF).
+    pub mem_write_fast_eram: u32,
+    /// Time spent in `write_fast` for VRAM writes (0x8000-0x9FFF).
+    pub mem_write_fast_vram: u32,
+    /// Time spent in `write_fast` for WRAM writes (0xC000-0xDFFF).
+    pub mem_write_fast_wram: u32,
+    /// Time spent in `write_fast` for OAM writes (0xFE00-0xFE9F).
+    pub mem_write_fast_oam: u32,
+    /// Time spent in `write_fast` for HRAM writes (0xFF80-0xFFFE).
+    pub mem_write_fast_hram: u32,
+    /// Time spent in `write_fast` for unmapped / ignored writes.
+    pub mem_write_fast_unmapped: u32,
+    /// Time spent in direct `memory.write_io(...)` calls from bus_write.
+    pub mem_write_io: u32,
+    /// Time spent enqueueing `pending_bus_events` from bus_write.
+    pub mem_write_enqueue: u32,
+    /// Time spent draining and handling queued bus events on the next M-cycle.
+    pub mem_write_route: u32,
 }
 
 #[derive(Default)]
@@ -351,6 +381,13 @@ impl Sm83 {
         self.apu.take_perf_profile()
     }
 
+    #[cfg(feature = "perf")]
+    pub fn take_cartridge_perf_profile(
+        &mut self,
+    ) -> crate::memory::cartridge::CartridgePerfProfile {
+        self.memory.take_cartridge_perf_profile()
+    }
+
     /// Returns the cartridge external RAM (battery save data), or `None` if cart has no RAM.
     pub fn external_ram(&self) -> Option<&[u8]> {
         self.memory.external_ram()
@@ -468,22 +505,105 @@ impl Sm83 {
         let t0 = crate::cpu::perf::cyccnt();
         let result = match addr {
             0xFF00..=0xFF7F | 0xFFFF => {
+                #[cfg(feature = "perf")]
+                let t_io = crate::cpu::perf::cyccnt();
                 self.memory.write_io(addr, value);
+                #[cfg(feature = "perf")]
+                {
+                    self.perf.mem_write_io = self
+                        .perf
+                        .mem_write_io
+                        .wrapping_add(crate::cpu::perf::cyccnt().wrapping_sub(t_io));
+                }
+
+                #[cfg(feature = "perf")]
+                let t_enqueue = crate::cpu::perf::cyccnt();
                 self.pending_bus_events.push(BusEvent {
                     address: addr,
                     value,
                 });
+                #[cfg(feature = "perf")]
+                {
+                    self.perf.mem_write_enqueue = self
+                        .perf
+                        .mem_write_enqueue
+                        .wrapping_add(crate::cpu::perf::cyccnt().wrapping_sub(t_enqueue));
+                }
                 Ok(())
             }
             0xE000..=0xFDFF => Err(MemoryError::ReadOnly(addr)),
             _ => {
+                #[cfg(feature = "perf")]
+                let t_fast = crate::cpu::perf::cyccnt();
                 self.memory.write_fast(addr, value);
+                #[cfg(feature = "perf")]
+                {
+                    let dt = crate::cpu::perf::cyccnt().wrapping_sub(t_fast);
+                    self.perf.mem_write_fast = self.perf.mem_write_fast.wrapping_add(dt);
+                    self.record_mem_write_fast_region(addr, dt);
+                }
                 Ok(())
             }
         };
         #[cfg(feature = "perf")]
         { self.perf.mem_write = self.perf.mem_write.wrapping_add(crate::cpu::perf::cyccnt().wrapping_sub(t0)); }
         result
+    }
+
+    #[cfg(feature = "perf")]
+    #[inline]
+    fn record_mem_write_fast_region(&mut self, addr: u16, dt: u32) {
+        match addr {
+            0x0000..=0x7FFF => {
+                self.perf.mem_write_fast_rom = self.perf.mem_write_fast_rom.wrapping_add(dt);
+                match addr {
+                    0x0000..=0x1FFF => {
+                        self.perf.mem_write_fast_rom_0000_1fff = self
+                            .perf
+                            .mem_write_fast_rom_0000_1fff
+                            .wrapping_add(dt);
+                    }
+                    0x2000..=0x3FFF => {
+                        self.perf.mem_write_fast_rom_2000_3fff = self
+                            .perf
+                            .mem_write_fast_rom_2000_3fff
+                            .wrapping_add(dt);
+                    }
+                    0x4000..=0x5FFF => {
+                        self.perf.mem_write_fast_rom_4000_5fff = self
+                            .perf
+                            .mem_write_fast_rom_4000_5fff
+                            .wrapping_add(dt);
+                    }
+                    0x6000..=0x7FFF => {
+                        self.perf.mem_write_fast_rom_6000_7fff = self
+                            .perf
+                            .mem_write_fast_rom_6000_7fff
+                            .wrapping_add(dt);
+                    }
+                    _ => {}
+                }
+            }
+            0x8000..=0x9FFF => {
+                self.perf.mem_write_fast_vram = self.perf.mem_write_fast_vram.wrapping_add(dt);
+            }
+            0xA000..=0xBFFF => {
+                self.perf.mem_write_fast_eram = self.perf.mem_write_fast_eram.wrapping_add(dt);
+            }
+            0xC000..=0xDFFF => {
+                self.perf.mem_write_fast_wram = self.perf.mem_write_fast_wram.wrapping_add(dt);
+            }
+            0xFE00..=0xFE9F => {
+                self.perf.mem_write_fast_oam = self.perf.mem_write_fast_oam.wrapping_add(dt);
+            }
+            0xFF80..=0xFFFE => {
+                self.perf.mem_write_fast_hram = self.perf.mem_write_fast_hram.wrapping_add(dt);
+            }
+            _ => {
+                self.perf.mem_write_fast_unmapped =
+                    self.perf.mem_write_fast_unmapped.wrapping_add(dt);
+            }
+        }
     }
 
     /// Advance peripherals by one M-cycle (4 T-cycles) without a bus access.
@@ -595,6 +715,12 @@ impl Sm83 {
 
     #[cfg_attr(target_arch = "arm", link_section = ".data")]
     fn route_bus_events(&mut self) {
+        if self.pending_bus_events.is_empty() {
+            return;
+        }
+
+        #[cfg(feature = "perf")]
+        let t0 = crate::cpu::perf::cyccnt();
         // Index-based loop: BusEvent is Copy, so each `e` is copied out before
         // handle_bus_event borrows &mut self, avoiding a borrow conflict.
         for i in 0..self.pending_bus_events.len() {
@@ -602,6 +728,13 @@ impl Sm83 {
             self.handle_bus_event(e.address, e.value);
         }
         self.pending_bus_events.clear();
+        #[cfg(feature = "perf")]
+        {
+            self.perf.mem_write_route = self
+                .perf
+                .mem_write_route
+                .wrapping_add(crate::cpu::perf::cyccnt().wrapping_sub(t0));
+        }
     }
 
     #[cfg_attr(target_arch = "arm", link_section = ".data")]

--- a/core/src/memory/cartridge.rs
+++ b/core/src/memory/cartridge.rs
@@ -9,6 +9,20 @@ use alloc::{boxed::Box, vec, vec::Vec};
 
 // ── Cartridge trait ──────────────────────────────────────────────────────────
 
+#[cfg(feature = "perf")]
+#[derive(Default)]
+pub struct CartridgePerfProfile {
+    pub write_rom: u32,
+    pub write_ram: u32,
+    pub control_write: u32,
+    pub sync_caches: u32,
+    pub sync_caches_calls: u32,
+    pub read_bank_fixed: u32,
+    pub read_bank_fixed_calls: u32,
+    pub read_bank_switchable: u32,
+    pub read_bank_switchable_calls: u32,
+}
+
 pub trait Cartridge {
     fn read_rom(&self, addr: u16) -> u8;
     fn read_ram(&self, addr: u16) -> u8;
@@ -28,6 +42,10 @@ pub trait Cartridge {
     /// Restore MBC register state from `data` starting at `offset`.
     /// Returns number of bytes consumed. Default: 0 (no state).
     fn load_mbc_state(&mut self, _data: &[u8], _offset: usize) -> usize { 0 }
+    #[cfg(feature = "perf")]
+    fn take_perf_profile(&mut self) -> CartridgePerfProfile {
+        CartridgePerfProfile::default()
+    }
 }
 
 // ── Header helpers ───────────────────────────────────────────────────────────
@@ -268,23 +286,35 @@ impl Cartridge for Mbc1 {
         match addr {
             // RAM enable: any write with lower nibble 0x0A enables, anything else disables
             0x0000..=0x1FFF => {
-                self.ram_enabled = value & 0x0F == 0x0A;
+                let enabled = value & 0x0F == 0x0A;
+                if self.ram_enabled != enabled {
+                    self.ram_enabled = enabled;
+                }
             }
             // ROM bank number (lower 5 bits)
             0x2000..=0x3FFF => {
-                self.rom_bank_lo = value & 0x1F;
+                let mut bank = value & 0x1F;
                 // Writing 0 is treated as 1
-                if self.rom_bank_lo == 0 {
-                    self.rom_bank_lo = 1;
+                if bank == 0 {
+                    bank = 1;
+                }
+                if self.rom_bank_lo != bank {
+                    self.rom_bank_lo = bank;
                 }
             }
             // Upper bits register (2 bits)
             0x4000..=0x5FFF => {
-                self.upper_bits = value & 0x03;
+                let bits = value & 0x03;
+                if self.upper_bits != bits {
+                    self.upper_bits = bits;
+                }
             }
             // Banking mode select
             0x6000..=0x7FFF => {
-                self.ram_mode = value & 0x01 != 0;
+                let ram_mode = value & 0x01 != 0;
+                if self.ram_mode != ram_mode {
+                    self.ram_mode = ram_mode;
+                }
             }
             // External RAM write
             0xA000..=0xBFFF => {
@@ -412,20 +442,32 @@ impl Cartridge for Mbc1Multicart {
     fn write(&mut self, addr: u16, value: u8) {
         match addr {
             0x0000..=0x1FFF => {
-                self.ram_enabled = value & 0x0F == 0x0A;
+                let enabled = value & 0x0F == 0x0A;
+                if self.ram_enabled != enabled {
+                    self.ram_enabled = enabled;
+                }
             }
             // Lower bank register: 4-bit effective, 0→1 alias preserved
             0x2000..=0x3FFF => {
-                self.rom_bank_lo = value & 0x1F;
-                if self.rom_bank_lo == 0 {
-                    self.rom_bank_lo = 1;
+                let mut bank = value & 0x1F;
+                if bank == 0 {
+                    bank = 1;
+                }
+                if self.rom_bank_lo != bank {
+                    self.rom_bank_lo = bank;
                 }
             }
             0x4000..=0x5FFF => {
-                self.upper_bits = value & 0x03;
+                let bits = value & 0x03;
+                if self.upper_bits != bits {
+                    self.upper_bits = bits;
+                }
             }
             0x6000..=0x7FFF => {
-                self.ram_mode = value & 0x01 != 0;
+                let ram_mode = value & 0x01 != 0;
+                if self.ram_mode != ram_mode {
+                    self.ram_mode = ram_mode;
+                }
             }
             0xA000..=0xBFFF => {
                 if self.ram_enabled && !self.ram.is_empty() {
@@ -638,15 +680,23 @@ impl Cartridge for Mbc3 {
         match addr {
             // RAM/timer enable
             0x0000..=0x1FFF => {
-                self.ram_rtc_enabled = value & 0x0F == 0x0A;
+                let enabled = value & 0x0F == 0x0A;
+                if self.ram_rtc_enabled != enabled {
+                    self.ram_rtc_enabled = enabled;
+                }
             }
             // ROM bank number (7-bit, 0→1)
             0x2000..=0x3FFF => {
-                self.rom_bank = if value & 0x7F == 0 { 1 } else { value & 0x7F };
+                let bank = if value & 0x7F == 0 { 1 } else { value & 0x7F };
+                if self.rom_bank != bank {
+                    self.rom_bank = bank;
+                }
             }
             // RAM bank / RTC register select
             0x4000..=0x5FFF => {
-                self.bank_or_rtc = value;
+                if self.bank_or_rtc != value {
+                    self.bank_or_rtc = value;
+                }
             }
             // Latch clock data: 0x00 arms, 0x01 latches
             0x6000..=0x7FFF => {

--- a/core/src/memory/memory.rs
+++ b/core/src/memory/memory.rs
@@ -158,6 +158,11 @@ impl GameBoyMemory {
         self.cartridge.current_rom_bank()
     }
 
+    #[cfg(feature = "perf")]
+    pub fn take_cartridge_perf_profile(&mut self) -> super::cartridge::CartridgePerfProfile {
+        self.cartridge.take_perf_profile()
+    }
+
     /// Advance the cartridge RTC by `cycles` T-cycles. No-op for non-RTC carts.
     pub fn tick_rtc(&mut self, cycles: u32) {
         self.cartridge.tick_rtc(cycles);

--- a/core/src/memory/streaming.rs
+++ b/core/src/memory/streaming.rs
@@ -2,6 +2,8 @@ use alloc::vec;
 use alloc::vec::Vec;
 
 use super::cartridge::Cartridge;
+#[cfg(feature = "perf")]
+use super::cartridge::CartridgePerfProfile;
 
 // ── RomReader trait ──────────────────────────────────────────────────────────
 
@@ -51,6 +53,8 @@ pub struct StreamingCartridge<R: RomReader> {
     rom_bank_count:   usize,
     mbc:              MbcState,
     ram:              Vec<u8>,
+    #[cfg(feature = "perf")]
+    perf_profile:     CartridgePerfProfile,
 }
 
 impl<R: RomReader> StreamingCartridge<R> {
@@ -76,6 +80,8 @@ impl<R: RomReader> StreamingCartridge<R> {
             rom_bank_count,
             mbc,
             ram: vec![0u8; ram_bytes],
+            #[cfg(feature = "perf")]
+            perf_profile: CartridgePerfProfile::default(),
         })
     }
 
@@ -106,46 +112,128 @@ impl<R: RomReader> StreamingCartridge<R> {
     }
 
     fn sync_caches(&mut self) {
+        #[cfg(feature = "perf")]
+        let t_sync = crate::cpu::perf::cyccnt();
         let new_fixed      = self.effective_fixed_bank();
         let new_switchable = self.effective_switchable_bank();
 
         if new_fixed != self.fixed_bank_num {
+            #[cfg(feature = "perf")]
+            let t_read = crate::cpu::perf::cyccnt();
             if self.reader.read_bank(new_fixed, &mut self.bank0_cache).is_err() {
                 self.bank0_cache.fill(0xFF);
+            }
+            #[cfg(feature = "perf")]
+            {
+                self.perf_profile.read_bank_fixed = self
+                    .perf_profile
+                    .read_bank_fixed
+                    .wrapping_add(crate::cpu::perf::cyccnt().wrapping_sub(t_read));
+                self.perf_profile.read_bank_fixed_calls = self
+                    .perf_profile
+                    .read_bank_fixed_calls
+                    .wrapping_add(1);
             }
             self.fixed_bank_num = new_fixed;
         }
         if new_switchable != self.current_bank_num {
+            #[cfg(feature = "perf")]
+            let t_read = crate::cpu::perf::cyccnt();
             if self.reader.read_bank(new_switchable, &mut self.banked_cache).is_err() {
                 self.banked_cache.fill(0xFF);
             }
+            #[cfg(feature = "perf")]
+            {
+                self.perf_profile.read_bank_switchable = self
+                    .perf_profile
+                    .read_bank_switchable
+                    .wrapping_add(crate::cpu::perf::cyccnt().wrapping_sub(t_read));
+                self.perf_profile.read_bank_switchable_calls = self
+                    .perf_profile
+                    .read_bank_switchable_calls
+                    .wrapping_add(1);
+            }
             self.current_bank_num = new_switchable;
+        }
+        #[cfg(feature = "perf")]
+        {
+            self.perf_profile.sync_caches = self
+                .perf_profile
+                .sync_caches
+                .wrapping_add(crate::cpu::perf::cyccnt().wrapping_sub(t_sync));
+            self.perf_profile.sync_caches_calls = self
+                .perf_profile
+                .sync_caches_calls
+                .wrapping_add(1);
         }
     }
 
-    fn handle_mbc_write(&mut self, addr: u16, value: u8) {
+    /// Apply an MBC register write.
+    ///
+    /// Returns `true` only when the write can change the visible ROM mapping
+    /// and therefore requires `sync_caches()`.
+    fn handle_mbc_write(&mut self, addr: u16, value: u8) -> bool {
         match &mut self.mbc {
-            MbcState::NoMbc => {}
+            MbcState::NoMbc => false,
             MbcState::Mbc1 { rom_bank_lo, upper_bits, ram_mode, ram_enabled, .. } => {
                 match addr {
-                    0x0000..=0x1FFF => *ram_enabled = value & 0x0F == 0x0A,
-                    0x2000..=0x3FFF => {
-                        *rom_bank_lo = value & 0x1F;
-                        if *rom_bank_lo == 0 { *rom_bank_lo = 1; }
+                    0x0000..=0x1FFF => {
+                        *ram_enabled = value & 0x0F == 0x0A;
+                        false
                     }
-                    0x4000..=0x5FFF => *upper_bits = value & 0x03,
-                    0x6000..=0x7FFF => *ram_mode   = value & 0x01 != 0,
-                    _ => {}
+                    0x2000..=0x3FFF => {
+                        let mut bank = value & 0x1F;
+                        if bank == 0 {
+                            bank = 1;
+                        }
+                        if *rom_bank_lo == bank {
+                            false
+                        } else {
+                            *rom_bank_lo = bank;
+                            true
+                        }
+                    }
+                    0x4000..=0x5FFF => {
+                        let bits = value & 0x03;
+                        if *upper_bits == bits {
+                            false
+                        } else {
+                            *upper_bits = bits;
+                            true
+                        }
+                    }
+                    0x6000..=0x7FFF => {
+                        let new_ram_mode = value & 0x01 != 0;
+                        if *ram_mode == new_ram_mode {
+                            false
+                        } else {
+                            *ram_mode = new_ram_mode;
+                            true
+                        }
+                    }
+                    _ => false,
                 }
             }
             MbcState::Mbc3 { rom_bank, bank_or_rtc, ram_rtc_enabled } => {
                 match addr {
-                    0x0000..=0x1FFF => *ram_rtc_enabled = value & 0x0F == 0x0A,
-                    0x2000..=0x3FFF => {
-                        *rom_bank = if value & 0x7F == 0 { 1 } else { value & 0x7F };
+                    0x0000..=0x1FFF => {
+                        *ram_rtc_enabled = value & 0x0F == 0x0A;
+                        false
                     }
-                    0x4000..=0x5FFF => *bank_or_rtc = value,
-                    _ => {}
+                    0x2000..=0x3FFF => {
+                        let bank = if value & 0x7F == 0 { 1 } else { value & 0x7F };
+                        if *rom_bank == bank {
+                            false
+                        } else {
+                            *rom_bank = bank;
+                            true
+                        }
+                    }
+                    0x4000..=0x5FFF => {
+                        *bank_or_rtc = value;
+                        false
+                    }
+                    _ => false,
                 }
             }
         }
@@ -188,13 +276,49 @@ impl<R: RomReader> Cartridge for StreamingCartridge<R> {
 
     fn write(&mut self, addr: u16, value: u8) {
         if (0xA000..=0xBFFF).contains(&addr) {
+            #[cfg(feature = "perf")]
+            let t_ram = crate::cpu::perf::cyccnt();
             if self.is_ram_enabled() && !self.ram.is_empty() {
                 let offset = self.mbc1_ram_bank() * 0x2000 + (addr - 0xA000) as usize;
                 if let Some(b) = self.ram.get_mut(offset) { *b = value; }
             }
+            #[cfg(feature = "perf")]
+            {
+                self.perf_profile.write_ram = self
+                    .perf_profile
+                    .write_ram
+                    .wrapping_add(crate::cpu::perf::cyccnt().wrapping_sub(t_ram));
+            }
         } else {
-            self.handle_mbc_write(addr, value);
-            self.sync_caches();
+            #[cfg(feature = "perf")]
+            let t_rom = crate::cpu::perf::cyccnt();
+            #[cfg(feature = "perf")]
+            let t_control = crate::cpu::perf::cyccnt();
+            if self.handle_mbc_write(addr, value) {
+                #[cfg(feature = "perf")]
+                {
+                    self.perf_profile.control_write = self
+                        .perf_profile
+                        .control_write
+                        .wrapping_add(crate::cpu::perf::cyccnt().wrapping_sub(t_control));
+                }
+                self.sync_caches();
+            } else {
+                #[cfg(feature = "perf")]
+                {
+                    self.perf_profile.control_write = self
+                        .perf_profile
+                        .control_write
+                        .wrapping_add(crate::cpu::perf::cyccnt().wrapping_sub(t_control));
+                }
+            }
+            #[cfg(feature = "perf")]
+            {
+                self.perf_profile.write_rom = self
+                    .perf_profile
+                    .write_rom
+                    .wrapping_add(crate::cpu::perf::cyccnt().wrapping_sub(t_rom));
+            }
         }
     }
 
@@ -246,6 +370,11 @@ impl<R: RomReader> Cartridge for StreamingCartridge<R> {
             self.sync_caches();
         }
         consumed
+    }
+
+    #[cfg(feature = "perf")]
+    fn take_perf_profile(&mut self) -> CartridgePerfProfile {
+        core::mem::take(&mut self.perf_profile)
     }
 }
 
@@ -439,6 +568,14 @@ mod tests {
         let mut cart = mbc3(8);
         cart.write(0x2000, 0x00);
         assert_eq!(cart.current_rom_bank(), 1);
+    }
+
+    #[test]
+    fn mbc3_bank_or_rtc_select_skips_reload() {
+        let mut cart = mbc3(8);
+        cart.reader.read_log.clear();
+        cart.write(0x4000, 0x02);
+        assert!(cart.reader.read_log.is_empty());
     }
 
     #[test]

--- a/docs/performance-roadmap.md
+++ b/docs/performance-roadmap.md
@@ -1,139 +1,96 @@
 # Performance Roadmap
 
-## Current state — post dispatch-refactor baseline
+## Current state — post display/APU work and direct-XIP cartridge path
 
 ROM: Tetris, Pico2W @ 250 MHz.
 
-### Wall-clock breakdown (fps = 9)
+### Representative steady-state perf window (fps = 16)
 
-| Bucket | Time / 60 frames | % of wall clock |
+| Bucket | Cycles / 60 frames | Notes |
 |---|---|---|
-| Emulation (DWT) | 3.52 s (879M cycles) | 53% |
-| Display + other | 3.15 s | 47% |
-| **Total** | **6.67 s** | **100%** |
+| total | 825M–838M | Perf build, Tetris |
+| decode / dispatch | 461M–466M | Now the clearest CPU wall |
+| ppu | 224M–226M | Still substantial but secondary |
+| apu | 83M–90M | APU batching landed successfully |
+| mem_read | 34M–35M | Slightly higher after direct XIP, still small |
+| mem_write | 3M–4M | Bank-switch copy cost is gone |
+| timer | ~18M | Stable |
 
-Target: 1.00 s / 60 frames (60 fps).  
-Required speedup: **6.7×**.
+### Display status
 
-### Emulation sub-breakdown (879M cycles)
-
-| Component | Cycles | % of emulation |
-|---|---|---|
-| decode / dispatch | 406M | 46% |
-| apu | 205M | 23% |
-| ppu | 160M | 18% |
-| mem_write | 54M | 6% |
-| mem_read | 29M | 3% |
-| timer | 26M | 3% |
-
-### Hard ceiling without touching display
-
-Even if emulation cost were zero, the display/other overhead alone gives:
-
-60 ÷ 3.15 s = **~19 fps maximum**
-
-Both tracks (emulation and display) must be attacked together to reach 60 fps.
+- `fill` is now ~1 ms / 60f after the async transfer work.
+- `scale` is still ~224 ms / 60f, but display is no longer the main ceiling.
+- The performance story is now mostly CPU-side again.
 
 ---
 
-## Priority 1 — Async display transfer
+## Landed — Direct-XIP ROM path for staged flash
 
-**Expected impact: largest single lever, potentially 2–3× fps gain**
+The Pico now uses a direct-XIP cartridge path instead of refilling a 16 KiB SRAM
+bank cache on every ROM bank switch.
 
-The display currently blocks the CPU for ~13 ms per frame (240×216 × 2 bytes over
-62.5 MHz SPI), plus unknown software-scaling overhead. The game loop sits idle
-waiting for this transfer to complete.
+Measured result on Tetris:
+
+- `fps` improved from 13–14 to 16
+- `total` dropped from ~976M–1009M to ~825M–838M cycles / 60f
+- `mem_write` dropped from ~140M–169M to ~3M–4M cycles / 60f
+- Cartridge perf counters now show tiny ROM control-write cost and zero bank-reload work
+
+This change paid off immediately and should stay.
+
+---
+
+## Priority 1 — Decode / ROM fetch fast path
+
+**Expected impact: still likely the next broad CPU win after the cartridge path**
+
+Now that the cartridge bank-switch path is addressed, `decode` remains the biggest
+bucket by a wide margin.
 
 ### What to do
 
-1. **Profile the display path** — add DWT instrumentation around `render_game_only`
-   to separate the SPI transfer time from the software scaler (1.5× pixel iterator).
-
-2. **DMA-backed SPI transfer** — `embassy-rp` supports async DMA SPI writes. Start
-   the transfer at VBlank, let emulation run for the next frame concurrently, await
-   completion only if the next VBlank arrives before the DMA finishes. This hides
-   the transfer latency almost entirely behind emulation work.
-
-3. **Pre-scale into a u16 framebuffer** — instead of running the 1.5× scale iterator
-   inside the SPI callback, maintain a `[u16; 240 * 216]` front buffer that is updated
-   once per VBlank. The DMA transfer then reads directly from this buffer with no
-   per-pixel CPU work during the transfer.
+1. Revisit a ROM opcode-fetch fast path after the cartridge work lands.
+2. Prefer this over instruction-level tick batching unless timing evidence says
+   batching is required; the ROM fast path is less invasive.
 
 ---
 
-## Priority 2 — APU cycle batching
+## Priority 2 — PPU work that is actually hot
 
-**Expected impact: ~80–100M cycles saved (~9–11% of total emulation)**
+**Expected impact: moderate; only worth revisiting with a simpler design**
 
-`advance_apu` is called on every M-cycle (~1.05M times/second). The APU already
-implements skip-ahead arithmetic for frequency timers, so it handles large cycle
-batches correctly.
+The attempted `build_stat` cache did not pay off and added invalidation complexity.
+Keep the simple implementation unless we move to a more event-driven STAT update
+model later.
 
 ### What to do
 
-Add a `pending_apu_cycles: u16` accumulator to `Sm83`. Increment it instead of
-calling `apu.tick()` on every `tick_cycle`. Flush via `apu.tick(pending, ...)` at:
-- End of each instruction (in `tick_impl`, before the interrupt check)
-- Before any APU register write (the `tick_cycle_to_t3` path already handles
-  T-cycle precision for writes — flush before entering that path)
-
-This reduces APU tick call frequency from ~1M/s to ~350K/s (once per instruction
-on average), cutting function-call overhead by ~3× while the skip-ahead arithmetic
-absorbs the larger cycle batches.
+1. Leave `build_stat` alone for now.
+2. If PPU optimization comes back onto the critical path, look for a transition-based
+   design rather than another tiny hot-path cache.
 
 ---
 
-## Priority 3 — PPU `build_stat` cache
+## Priority 3 — Display scaler cleanup
 
-**Expected impact: ~20M cycles saved (~2% of total emulation)**
+**Expected impact: useful but no longer urgent**
 
-`build_stat` recomputes the STAT register and STAT interrupt edge on every M-cycle
-(~1M times/second). The result only changes when LY changes (154×/frame), the PPU
-mode changes (~4×/scanline), or the game writes to STAT.
+The remaining display cost is mostly scaling (`~224 ms / 60f`). That matters, but
+it is smaller than the current CPU hotspots.
 
 ### What to do
 
-Add `stat_cache: u8` and `stat_line_cache: bool` fields to `PpuPeripheral`.  
-Set a `stat_dirty: bool` flag when:
-- `self.ly` changes
-- `self.mode` changes  
-- A new `input.stat` differs from the previous call's stat
-
-In `build_stat`, return the cached value if `!stat_dirty`. Reset the flag after
-recomputing. This drops 99%+ of `build_stat` calls to a single branch.
+Look at scaler-specific wins only after the cartridge and decode work, or if a
+non-invasive scaler cleanup becomes obvious.
 
 ---
 
-## Priority 4 — `pending_bus_events` fixed-size array
+## Priority 4 — Deprioritized experiments
 
-**Expected impact: small, reduces mem_write overhead**
-
-`pending_bus_events: Vec<BusEvent>` does a bounds-check + capacity-check on every
-I/O write. Since at most one I/O write can be pending per M-cycle before
-`route_bus_events` drains it, the queue never exceeds a handful of entries.
-
-### What to do
-
-Replace `Vec<BusEvent>` with `[BusEvent; 4]` + `len: usize`. Eliminates the heap
-indirection and capacity check on the write hot path.
-
----
-
-## Priority 5 — `decode` remainder (longer term)
-
-After the above changes, decode/dispatch will still sit at ~350–400M cycles. The
-remaining cost is dominated by:
-
-- `read_next_pc` → `bus_read` → `tick_cycle` → `advance_peripherals` on every
-  opcode fetch and operand byte — this is inherently sequential and hard to batch
-- `resolve_r8` match per operand fetch
-
-Further gains here would require either:
-- **Instruction-level batching**: run N M-cycles of peripheral advance at the end
-  of each instruction rather than one per bus access (changes timing semantics,
-  needs careful correctness validation against blargg/mooneye)
-- **ROM read fast path**: detect that the PC is in ROM (0x0000–0x7FFF) and bypass
-  the full `bus_read` path for opcode fetches, since ROM reads have no side effects
+- `pending_bus_events` fixed-size array: measured cost is noise compared to
+  `write_fast` and should not be a near-term priority.
+- `PPU build_stat` cache: tried and reverted; complexity was not justified by the
+  measurements.
 
 ---
 
@@ -141,8 +98,7 @@ Further gains here would require either:
 
 | # | Change | Est. savings | Effort | Unblocks |
 |---|---|---|---|---|
-| 1 | Async DMA display | ~2–3× fps | Medium | 60 fps ceiling |
-| 2 | APU cycle batching | ~80–100M cycles | Small | — |
-| 3 | PPU build_stat cache | ~20M cycles | Small | — |
-| 4 | Fixed pending_bus_events | small | Trivial | — |
-| 5 | Instruction-level tick batching | ~100M+ cycles | Large | — |
+| 1 | ROM fetch / decode fast path | large | Medium | — |
+| 2 | Event-driven PPU STAT work | moderate | Medium | — |
+| 3 | Display scaler cleanup | small/moderate | Medium | — |
+| 4 | Fixed `pending_bus_events` / tiny caches | small | Small | — |

--- a/platform/pico2w/src/lib.rs
+++ b/platform/pico2w/src/lib.rs
@@ -1,5 +1,7 @@
 #![cfg_attr(target_arch = "arm", no_std)]
 
+extern crate alloc;
+
 #[cfg(target_arch = "arm")]
 pub mod audio;
 pub mod display;
@@ -10,3 +12,4 @@ pub mod input;
 pub mod sd;
 #[cfg(target_arch = "arm")]
 pub mod stack_probe;
+pub mod xip_cartridge;

--- a/platform/pico2w/src/main.rs
+++ b/platform/pico2w/src/main.rs
@@ -41,16 +41,17 @@ use rustyboy_core::cpu::instructions::opcodes::OpCodeDecoder;
 use rustyboy_core::cpu::peripheral::joypad::Button;
 use rustyboy_core::cpu::registers::{Flags, Registers};
 use rustyboy_core::cpu::sm83::Sm83;
-use rustyboy_core::memory::{GameBoyMemory, StreamingCartridge};
+use rustyboy_core::memory::GameBoyMemory;
 use rustyboy_pico2w::audio::{AudioBuffers, SAMPLE_RATE};
 use rustyboy_pico2w::display::hw::{GameDisplay, HwDisplay};
 use rustyboy_pico2w::display::scale_to_rgb565;
 use rustyboy_pico2w::flash_rom::{
-    new_onboard_flash, probe_staged_rom, stage_rom_from_reader, FlashRomReader,
+    new_onboard_flash, probe_staged_rom, stage_rom_from_reader,
 };
 use rustyboy_pico2w::input::{ButtonState, InputHandler};
 use rustyboy_pico2w::sd::{DummyClock, SdRomReader};
 use rustyboy_pico2w::stack_probe;
+use rustyboy_pico2w::xip_cartridge::XipCartridge;
 
 #[cfg(feature = "oc-266")]
 const TARGET_SYS_HZ: u32 = 266_000_000;
@@ -191,11 +192,11 @@ async fn main(_spawner: Spawner) {
         info
     };
 
-    info!("building StreamingCartridge");
-    let cart = match StreamingCartridge::new(FlashRomReader::new(onboard_flash, flash_info)) {
+    info!("building XipCartridge");
+    let cart = match XipCartridge::from_staged_flash(flash_info) {
         Ok(c) => c,
         Err(e) => {
-            error!("flash ROM load failed: {:?}", defmt::Debug2Format(&e));
+            error!("flash ROM mapping failed: {:?}", defmt::Debug2Format(&e));
             loop {
                 Timer::after(Duration::from_millis(2_000)).await;
             }

--- a/platform/pico2w/src/perf.rs
+++ b/platform/pico2w/src/perf.rs
@@ -52,9 +52,39 @@ impl PerfTracker {
             let p = cpu.take_perf_profile();
             let cpu_exec = p.total.wrapping_sub(p.ppu).wrapping_sub(p.timer).wrapping_sub(p.apu);
             let decode = cpu_exec.wrapping_sub(p.mem_read).wrapping_sub(p.mem_write);
+            let mem_write_other = p
+                .mem_write
+                .wrapping_sub(p.mem_write_fast)
+                .wrapping_sub(p.mem_write_io)
+                .wrapping_sub(p.mem_write_enqueue);
             info!(
                 "cycles/60f — total={} ppu={} timer={} apu={} cpu_exec={} (mem_r={} mem_w={} decode={})",
                 p.total, p.ppu, p.timer, p.apu, cpu_exec, p.mem_read, p.mem_write, decode
+            );
+            info!(
+                "mem_write breakdown — fast={} io={} enqueue={} other={} route={}",
+                p.mem_write_fast,
+                p.mem_write_io,
+                p.mem_write_enqueue,
+                mem_write_other,
+                p.mem_write_route
+            );
+            info!(
+                "mem_write fast breakdown — rom={} eram={} vram={} wram={} oam={} hram={} unmapped={}",
+                p.mem_write_fast_rom,
+                p.mem_write_fast_eram,
+                p.mem_write_fast_vram,
+                p.mem_write_fast_wram,
+                p.mem_write_fast_oam,
+                p.mem_write_fast_hram,
+                p.mem_write_fast_unmapped
+            );
+            info!(
+                "mem_write rom breakdown — 0000-1fff={} 2000-3fff={} 4000-5fff={} 6000-7fff={}",
+                p.mem_write_fast_rom_0000_1fff,
+                p.mem_write_fast_rom_2000_3fff,
+                p.mem_write_fast_rom_4000_5fff,
+                p.mem_write_fast_rom_6000_7fff
             );
 
             let pp = cpu.take_ppu_perf_profile();
@@ -67,6 +97,20 @@ impl PerfTracker {
             info!(
                 "apu breakdown — frame_seq={} pulse={} wave={} noise={} mix={}",
                 ap.frame_seq, ap.pulse, ap.wave, ap.noise, ap.mix
+            );
+
+            let cp = cpu.take_cartridge_perf_profile();
+            info!(
+                "cart breakdown — rom={} ram={} control={} sync={} sync_calls={} bank0={} bank0_calls={} banked={} banked_calls={}",
+                cp.write_rom,
+                cp.write_ram,
+                cp.control_write,
+                cp.sync_caches,
+                cp.sync_caches_calls,
+                cp.read_bank_fixed,
+                cp.read_bank_fixed_calls,
+                cp.read_bank_switchable,
+                cp.read_bank_switchable_calls
             );
 
             // At 250 MHz, divide cycles by 250_000 to get milliseconds.

--- a/platform/pico2w/src/xip_cartridge.rs
+++ b/platform/pico2w/src/xip_cartridge.rs
@@ -1,0 +1,526 @@
+use alloc::vec::Vec;
+
+use rustyboy_core::memory::cartridge::Cartridge;
+#[cfg(feature = "perf")]
+use rustyboy_core::memory::cartridge::CartridgePerfProfile;
+
+#[cfg(feature = "perf")]
+use rustyboy_core::cpu::perf::cyccnt;
+
+#[cfg(target_arch = "arm")]
+use crate::flash_rom::{FlashRomInfo, ROM_DATA_OFFSET};
+#[cfg(target_arch = "arm")]
+use embassy_rp::flash::FLASH_BASE;
+
+const ROM_BANK_BYTES: usize = 0x4000;
+const CART_TYPE: usize = 0x0147;
+const ROM_SIZE: usize = 0x0148;
+const RAM_SIZE: usize = 0x0149;
+
+enum MbcState {
+    NoMbc,
+    Mbc1 {
+        rom_bank_lo: u8,
+        upper_bits: u8,
+        ram_mode: bool,
+        ram_enabled: bool,
+        ram_bank_count: usize,
+    },
+    Mbc3 {
+        rom_bank: u8,
+        bank_or_rtc: u8,
+        ram_rtc_enabled: bool,
+    },
+}
+
+#[derive(Debug)]
+pub enum XipCartridgeError {
+    RomTooSmall {
+        expected_bytes: usize,
+        actual_bytes: usize,
+    },
+    UnsupportedCartType(u8),
+}
+
+pub struct XipCartridge {
+    rom: &'static [u8],
+    fixed_bank_num: usize,
+    fixed_bank_base: usize,
+    fixed_bank_valid: bool,
+    current_bank_num: usize,
+    current_bank_base: usize,
+    current_bank_valid: bool,
+    rom_bank_count: usize,
+    mbc: MbcState,
+    ram: Vec<u8>,
+    #[cfg(feature = "perf")]
+    perf_profile: CartridgePerfProfile,
+}
+
+impl XipCartridge {
+    pub fn new(rom: &'static [u8]) -> Result<Self, XipCartridgeError> {
+        let cart_type = *rom.get(CART_TYPE).unwrap_or(&0);
+        let rom_bank_count = rom_bank_count_from_code(*rom.get(ROM_SIZE).unwrap_or(&0))
+            .ok_or(XipCartridgeError::UnsupportedCartType(cart_type))?;
+        let ram_bytes = ram_bytes_from_code(*rom.get(RAM_SIZE).unwrap_or(&0));
+        let expected_bytes = rom_bank_count * ROM_BANK_BYTES;
+        if rom.len() < expected_bytes {
+            return Err(XipCartridgeError::RomTooSmall {
+                expected_bytes,
+                actual_bytes: rom.len(),
+            });
+        }
+        let mbc = mbc_state_from_header(cart_type, ram_bytes)
+            .ok_or(XipCartridgeError::UnsupportedCartType(cart_type))?;
+
+        let mut cart = Self {
+            rom,
+            fixed_bank_num: 0,
+            fixed_bank_base: 0,
+            fixed_bank_valid: true,
+            current_bank_num: 1,
+            current_bank_base: ROM_BANK_BYTES,
+            current_bank_valid: rom_bank_count > 1,
+            rom_bank_count,
+            mbc,
+            ram: alloc::vec![0u8; ram_bytes],
+            #[cfg(feature = "perf")]
+            perf_profile: CartridgePerfProfile::default(),
+        };
+        cart.refresh_mappings();
+        Ok(cart)
+    }
+
+    #[cfg(target_arch = "arm")]
+    pub fn from_staged_flash(info: FlashRomInfo) -> Result<Self, XipCartridgeError> {
+        let rom = unsafe {
+            // The staged ROM lives in a stable XIP-mapped flash window for the
+            // whole program lifetime, and all staging writes are complete
+            // before we create the cartridge.
+            core::slice::from_raw_parts(
+                (FLASH_BASE as *const u8).add(ROM_DATA_OFFSET),
+                info.size_bytes,
+            )
+        };
+        Self::new(rom)
+    }
+
+    #[inline]
+    fn refresh_mappings(&mut self) {
+        let (fixed_bank_num, current_bank_num) = match &self.mbc {
+            MbcState::NoMbc => (0, 1),
+            MbcState::Mbc1 {
+                rom_bank_lo,
+                upper_bits,
+                ram_mode,
+                ..
+            } => {
+                let fixed = if *ram_mode {
+                    ((*upper_bits as usize) << 5) % self.rom_bank_count
+                } else {
+                    0
+                };
+                let bank = ((*upper_bits as usize) << 5) | (*rom_bank_lo as usize);
+                let bank = if bank == 0 { 1 } else { bank };
+                (fixed, bank % self.rom_bank_count)
+            }
+            MbcState::Mbc3 { rom_bank, .. } => (0, *rom_bank as usize),
+        };
+
+        self.fixed_bank_num = fixed_bank_num;
+        self.fixed_bank_valid = fixed_bank_num < self.rom_bank_count;
+        self.fixed_bank_base = fixed_bank_num * ROM_BANK_BYTES;
+
+        self.current_bank_num = current_bank_num;
+        self.current_bank_valid = current_bank_num < self.rom_bank_count;
+        self.current_bank_base = current_bank_num * ROM_BANK_BYTES;
+    }
+
+    /// Apply an MBC register write.
+    ///
+    /// Returns true only when the write changes the visible ROM mapping.
+    #[inline]
+    fn handle_mbc_write(&mut self, addr: u16, value: u8) -> bool {
+        match &mut self.mbc {
+            MbcState::NoMbc => false,
+            MbcState::Mbc1 {
+                rom_bank_lo,
+                upper_bits,
+                ram_mode,
+                ram_enabled,
+                ..
+            } => match addr {
+                0x0000..=0x1FFF => {
+                    *ram_enabled = value & 0x0F == 0x0A;
+                    false
+                }
+                0x2000..=0x3FFF => {
+                    let mut bank = value & 0x1F;
+                    if bank == 0 {
+                        bank = 1;
+                    }
+                    if *rom_bank_lo == bank {
+                        false
+                    } else {
+                        *rom_bank_lo = bank;
+                        true
+                    }
+                }
+                0x4000..=0x5FFF => {
+                    let bits = value & 0x03;
+                    if *upper_bits == bits {
+                        false
+                    } else {
+                        *upper_bits = bits;
+                        true
+                    }
+                }
+                0x6000..=0x7FFF => {
+                    let new_ram_mode = value & 0x01 != 0;
+                    if *ram_mode == new_ram_mode {
+                        false
+                    } else {
+                        *ram_mode = new_ram_mode;
+                        true
+                    }
+                }
+                _ => false,
+            },
+            MbcState::Mbc3 {
+                rom_bank,
+                bank_or_rtc,
+                ram_rtc_enabled,
+            } => match addr {
+                0x0000..=0x1FFF => {
+                    *ram_rtc_enabled = value & 0x0F == 0x0A;
+                    false
+                }
+                0x2000..=0x3FFF => {
+                    let bank = if value & 0x7F == 0 { 1 } else { value & 0x7F };
+                    if *rom_bank == bank {
+                        false
+                    } else {
+                        *rom_bank = bank;
+                        true
+                    }
+                }
+                0x4000..=0x5FFF => {
+                    *bank_or_rtc = value;
+                    false
+                }
+                _ => false,
+            },
+        }
+    }
+
+    #[inline]
+    fn mbc1_ram_bank(&self) -> usize {
+        match &self.mbc {
+            MbcState::Mbc1 {
+                upper_bits,
+                ram_mode: true,
+                ram_bank_count,
+                ..
+            } => (*upper_bits as usize) % (*ram_bank_count).max(1),
+            _ => 0,
+        }
+    }
+
+    #[inline]
+    fn is_ram_enabled(&self) -> bool {
+        match &self.mbc {
+            MbcState::NoMbc => false,
+            MbcState::Mbc1 { ram_enabled, .. } => *ram_enabled,
+            MbcState::Mbc3 {
+                ram_rtc_enabled,
+                bank_or_rtc,
+                ..
+            } => *ram_rtc_enabled && !matches!(bank_or_rtc, 0x08..=0x0C),
+        }
+    }
+}
+
+impl Cartridge for XipCartridge {
+    #[inline(always)]
+    fn read_rom(&self, addr: u16) -> u8 {
+        match addr {
+            0x0000..=0x3FFF => {
+                if !self.fixed_bank_valid {
+                    return 0xFF;
+                }
+                unsafe {
+                    *self
+                        .rom
+                        .get_unchecked(self.fixed_bank_base + addr as usize)
+                }
+            }
+            0x4000..=0x7FFF => {
+                if !self.current_bank_valid {
+                    return 0xFF;
+                }
+                unsafe {
+                    *self
+                        .rom
+                        .get_unchecked(self.current_bank_base + (addr as usize - 0x4000))
+                }
+            }
+            _ => 0xFF,
+        }
+    }
+
+    fn read_ram(&self, addr: u16) -> u8 {
+        if !self.is_ram_enabled() || self.ram.is_empty() {
+            return 0xFF;
+        }
+        let offset = self.mbc1_ram_bank() * 0x2000 + addr as usize;
+        self.ram.get(offset).copied().unwrap_or(0xFF)
+    }
+
+    fn write(&mut self, addr: u16, value: u8) {
+        if (0xA000..=0xBFFF).contains(&addr) {
+            #[cfg(feature = "perf")]
+            let t_ram = cyccnt();
+            if self.is_ram_enabled() && !self.ram.is_empty() {
+                let offset = self.mbc1_ram_bank() * 0x2000 + (addr - 0xA000) as usize;
+                if let Some(b) = self.ram.get_mut(offset) {
+                    *b = value;
+                }
+            }
+            #[cfg(feature = "perf")]
+            {
+                self.perf_profile.write_ram = self
+                    .perf_profile
+                    .write_ram
+                    .wrapping_add(cyccnt().wrapping_sub(t_ram));
+            }
+            return;
+        }
+
+        #[cfg(feature = "perf")]
+        let t_rom = cyccnt();
+        #[cfg(feature = "perf")]
+        let t_control = cyccnt();
+        let changed = self.handle_mbc_write(addr, value);
+        #[cfg(feature = "perf")]
+        {
+            self.perf_profile.control_write = self
+                .perf_profile
+                .control_write
+                .wrapping_add(cyccnt().wrapping_sub(t_control));
+        }
+        if changed {
+            self.refresh_mappings();
+        }
+        #[cfg(feature = "perf")]
+        {
+            self.perf_profile.write_rom = self
+                .perf_profile
+                .write_rom
+                .wrapping_add(cyccnt().wrapping_sub(t_rom));
+        }
+    }
+
+    fn current_rom_bank(&self) -> usize {
+        self.current_bank_num
+    }
+
+    fn external_ram(&self) -> Option<&[u8]> {
+        if self.ram.is_empty() {
+            None
+        } else {
+            Some(&self.ram)
+        }
+    }
+
+    fn set_external_ram(&mut self, data: &[u8]) {
+        let len = self.ram.len().min(data.len());
+        self.ram[..len].copy_from_slice(&data[..len]);
+    }
+
+    fn save_mbc_state(&self, out: &mut Vec<u8>) {
+        match &self.mbc {
+            MbcState::NoMbc => {}
+            MbcState::Mbc1 {
+                rom_bank_lo,
+                upper_bits,
+                ram_mode,
+                ram_enabled,
+                ..
+            } => {
+                out.extend_from_slice(&[
+                    *rom_bank_lo,
+                    *upper_bits,
+                    *ram_mode as u8,
+                    *ram_enabled as u8,
+                ]);
+            }
+            MbcState::Mbc3 {
+                rom_bank,
+                bank_or_rtc,
+                ram_rtc_enabled,
+            } => {
+                out.extend_from_slice(&[*rom_bank, *bank_or_rtc, *ram_rtc_enabled as u8]);
+            }
+        }
+    }
+
+    fn load_mbc_state(&mut self, data: &[u8], offset: usize) -> usize {
+        let consumed = match &mut self.mbc {
+            MbcState::NoMbc => 0,
+            MbcState::Mbc1 {
+                rom_bank_lo,
+                upper_bits,
+                ram_mode,
+                ram_enabled,
+                ..
+            } => {
+                if data.len() < offset + 4 {
+                    return 0;
+                }
+                *rom_bank_lo = data[offset].max(1);
+                *upper_bits = data[offset + 1] & 0x03;
+                *ram_mode = data[offset + 2] != 0;
+                *ram_enabled = data[offset + 3] != 0;
+                4
+            }
+            MbcState::Mbc3 {
+                rom_bank,
+                bank_or_rtc,
+                ram_rtc_enabled,
+            } => {
+                if data.len() < offset + 3 {
+                    return 0;
+                }
+                *rom_bank = data[offset].max(1);
+                *bank_or_rtc = data[offset + 1];
+                *ram_rtc_enabled = data[offset + 2] != 0;
+                3
+            }
+        };
+        if consumed > 0 {
+            self.refresh_mappings();
+        }
+        consumed
+    }
+
+    #[cfg(feature = "perf")]
+    fn take_perf_profile(&mut self) -> CartridgePerfProfile {
+        core::mem::take(&mut self.perf_profile)
+    }
+}
+
+fn rom_bank_count_from_code(code: u8) -> Option<usize> {
+    match code {
+        0x00..=0x08 => Some(2usize << code),
+        0x52 => Some(72),
+        0x53 => Some(80),
+        0x54 => Some(96),
+        _ => None,
+    }
+}
+
+fn ram_bytes_from_code(code: u8) -> usize {
+    match code {
+        0x01 => 2 * 1024,
+        0x02 => 8 * 1024,
+        0x03 => 32 * 1024,
+        0x04 => 128 * 1024,
+        0x05 => 64 * 1024,
+        _ => 0,
+    }
+}
+
+fn mbc_state_from_header(cart_type: u8, ram_bytes: usize) -> Option<MbcState> {
+    let ram_bank_count = if ram_bytes == 0 {
+        0
+    } else {
+        (ram_bytes / 0x2000).max(1)
+    };
+    match cart_type {
+        0x00 => Some(MbcState::NoMbc),
+        0x01 | 0x02 | 0x03 => Some(MbcState::Mbc1 {
+            rom_bank_lo: 1,
+            upper_bits: 0,
+            ram_mode: false,
+            ram_enabled: false,
+            ram_bank_count,
+        }),
+        0x0F | 0x10 | 0x11 | 0x12 | 0x13 => Some(MbcState::Mbc3 {
+            rom_bank: 1,
+            bank_or_rtc: 0,
+            ram_rtc_enabled: false,
+        }),
+        _ => None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn rom_size_code_for(num_banks: usize) -> u8 {
+        match num_banks {
+            2 => 0,
+            4 => 1,
+            8 => 2,
+            16 => 3,
+            32 => 4,
+            64 => 5,
+            _ => 0,
+        }
+    }
+
+    fn leak_rom(num_banks: usize, cart_type: u8, ram_size_code: u8) -> &'static [u8] {
+        let mut rom = alloc::vec![0u8; num_banks * ROM_BANK_BYTES];
+        for (i, chunk) in rom.chunks_exact_mut(ROM_BANK_BYTES).enumerate() {
+            chunk.fill(i as u8);
+        }
+        rom[CART_TYPE] = cart_type;
+        rom[ROM_SIZE] = rom_size_code_for(num_banks);
+        rom[RAM_SIZE] = ram_size_code;
+        Box::leak(rom.into_boxed_slice())
+    }
+
+    #[test]
+    fn mbc1_bank_switch_reads_from_xip_slice() {
+        let mut cart = XipCartridge::new(leak_rom(4, 0x01, 0x00)).unwrap();
+        assert_eq!(cart.read_rom(0x4000), 0x01);
+        cart.write(0x2000, 0x02);
+        assert_eq!(cart.current_rom_bank(), 2);
+        assert_eq!(cart.read_rom(0x4000), 0x02);
+    }
+
+    #[test]
+    fn mbc1_ram_mode_remaps_fixed_window() {
+        let mut cart = XipCartridge::new(leak_rom(64, 0x01, 0x00)).unwrap();
+        cart.write(0x4000, 0x01);
+        cart.write(0x6000, 0x01);
+        assert_eq!(cart.read_rom(0x0000), 32);
+    }
+
+    #[test]
+    fn mbc3_out_of_bounds_bank_reads_ff() {
+        let mut cart = XipCartridge::new(leak_rom(8, 0x13, 0x00)).unwrap();
+        cart.write(0x2000, 0x20);
+        assert_eq!(cart.current_rom_bank(), 0x20);
+        assert_eq!(cart.read_rom(0x4000), 0xFF);
+    }
+
+    #[test]
+    fn save_state_round_trip_restores_mbc1_mapping() {
+        let mut cart = XipCartridge::new(leak_rom(64, 0x01, 0x00)).unwrap();
+        cart.write(0x4000, 0x01);
+        cart.write(0x2000, 0x03);
+        cart.write(0x6000, 0x01);
+
+        let mut blob = Vec::new();
+        cart.save_mbc_state(&mut blob);
+
+        let mut restored = XipCartridge::new(leak_rom(64, 0x01, 0x00)).unwrap();
+        let consumed = restored.load_mbc_state(&blob, 0);
+        assert_eq!(consumed, 4);
+        assert_eq!(restored.current_rom_bank(), 35);
+        assert_eq!(restored.read_rom(0x0000), 32);
+        assert_eq!(restored.read_rom(0x4000), 35);
+    }
+}


### PR DESCRIPTION
## Summary
- add a Pico-specific XIP cartridge that reads the staged ROM directly from flash and tracks MBC mapping without refilling 16 KiB SRAM banks
- switch the Pico runtime from StreamingCartridge + FlashRomReader runtime reads to the new XIP path
- keep the perf instrumentation and roadmap aligned with the new bottleneck picture after the cartridge change

## Perf
- fps improved from 13-14 to 16 in steady Tetris perf runs
- total cycles/60f dropped from ~976M-1009M to ~825M-838M
- mem_write dropped from ~140M-169M to ~3M-4M
- cartridge bank reload work dropped to zero in the perf counters

## Verification
- cargo test --lib --target x86_64-unknown-linux-gnu xip_cartridge -- --nocapture
- cargo check --features perf
- cargo run --release --features perf on hardware