### PR TITLE
Optimize SM83 decode/fetch hot path on Pico

### DIFF
--- a/core/src/cpu/perf.rs
+++ b/core/src/cpu/perf.rs
@@ -44,6 +44,35 @@ pub struct Sm83PerfProfile {
     pub mem_write_enqueue: u32,
     /// Time spent draining and handling queued bus events on the next M-cycle.
     pub mem_write_route: u32,
+    /// Nested decode hotspot: time spent in `read_next_pc`, excluding nested PPU/timer/APU work.
+    pub pc_fetch: u32,
+    /// Number of `read_next_pc` calls.
+    pub pc_fetch_calls: u32,
+    /// Nested decode hotspot: `read_next_pc` time for PC reads in cartridge ROM space.
+    pub pc_fetch_rom: u32,
+    /// Number of `read_next_pc` calls in `0x0000..=0x7FFF`.
+    pub pc_fetch_rom_calls: u32,
+    /// Nested decode hotspot: ROM `read_next_pc` common-case fast path
+    /// (no queued bus events, DMA, active serial transfer, or cartridge RTC).
+    pub pc_fetch_rom_idle: u32,
+    /// Number of ROM `read_next_pc` calls that used the common-case fast path.
+    pub pc_fetch_rom_idle_calls: u32,
+    /// Nested decode hotspot: time spent in generic non-wave `bus_read`, excluding nested PPU/timer/APU work.
+    pub bus_read: u32,
+    /// Number of generic non-wave `bus_read` calls.
+    pub bus_read_calls: u32,
+    /// Nested decode hotspot: time spent in opcode-table lookup (`get` / `get_cb`).
+    pub opcode_dispatch: u32,
+    /// Number of opcode-table lookups.
+    pub opcode_dispatch_calls: u32,
+    /// Nested decode hotspot: time spent in the `0xCB` prefix path, including second-byte fetch.
+    pub cb_prefix: u32,
+    /// Number of `0xCB` prefix dispatches.
+    pub cb_prefix_calls: u32,
+    /// Nested decode hotspot: time spent in `get_8bit_operand`, excluding nested PPU/timer/APU work.
+    pub operand8: u32,
+    /// Number of `get_8bit_operand` calls.
+    pub operand8_calls: u32,
 }
 
 #[cfg(feature = "perf")]
@@ -53,10 +82,36 @@ pub(crate) struct Sm83PerfRecorder {
 }
 
 #[cfg(feature = "perf")]
+#[derive(Clone, Copy)]
+pub(crate) struct NestedPerfSnapshot {
+    ppu: u32,
+    timer: u32,
+    apu: u32,
+}
+
+#[cfg(feature = "perf")]
 impl Sm83PerfRecorder {
     #[inline]
     pub(crate) fn take_profile(&mut self) -> Sm83PerfProfile {
         core::mem::take(&mut self.profile)
+    }
+
+    #[inline]
+    pub(crate) fn nested_snapshot(&self) -> NestedPerfSnapshot {
+        NestedPerfSnapshot {
+            ppu: self.profile.ppu,
+            timer: self.profile.timer,
+            apu: self.profile.apu,
+        }
+    }
+
+    #[inline]
+    pub(crate) fn nested_cycles_since(&self, snapshot: NestedPerfSnapshot) -> u32 {
+        self.profile
+            .ppu
+            .wrapping_sub(snapshot.ppu)
+            .wrapping_add(self.profile.timer.wrapping_sub(snapshot.timer))
+            .wrapping_add(self.profile.apu.wrapping_sub(snapshot.apu))
     }
 
     #[inline]
@@ -141,6 +196,46 @@ impl Sm83PerfRecorder {
     }
 
     #[inline]
+    pub(crate) fn record_pc_fetch(&mut self, addr: u16, dt: u32) {
+        self.profile.pc_fetch = self.profile.pc_fetch.wrapping_add(dt);
+        self.profile.pc_fetch_calls = self.profile.pc_fetch_calls.wrapping_add(1);
+        if addr <= 0x7FFF {
+            self.profile.pc_fetch_rom = self.profile.pc_fetch_rom.wrapping_add(dt);
+            self.profile.pc_fetch_rom_calls = self.profile.pc_fetch_rom_calls.wrapping_add(1);
+        }
+    }
+
+    #[inline]
+    pub(crate) fn record_pc_fetch_rom_idle(&mut self, dt: u32) {
+        self.profile.pc_fetch_rom_idle = self.profile.pc_fetch_rom_idle.wrapping_add(dt);
+        self.profile.pc_fetch_rom_idle_calls = self.profile.pc_fetch_rom_idle_calls.wrapping_add(1);
+    }
+
+    #[inline]
+    pub(crate) fn record_bus_read(&mut self, dt: u32) {
+        self.profile.bus_read = self.profile.bus_read.wrapping_add(dt);
+        self.profile.bus_read_calls = self.profile.bus_read_calls.wrapping_add(1);
+    }
+
+    #[inline]
+    pub(crate) fn record_opcode_dispatch(&mut self, dt: u32) {
+        self.profile.opcode_dispatch = self.profile.opcode_dispatch.wrapping_add(dt);
+        self.profile.opcode_dispatch_calls = self.profile.opcode_dispatch_calls.wrapping_add(1);
+    }
+
+    #[inline]
+    pub(crate) fn record_cb_prefix(&mut self, dt: u32) {
+        self.profile.cb_prefix = self.profile.cb_prefix.wrapping_add(dt);
+        self.profile.cb_prefix_calls = self.profile.cb_prefix_calls.wrapping_add(1);
+    }
+
+    #[inline]
+    pub(crate) fn record_operand8(&mut self, dt: u32) {
+        self.profile.operand8 = self.profile.operand8.wrapping_add(dt);
+        self.profile.operand8_calls = self.profile.operand8_calls.wrapping_add(1);
+    }
+
+    #[inline]
     pub(crate) fn record_ppu(&mut self, dt: u32) {
         self.profile.ppu = self.profile.ppu.wrapping_add(dt);
     }
@@ -196,6 +291,31 @@ mod tests {
         assert_eq!(profile.mem_write_fast_rom, 3);
         assert_eq!(profile.mem_write_fast_rom_2000_3fff, 3);
         assert_eq!(profile.mem_write_fast_wram, 5);
+    }
+
+    #[test]
+    fn record_decode_hotspots_track_cycles_and_calls() {
+        let mut perf = Sm83PerfRecorder::default();
+        perf.record_pc_fetch(0x1234, 3);
+        perf.record_pc_fetch(0xC123, 5);
+        perf.record_bus_read(7);
+        perf.record_opcode_dispatch(11);
+        perf.record_cb_prefix(13);
+        perf.record_operand8(17);
+
+        let profile = perf.take_profile();
+        assert_eq!(profile.pc_fetch, 8);
+        assert_eq!(profile.pc_fetch_calls, 2);
+        assert_eq!(profile.pc_fetch_rom, 3);
+        assert_eq!(profile.pc_fetch_rom_calls, 1);
+        assert_eq!(profile.bus_read, 7);
+        assert_eq!(profile.bus_read_calls, 1);
+        assert_eq!(profile.opcode_dispatch, 11);
+        assert_eq!(profile.opcode_dispatch_calls, 1);
+        assert_eq!(profile.cb_prefix, 13);
+        assert_eq!(profile.cb_prefix_calls, 1);
+        assert_eq!(profile.operand8, 17);
+        assert_eq!(profile.operand8_calls, 1);
     }
 
     #[test]

--- a/core/src/cpu/peripheral/serial.rs
+++ b/core/src/cpu/peripheral/serial.rs
@@ -43,6 +43,11 @@ impl SerialPort {
         &self.output
     }
 
+    #[inline(always)]
+    pub fn is_idle(&self) -> bool {
+        self.cycles_remaining.is_none()
+    }
+
     /// Called when SC (0xFF02) is written. Captures `sb` and starts a timed
     /// transfer if the internal clock bit is set; completes immediately for
     /// external-clock transfers (no link cable present).

--- a/core/src/cpu/sm83.rs
+++ b/core/src/cpu/sm83.rs
@@ -429,15 +429,64 @@ impl Sm83 {
             self.queue_apu_cycles(1);
             return Ok(value);
         }
-        self.tick_cycle();
+        #[cfg(feature = "perf")]
+        let nested0 = self.perf.nested_snapshot();
         #[cfg(feature = "perf")]
         let t0 = cyccnt();
+        self.tick_cycle();
+        #[cfg(feature = "perf")]
+        let t_read = cyccnt();
         let value = self.memory.read_fast(addr);
         #[cfg(feature = "perf")]
         {
-            self.perf.record_mem_read(cyccnt().wrapping_sub(t0));
+            let t1 = cyccnt();
+            self.perf.record_mem_read(t1.wrapping_sub(t_read));
+            self.perf.record_bus_read(
+                t1.wrapping_sub(t0)
+                    .wrapping_sub(self.perf.nested_cycles_since(nested0)),
+            );
         }
         Ok(value)
+    }
+
+    /// Fast path for opcode/immediate fetches when `PC` is in cartridge ROM.
+    ///
+    /// This preserves the exact same M-cycle-side effects as `bus_read`.
+    /// When the M-cycle is otherwise idle, we bypass the generic helper stack
+    /// entirely and run the straight-line common case directly.
+    #[cfg_attr(target_arch = "arm", link_section = ".data")]
+    #[inline(always)]
+    fn read_pc_rom_fast(&mut self, addr: u16) -> u8 {
+        #[cfg(feature = "perf")]
+        let nested0 = self.perf.nested_snapshot();
+        #[cfg(feature = "perf")]
+        let t0 = cyccnt();
+        if self.can_use_idle_m_cycle_fast_path() {
+            self.run_idle_m_cycle();
+            #[cfg(feature = "perf")]
+            let t_read = cyccnt();
+            let value = self.memory.read_rom_fast(addr);
+            #[cfg(feature = "perf")]
+            {
+                let t1 = cyccnt();
+                self.perf.record_mem_read(t1.wrapping_sub(t_read));
+                self.perf.record_pc_fetch_rom_idle(
+                    t1.wrapping_sub(t0)
+                        .wrapping_sub(self.perf.nested_cycles_since(nested0)),
+                );
+            }
+            return value;
+        }
+
+        self.tick_cycle();
+        #[cfg(feature = "perf")]
+        let t_read = cyccnt();
+        let value = self.memory.read_rom_fast(addr);
+        #[cfg(feature = "perf")]
+        {
+            self.perf.record_mem_read(cyccnt().wrapping_sub(t_read));
+        }
+        value
     }
 
     /// Perform a bus write: advance all peripherals by one M-cycle (4 T-cycles),
@@ -509,6 +558,10 @@ impl Sm83 {
     /// Used for internal M-cycles (e.g. ALU operations, SP adjustment).
     #[cfg_attr(target_arch = "arm", link_section = ".data")]
     fn tick_cycle(&mut self) {
+        if self.can_use_idle_m_cycle_fast_path() {
+            self.run_idle_m_cycle();
+            return;
+        }
         self.begin_m_cycle();
         self.advance_peripherals(4);
     }
@@ -535,8 +588,12 @@ impl Sm83 {
         self.advance_ppu(cycles);
         self.advance_timer(cycles);
         self.queue_apu_cycles(cycles);
-        self.memory.tick_rtc(cycles as u32);
-        self.advance_serial(cycles);
+        if self.memory.has_rtc() {
+            self.memory.tick_rtc(cycles as u32);
+        }
+        if !self.serial.is_idle() {
+            self.advance_serial(cycles);
+        }
     }
 
     #[cfg_attr(target_arch = "arm", link_section = ".data")]
@@ -574,6 +631,24 @@ impl Sm83 {
         self.flush_apu_before_bus_events();
         self.route_bus_events();
         self.advance_dma();
+    }
+
+    #[cfg_attr(target_arch = "arm", link_section = ".data")]
+    #[inline(always)]
+    fn can_use_idle_m_cycle_fast_path(&self) -> bool {
+        self.pending_bus_events.is_empty()
+            && self.dma.is_none()
+            && self.serial.is_idle()
+            && !self.memory.has_rtc()
+    }
+
+    #[cfg_attr(target_arch = "arm", link_section = ".data")]
+    #[inline(always)]
+    fn run_idle_m_cycle(&mut self) {
+        self.cycle_counter += 4;
+        self.advance_ppu(4);
+        self.advance_timer(4);
+        self.queue_apu_cycles(4);
     }
 
     #[cfg_attr(target_arch = "arm", link_section = ".data")]
@@ -843,14 +918,36 @@ impl Sm83 {
 
     #[cfg_attr(target_arch = "arm", link_section = ".data")]
     fn read_next_pc(&mut self) -> Result<u8, MemoryError> {
-        let byte = self.bus_read(self.registers.pc)?;
+        let addr = self.registers.pc;
+        #[cfg(feature = "perf")]
+        let nested0 = self.perf.nested_snapshot();
+        #[cfg(feature = "perf")]
+        let t0 = cyccnt();
+        let byte = if addr <= 0x7FFF {
+            self.read_pc_rom_fast(addr)
+        } else {
+            self.bus_read(addr)?
+        };
         self.registers.pc = self.registers.pc.wrapping_add(1);
+        #[cfg(feature = "perf")]
+        {
+            self.perf.record_pc_fetch(
+                addr,
+                cyccnt()
+                    .wrapping_sub(t0)
+                    .wrapping_sub(self.perf.nested_cycles_since(nested0)),
+            );
+        }
         Ok(byte)
     }
 
     #[cfg_attr(target_arch = "arm", link_section = ".data")]
     fn get_8bit_operand(&mut self, operand: Operand) -> Result<u8, InstructionError> {
-        match operand {
+        #[cfg(feature = "perf")]
+        let nested0 = self.perf.nested_snapshot();
+        #[cfg(feature = "perf")]
+        let t0 = cyccnt();
+        let result = match operand {
             Operand::Register8(reg) => Ok(self.get_register8_operand(reg)),
             Operand::Memory(Memory::HL) => {
                 let address = self.registers.hl();
@@ -863,7 +960,16 @@ impl Sm83 {
                     operand
                 )))
             }
+        };
+        #[cfg(feature = "perf")]
+        {
+            self.perf.record_operand8(
+                cyccnt()
+                    .wrapping_sub(t0)
+                    .wrapping_sub(self.perf.nested_cycles_since(nested0)),
+            );
         }
+        result
     }
 
     #[cfg_attr(target_arch = "arm", link_section = ".data")]
@@ -1023,10 +1129,34 @@ impl Sm83 {
         // &mut self.  The atomic increment is ~10 cycles vs ~50 000 cycles for
         // the previous Box::new() per instruction.
         let op = if opcode == 0xCB {
+            #[cfg(feature = "perf")]
+            let nested0 = self.perf.nested_snapshot();
+            #[cfg(feature = "perf")]
+            let cb_t0 = cyccnt();
             let cb_opcode = self.read_next_pc()?;
-            self.opcodes.get_cb(cb_opcode)?
+            #[cfg(feature = "perf")]
+            let dispatch_t0 = cyccnt();
+            let op = self.opcodes.get_cb(cb_opcode)?;
+            #[cfg(feature = "perf")]
+            {
+                let t1 = cyccnt();
+                self.perf.record_opcode_dispatch(t1.wrapping_sub(dispatch_t0));
+                self.perf.record_cb_prefix(
+                    t1.wrapping_sub(cb_t0)
+                        .wrapping_sub(self.perf.nested_cycles_since(nested0)),
+                );
+            }
+            op
         } else {
-            self.opcodes.get(opcode)?
+            #[cfg(feature = "perf")]
+            let dispatch_t0 = cyccnt();
+            let op = self.opcodes.get(opcode)?;
+            #[cfg(feature = "perf")]
+            {
+                self.perf
+                    .record_opcode_dispatch(cyccnt().wrapping_sub(dispatch_t0));
+            }
+            op
         };
         op.execute(self)?;
 
@@ -2757,6 +2887,62 @@ mod tests {
         assert_eq!(cpu.registers().pc, 1);
         assert_eq!(cpu.registers().a, 0x00);
         assert_eq!(cpu.registers().f, Flags::empty());
+    }
+
+    #[cfg(feature = "perf")]
+    #[test]
+    fn test_rom_pc_fetch_uses_fast_path_not_generic_bus_read() {
+        let mut cpu = make_test_cpu(vec![0x00]).with_registers(Registers {
+            ..Default::default()
+        });
+
+        let cycles = cpu.tick().unwrap();
+        let perf = cpu.take_perf_profile();
+
+        assert_eq!(cycles, 4);
+        assert_eq!(perf.pc_fetch_calls, 1);
+        assert_eq!(perf.pc_fetch_rom_calls, 1);
+        assert_eq!(perf.pc_fetch_rom_idle_calls, 1);
+        assert_eq!(perf.bus_read_calls, 0);
+    }
+
+    #[cfg(feature = "perf")]
+    #[test]
+    fn test_non_rom_pc_fetch_stays_on_generic_bus_read_path() {
+        let mut cpu = make_test_cpu_with_memory(
+            |m| { m.write(0xC000, 0x00).unwrap(); },
+            vec![],
+        ).with_registers(Registers {
+            pc: 0xC000,
+            ..Default::default()
+        });
+
+        let cycles = cpu.tick().unwrap();
+        let perf = cpu.take_perf_profile();
+
+        assert_eq!(cycles, 4);
+        assert_eq!(perf.pc_fetch_calls, 1);
+        assert_eq!(perf.pc_fetch_rom_calls, 0);
+        assert_eq!(perf.pc_fetch_rom_idle_calls, 0);
+        assert_eq!(perf.bus_read_calls, 1);
+    }
+
+    #[cfg(feature = "perf")]
+    #[test]
+    fn test_rom_pc_fetch_skips_idle_fast_path_when_dma_active() {
+        let mut cpu = make_test_cpu(vec![0x00]).with_registers(Registers {
+            ..Default::default()
+        });
+        cpu.dma = Some(DmaState { source: 0x0000, progress: 0 });
+
+        let cycles = cpu.tick().unwrap();
+        let perf = cpu.take_perf_profile();
+
+        assert_eq!(cycles, 4);
+        assert_eq!(perf.pc_fetch_calls, 1);
+        assert_eq!(perf.pc_fetch_rom_calls, 1);
+        assert_eq!(perf.pc_fetch_rom_idle_calls, 0);
+        assert_eq!(cpu.dma.as_ref().map(|d| d.progress), Some(1));
     }
 
     /// HALT (0x76): returns 4 cycles without crashing.

--- a/core/src/memory/cartridge.rs
+++ b/core/src/memory/cartridge.rs
@@ -23,12 +23,34 @@ pub struct CartridgePerfProfile {
     pub read_bank_switchable_calls: u32,
 }
 
+#[derive(Clone, Copy)]
+pub struct CartridgeRomWindows {
+    pub fixed_ptr: *const u8,
+    pub fixed_len: usize,
+    pub banked_ptr: *const u8,
+    pub banked_len: usize,
+}
+
+impl CartridgeRomWindows {
+    pub const EMPTY: Self = Self {
+        fixed_ptr: core::ptr::null(),
+        fixed_len: 0,
+        banked_ptr: core::ptr::null(),
+        banked_len: 0,
+    };
+}
+
 pub trait Cartridge {
     fn read_rom(&self, addr: u16) -> u8;
     fn read_ram(&self, addr: u16) -> u8;
     fn write(&mut self, addr: u16, value: u8);
+    /// Returns direct pointers to the currently mapped ROM windows when the
+    /// cartridge can expose them safely for hot-path reads.
+    fn rom_windows(&self) -> Option<CartridgeRomWindows> { None }
     /// Returns the currently mapped ROM bank number for the switchable window (0x4000–0x7FFF).
     fn current_rom_bank(&self) -> usize { 1 }
+    /// Returns whether this cartridge needs per-M-cycle RTC ticking.
+    fn has_rtc(&self) -> bool { false }
     /// Advance the cartridge clock by `cycles` T-cycles (4 MHz). Only meaningful for
     /// MBC3 carts with an RTC; other implementations ignore this.
     fn tick_rtc(&mut self, _cycles: u32) {}
@@ -134,6 +156,13 @@ fn decode_ram_size(code: u8) -> usize {
     }
 }
 
+fn rom_window(rom: &[u8], base: usize) -> (*const u8, usize) {
+    match rom.get(base..) {
+        Some(slice) => (slice.as_ptr(), slice.len().min(0x4000)),
+        None => (core::ptr::null(), 0),
+    }
+}
+
 // ── NoMbc ────────────────────────────────────────────────────────────────────
 
 /// Flat ROM with no bank switching. Supports up to 32 KiB ROM and 8 KiB RAM.
@@ -152,6 +181,17 @@ impl NoMbc {
 }
 
 impl Cartridge for NoMbc {
+    fn rom_windows(&self) -> Option<CartridgeRomWindows> {
+        let (fixed_ptr, fixed_len) = rom_window(&self.rom, 0);
+        let (banked_ptr, banked_len) = rom_window(&self.rom, 0x4000);
+        Some(CartridgeRomWindows {
+            fixed_ptr,
+            fixed_len,
+            banked_ptr,
+            banked_len,
+        })
+    }
+
     fn read_rom(&self, addr: u16) -> u8 {
         self.rom.get(addr as usize).copied().unwrap_or(0xFF)
     }
@@ -256,6 +296,17 @@ impl Mbc1 {
 }
 
 impl Cartridge for Mbc1 {
+    fn rom_windows(&self) -> Option<CartridgeRomWindows> {
+        let (fixed_ptr, fixed_len) = rom_window(&self.rom, self.rom_bank0() * 0x4000);
+        let (banked_ptr, banked_len) = rom_window(&self.rom, self.rom_bank() * 0x4000);
+        Some(CartridgeRomWindows {
+            fixed_ptr,
+            fixed_len,
+            banked_ptr,
+            banked_len,
+        })
+    }
+
     fn external_ram(&self) -> Option<&[u8]> {
         if self.ram.is_empty() { None } else { Some(&self.ram) }
     }
@@ -415,6 +466,17 @@ impl Mbc1Multicart {
 }
 
 impl Cartridge for Mbc1Multicart {
+    fn rom_windows(&self) -> Option<CartridgeRomWindows> {
+        let (fixed_ptr, fixed_len) = rom_window(&self.rom, self.rom_bank0() * 0x4000);
+        let (banked_ptr, banked_len) = rom_window(&self.rom, self.rom_bank() * 0x4000);
+        Some(CartridgeRomWindows {
+            fixed_ptr,
+            fixed_len,
+            banked_ptr,
+            banked_len,
+        })
+    }
+
     fn external_ram(&self) -> Option<&[u8]> {
         if self.ram.is_empty() { None } else { Some(&self.ram) }
     }
@@ -640,6 +702,17 @@ impl Mbc3 {
 }
 
 impl Cartridge for Mbc3 {
+    fn rom_windows(&self) -> Option<CartridgeRomWindows> {
+        let (fixed_ptr, fixed_len) = rom_window(&self.rom, 0);
+        let (banked_ptr, banked_len) = rom_window(&self.rom, self.rom_bank as usize * 0x4000);
+        Some(CartridgeRomWindows {
+            fixed_ptr,
+            fixed_len,
+            banked_ptr,
+            banked_len,
+        })
+    }
+
     fn external_ram(&self) -> Option<&[u8]> {
         if self.ram.is_empty() { None } else { Some(&self.ram) }
     }
@@ -648,6 +721,10 @@ impl Cartridge for Mbc3 {
         self.ram[..len].copy_from_slice(&data[..len]);
     }
     fn current_rom_bank(&self) -> usize { self.rom_bank as usize }
+
+    fn has_rtc(&self) -> bool {
+        self.has_timer
+    }
 
     fn tick_rtc(&mut self, cycles: u32) {
         self.tick(cycles);

--- a/core/src/memory/memory.rs
+++ b/core/src/memory/memory.rs
@@ -3,7 +3,7 @@ use alloc::collections::VecDeque;
 use alloc::{vec, vec::Vec};
 use core::fmt;
 
-use super::cartridge::{self, Cartridge, NoMbc};
+use super::cartridge::{self, Cartridge, CartridgeRomWindows, NoMbc};
 use crate::cpu::save_state::SaveState;
 
 /// An event produced when a write occurs to an I/O or IE register address.
@@ -87,6 +87,11 @@ impl RegionMapping {
 ///   Everything else: unmapped (returns 0xFF on read, silently ignored on write)
 pub struct GameBoyMemory {
     cartridge: Box<dyn Cartridge>,
+    cartridge_has_rtc: bool,
+    rom_fixed_ptr: *const u8,
+    rom_fixed_len: usize,
+    rom_banked_ptr: *const u8,
+    rom_banked_len: usize,
     vram: [u8; 0x2000],
     wram: [u8; 0x2000],
     oam: [u8; 0xA0],
@@ -98,8 +103,15 @@ pub struct GameBoyMemory {
 
 impl GameBoyMemory {
     pub fn new() -> Self {
+        let cartridge: Box<dyn Cartridge> = Box::new(NoMbc::new(vec![0u8; 0x8000]));
+        let rom_windows = cartridge.rom_windows().unwrap_or(CartridgeRomWindows::EMPTY);
         Self {
-            cartridge: Box::new(NoMbc::new(vec![0u8; 0x8000])),
+            cartridge_has_rtc: cartridge.has_rtc(),
+            rom_fixed_ptr: rom_windows.fixed_ptr,
+            rom_fixed_len: rom_windows.fixed_len,
+            rom_banked_ptr: rom_windows.banked_ptr,
+            rom_banked_len: rom_windows.banked_len,
+            cartridge,
             vram: [0; 0x2000],
             wram: [0; 0x2000],
             oam: [0; 0xA0],
@@ -112,7 +124,14 @@ impl GameBoyMemory {
 
     /// Construct memory backed by a pre-built cartridge implementation.
     pub fn with_cartridge(cart: Box<dyn Cartridge>) -> Self {
+        let cartridge_has_rtc = cart.has_rtc();
+        let rom_windows = cart.rom_windows().unwrap_or(CartridgeRomWindows::EMPTY);
         Self {
+            cartridge_has_rtc,
+            rom_fixed_ptr: rom_windows.fixed_ptr,
+            rom_fixed_len: rom_windows.fixed_len,
+            rom_banked_ptr: rom_windows.banked_ptr,
+            rom_banked_len: rom_windows.banked_len,
             cartridge: cart,
             vram: [0; 0x2000],
             wram: [0; 0x2000],
@@ -127,8 +146,15 @@ impl GameBoyMemory {
     /// Construct memory with a cartridge ROM. The cartridge type is auto-detected
     /// from the ROM header (byte 0x0147) to select the correct MBC.
     pub fn with_rom(data: Vec<u8>) -> Self {
+        let cartridge = cartridge::from_rom(data);
+        let rom_windows = cartridge.rom_windows().unwrap_or(CartridgeRomWindows::EMPTY);
         Self {
-            cartridge: cartridge::from_rom(data),
+            cartridge_has_rtc: cartridge.has_rtc(),
+            rom_fixed_ptr: rom_windows.fixed_ptr,
+            rom_fixed_len: rom_windows.fixed_len,
+            rom_banked_ptr: rom_windows.banked_ptr,
+            rom_banked_len: rom_windows.banked_len,
+            cartridge,
             vram: [0; 0x2000],
             wram: [0; 0x2000],
             oam: [0; 0xA0],
@@ -153,9 +179,33 @@ impl GameBoyMemory {
         }
     }
 
+    #[inline(always)]
+    fn refresh_rom_windows(&mut self) {
+        let rom_windows = self.cartridge.rom_windows().unwrap_or(CartridgeRomWindows::EMPTY);
+        self.rom_fixed_ptr = rom_windows.fixed_ptr;
+        self.rom_fixed_len = rom_windows.fixed_len;
+        self.rom_banked_ptr = rom_windows.banked_ptr;
+        self.rom_banked_len = rom_windows.banked_len;
+    }
+
+    #[inline(always)]
+    fn read_cached_rom(ptr: *const u8, len: usize, offset: usize) -> u8 {
+        if offset >= len {
+            return 0xFF;
+        }
+        // The cached ROM window length is derived from a live cartridge-backed
+        // slice, so offsets below `len` are valid for direct reads.
+        unsafe { *ptr.add(offset) }
+    }
+
     /// Returns the currently mapped ROM bank number for the switchable window.
     pub fn current_rom_bank(&self) -> usize {
         self.cartridge.current_rom_bank()
+    }
+
+    #[inline(always)]
+    pub fn has_rtc(&self) -> bool {
+        self.cartridge_has_rtc
     }
 
     #[cfg(feature = "perf")]
@@ -164,6 +214,7 @@ impl GameBoyMemory {
     }
 
     /// Advance the cartridge RTC by `cycles` T-cycles. No-op for non-RTC carts.
+    #[inline(always)]
     pub fn tick_rtc(&mut self, cycles: u32) {
         self.cartridge.tick_rtc(cycles);
     }
@@ -172,7 +223,7 @@ impl GameBoyMemory {
     #[inline(always)]
     pub fn read_fast(&self, address: u16) -> u8 {
         match address {
-            0x0000..=0x7FFF => self.cartridge.read_rom(address),
+            0x0000..=0x7FFF => self.read_rom_fast(address),
             0x8000..=0x9FFF => Self::read_region_fast(&self.vram, address - 0x8000),
             0xA000..=0xBFFF => self.cartridge.read_ram(address - 0xA000),
             0xC000..=0xDFFF => Self::read_region_fast(&self.wram, address - 0xC000),
@@ -185,11 +236,42 @@ impl GameBoyMemory {
         }
     }
 
+    /// Fast direct cartridge-ROM read for callers that have already proven the
+    /// address is in `0x0000..=0x7FFF`.
+    #[inline(always)]
+    pub fn read_rom_fast(&self, address: u16) -> u8 {
+        match address {
+            0x0000..=0x3FFF => {
+                if self.rom_fixed_len != 0 {
+                    Self::read_cached_rom(self.rom_fixed_ptr, self.rom_fixed_len, address as usize)
+                } else {
+                    self.cartridge.read_rom(address)
+                }
+            }
+            0x4000..=0x7FFF => {
+                if self.rom_banked_len != 0 {
+                    Self::read_cached_rom(
+                        self.rom_banked_ptr,
+                        self.rom_banked_len,
+                        (address - 0x4000) as usize,
+                    )
+                } else {
+                    self.cartridge.read_rom(address)
+                }
+            }
+            _ => 0xFF,
+        }
+    }
+
     /// Fast infallible memory write used by hot non-IO paths.
     #[inline(always)]
     pub fn write_fast(&mut self, address: u16, value: u8) {
         match address {
-            0x0000..=0x7FFF | 0xA000..=0xBFFF => self.cartridge.write(address, value),
+            0x0000..=0x7FFF => {
+                self.cartridge.write(address, value);
+                self.refresh_rom_windows();
+            }
+            0xA000..=0xBFFF => self.cartridge.write(address, value),
             0x8000..=0x9FFF => Self::write_region_fast(&mut self.vram, address - 0x8000, value),
             0xC000..=0xDFFF => Self::write_region_fast(&mut self.wram, address - 0xC000, value),
             0xE000..=0xFDFF => {}
@@ -296,6 +378,7 @@ impl GameBoyMemory {
             // We build a minimal 4-byte buffer and reuse load_mbc_state.
             let buf = [mbc.rom_bank_lo, mbc.upper_bits, mbc.ram_mode as u8, mbc.ram_enabled as u8];
             self.cartridge.load_mbc_state(&buf, 0);
+            self.refresh_rom_windows();
         }
         if let Some(ram) = state.cart_ram() {
             self.cartridge.set_external_ram(ram);
@@ -345,7 +428,7 @@ impl GameBoyMemory {
 impl Memory for GameBoyMemory {
     fn read(&self, address: u16) -> Result<u8, Error> {
         match RegionMapping::for_address(address) {
-            RegionMapping::Rom => Ok(self.cartridge.read_rom(address)),
+            RegionMapping::Rom => Ok(self.read_rom_fast(address)),
             RegionMapping::Vram(offset) => Ok(self.vram[offset as usize]),
             RegionMapping::ExternalRam(offset) => Ok(self.cartridge.read_ram(offset)),
             RegionMapping::Wram(offset) => Ok(self.wram[offset as usize]),
@@ -361,7 +444,12 @@ impl Memory for GameBoyMemory {
     fn write(&mut self, address: u16, value: u8) -> Result<(), Error> {
         match RegionMapping::for_address(address) {
             // ROM writes and external RAM writes go to the cartridge (MBC registers or RAM)
-            RegionMapping::Rom | RegionMapping::ExternalRam(_) => {
+            RegionMapping::Rom => {
+                self.cartridge.write(address, value);
+                self.refresh_rom_windows();
+                Ok(())
+            }
+            RegionMapping::ExternalRam(_) => {
                 self.cartridge.write(address, value);
                 Ok(())
             }
@@ -406,6 +494,19 @@ mod tests {
     use super::*;
     use alloc::format;
 
+    fn make_mbc1_rom(size_kb: usize) -> Vec<u8> {
+        let size = size_kb * 1024;
+        let mut data = vec![0u8; size];
+        for bank in 0..(size / 0x4000) {
+            for byte in &mut data[bank * 0x4000..(bank + 1) * 0x4000] {
+                *byte = bank as u8;
+            }
+        }
+        data[0x0147] = 0x01;
+        data[0x0148] = (size / (32 * 1024)).trailing_zeros() as u8;
+        data
+    }
+
     // --- ROM region (read-only) ---
 
     #[test]
@@ -425,6 +526,21 @@ mod tests {
         assert!(mem.write(0x0000, 0xFF).is_ok());
         // ROM data should be unchanged
         assert_eq!(mem.read(0x0000).unwrap(), 0x11);
+    }
+
+    #[test]
+    fn test_read_fast_rom_cache_tracks_bank_switches() {
+        let mut mem = GameBoyMemory::with_rom(make_mbc1_rom(128));
+
+        assert_eq!(mem.read_fast(0x0000), 0x00);
+        assert_eq!(mem.read_fast(0x4000), 0x01);
+
+        mem.write(0x2000, 0x03).unwrap();
+        assert_eq!(mem.read_fast(0x0000), 0x00);
+        assert_eq!(mem.read_fast(0x4000), 0x03);
+
+        mem.write_fast(0x2000, 0x02);
+        assert_eq!(mem.read_fast(0x4000), 0x02);
     }
 
     // --- VRAM (0x8000–0x9FFF) ---

--- a/platform/pico2w/src/perf.rs
+++ b/platform/pico2w/src/perf.rs
@@ -50,7 +50,11 @@ impl PerfTracker {
         #[cfg(feature = "perf")]
         {
             let p = cpu.take_perf_profile();
-            let cpu_exec = p.total.wrapping_sub(p.ppu).wrapping_sub(p.timer).wrapping_sub(p.apu);
+            let cpu_exec = p
+                .total
+                .wrapping_sub(p.ppu)
+                .wrapping_sub(p.timer)
+                .wrapping_sub(p.apu);
             let decode = cpu_exec.wrapping_sub(p.mem_read).wrapping_sub(p.mem_write);
             let mem_write_other = p
                 .mem_write
@@ -60,6 +64,26 @@ impl PerfTracker {
             info!(
                 "cycles/60f — total={} ppu={} timer={} apu={} cpu_exec={} (mem_r={} mem_w={} decode={})",
                 p.total, p.ppu, p.timer, p.apu, cpu_exec, p.mem_read, p.mem_write, decode
+            );
+            info!(
+                "decode hotspots/60f (nested) — pc_fetch={} rom_pc_fetch={} rom_pc_fetch_idle={} bus_read={} opcode={} cb_prefix={} operand8={}",
+                p.pc_fetch,
+                p.pc_fetch_rom,
+                p.pc_fetch_rom_idle,
+                p.bus_read,
+                p.opcode_dispatch,
+                p.cb_prefix,
+                p.operand8
+            );
+            info!(
+                "decode hotspot calls/60f — pc_fetch={} rom_pc_fetch={} rom_pc_fetch_idle={} bus_read={} opcode={} cb_prefix={} operand8={}",
+                p.pc_fetch_calls,
+                p.pc_fetch_rom_calls,
+                p.pc_fetch_rom_idle_calls,
+                p.bus_read_calls,
+                p.opcode_dispatch_calls,
+                p.cb_prefix_calls,
+                p.operand8_calls
             );
             info!(
                 "mem_write breakdown — fast={} io={} enqueue={} other={} route={}",

--- a/platform/pico2w/src/xip_cartridge.rs
+++ b/platform/pico2w/src/xip_cartridge.rs
@@ -1,6 +1,6 @@
 use alloc::vec::Vec;
 
-use rustyboy_core::memory::cartridge::Cartridge;
+use rustyboy_core::memory::cartridge::{Cartridge, CartridgeRomWindows};
 #[cfg(feature = "perf")]
 use rustyboy_core::memory::cartridge::CartridgePerfProfile;
 
@@ -238,9 +238,32 @@ impl XipCartridge {
             } => *ram_rtc_enabled && !matches!(bank_or_rtc, 0x08..=0x0C),
         }
     }
+
+    #[inline(always)]
+    fn rom_window(&self, base: usize, valid: bool) -> (*const u8, usize) {
+        if !valid {
+            return (core::ptr::null(), 0);
+        }
+        match self.rom.get(base..) {
+            Some(slice) => (slice.as_ptr(), slice.len().min(ROM_BANK_BYTES)),
+            None => (core::ptr::null(), 0),
+        }
+    }
 }
 
 impl Cartridge for XipCartridge {
+    fn rom_windows(&self) -> Option<CartridgeRomWindows> {
+        let (fixed_ptr, fixed_len) = self.rom_window(self.fixed_bank_base, self.fixed_bank_valid);
+        let (banked_ptr, banked_len) =
+            self.rom_window(self.current_bank_base, self.current_bank_valid);
+        Some(CartridgeRomWindows {
+            fixed_ptr,
+            fixed_len,
+            banked_ptr,
+            banked_len,
+        })
+    }
+
     #[inline(always)]
     fn read_rom(&self, addr: u16) -> u8 {
         match addr {
@@ -248,11 +271,7 @@ impl Cartridge for XipCartridge {
                 if !self.fixed_bank_valid {
                     return 0xFF;
                 }
-                unsafe {
-                    *self
-                        .rom
-                        .get_unchecked(self.fixed_bank_base + addr as usize)
-                }
+                unsafe { *self.rom.get_unchecked(self.fixed_bank_base + addr as usize) }
             }
             0x4000..=0x7FFF => {
                 if !self.current_bank_valid {


### PR DESCRIPTION
## Summary

This PR targets the SM83 decode/fetch hot path on Pico and adds the instrumentation needed to measure it precisely.

It includes:
- finer-grained decode perf counters for pc_fetch, ROM pc_fetch, generic bus_read, opcode dispatch, 0xCB prefix handling, and 8-bit operand fetches
- a ROM PC fetch fast path
- an idle M-cycle fast path for both ROM fetches and internal tick_cycle users
- cached direct ROM windows in GameBoyMemory and cartridge implementations so hot ROM reads avoid per-read cartridge dispatch
- skipping idle serial and absent-RTC work in the common M-cycle path
- Pico RTT output for the new decode hotspot counters

## Why

Profiling showed that the remaining decode wall was not opcode dispatch. The dominant cost was repeated ROM instruction fetch and the generic M-cycle scaffolding around it.

This change moves the common-case cost out of:
- generic bus read wrappers
- cartridge trait dispatch on every ROM fetch
- empty bus-event, DMA, serial, and RTC checks on idle M-cycles

and onto the rarer paths where that work is actually needed.

## Results

Representative Pico perf results improved from the initial post-instrumentation baseline of roughly:
- fps: 15
- total: 900M-906M cycles / 60f
- decode: 535M-539M
- pc_fetch: 264M-266M
- bus_read: 238M-239M

to the current build at roughly:
- fps: 18-19
- total: 733M-745M cycles / 60f
- decode: 385M-390M
- pc_fetch: 122M-123M
- bus_read: 29M-32M

## Validation

Passed:
- cargo test -p rustyboy-core --features perf
- cargo test -p rustyboy-core --features perf --test blargg_instr_timing --test blargg_mem_timing -- --ignored
- cargo check --features perf in platform/pico2w

Notes:
- ignored OAM-bug / DKL2 trace diagnostic suites were not run
- pre-existing warnings remain in core/src/memory/rom.rs and core/tests/dkl2_lcdc_trace.rs