### PR TITLE
Deepen SM83 fetch cuts and refresh performance roadmap

### DIFF
--- a/core/src/cpu/perf.rs
+++ b/core/src/cpu/perf.rs
@@ -52,11 +52,21 @@ pub struct Sm83PerfProfile {
     pub pc_fetch_rom: u32,
     /// Number of `read_next_pc` calls in `0x0000..=0x7FFF`.
     pub pc_fetch_rom_calls: u32,
+    /// Nested decode hotspot: post-read `read_next_pc` wrap-up work
+    /// (primarily `PC += 1`) after the underlying fetch completes.
+    pub pc_fetch_wrapper: u32,
+    /// Number of `read_next_pc` wrap-up measurements.
+    pub pc_fetch_wrapper_calls: u32,
     /// Nested decode hotspot: ROM `read_next_pc` common-case fast path
     /// (no queued bus events, DMA, active serial transfer, or cartridge RTC).
     pub pc_fetch_rom_idle: u32,
     /// Number of ROM `read_next_pc` calls that used the common-case fast path.
     pub pc_fetch_rom_idle_calls: u32,
+    /// Nested decode hotspot: raw direct ROM window read time inside
+    /// cartridge-ROM `PC` fetches.
+    pub pc_fetch_rom_read: u32,
+    /// Number of raw direct ROM window reads in cartridge-ROM `PC` fetches.
+    pub pc_fetch_rom_read_calls: u32,
     /// Nested decode hotspot: time spent in generic non-wave `bus_read`, excluding nested PPU/timer/APU work.
     pub bus_read: u32,
     /// Number of generic non-wave `bus_read` calls.
@@ -206,9 +216,21 @@ impl Sm83PerfRecorder {
     }
 
     #[inline]
+    pub(crate) fn record_pc_fetch_wrapper(&mut self, dt: u32) {
+        self.profile.pc_fetch_wrapper = self.profile.pc_fetch_wrapper.wrapping_add(dt);
+        self.profile.pc_fetch_wrapper_calls = self.profile.pc_fetch_wrapper_calls.wrapping_add(1);
+    }
+
+    #[inline]
     pub(crate) fn record_pc_fetch_rom_idle(&mut self, dt: u32) {
         self.profile.pc_fetch_rom_idle = self.profile.pc_fetch_rom_idle.wrapping_add(dt);
         self.profile.pc_fetch_rom_idle_calls = self.profile.pc_fetch_rom_idle_calls.wrapping_add(1);
+    }
+
+    #[inline]
+    pub(crate) fn record_pc_fetch_rom_read(&mut self, dt: u32) {
+        self.profile.pc_fetch_rom_read = self.profile.pc_fetch_rom_read.wrapping_add(dt);
+        self.profile.pc_fetch_rom_read_calls = self.profile.pc_fetch_rom_read_calls.wrapping_add(1);
     }
 
     #[inline]
@@ -298,6 +320,9 @@ mod tests {
         let mut perf = Sm83PerfRecorder::default();
         perf.record_pc_fetch(0x1234, 3);
         perf.record_pc_fetch(0xC123, 5);
+        perf.record_pc_fetch_wrapper(2);
+        perf.record_pc_fetch_rom_idle(7);
+        perf.record_pc_fetch_rom_read(11);
         perf.record_bus_read(7);
         perf.record_opcode_dispatch(11);
         perf.record_cb_prefix(13);
@@ -308,6 +333,12 @@ mod tests {
         assert_eq!(profile.pc_fetch_calls, 2);
         assert_eq!(profile.pc_fetch_rom, 3);
         assert_eq!(profile.pc_fetch_rom_calls, 1);
+        assert_eq!(profile.pc_fetch_wrapper, 2);
+        assert_eq!(profile.pc_fetch_wrapper_calls, 1);
+        assert_eq!(profile.pc_fetch_rom_idle, 7);
+        assert_eq!(profile.pc_fetch_rom_idle_calls, 1);
+        assert_eq!(profile.pc_fetch_rom_read, 11);
+        assert_eq!(profile.pc_fetch_rom_read_calls, 1);
         assert_eq!(profile.bus_read, 7);
         assert_eq!(profile.bus_read_calls, 1);
         assert_eq!(profile.opcode_dispatch, 11);

--- a/core/src/cpu/sm83.rs
+++ b/core/src/cpu/sm83.rs
@@ -154,20 +154,22 @@ struct PendingApuCycles {
 }
 
 impl PendingApuCycles {
+    #[inline(always)]
     fn queue(&mut self, cycles: u16) {
-        if cycles == 0 {
-            return;
-        }
-        self.cycles = self
-            .cycles
-            .checked_add(cycles)
-            .expect("pending APU cycle batch overflow");
+        debug_assert!(cycles != 0);
+        debug_assert!(
+            self.cycles <= u16::MAX - cycles,
+            "pending APU cycle batch overflow"
+        );
+        self.cycles = self.cycles.wrapping_add(cycles);
     }
 
+    #[inline(always)]
     fn take(&mut self) -> u16 {
         core::mem::take(&mut self.cycles)
     }
 
+    #[inline(always)]
     fn is_empty(&self) -> bool {
         self.cycles == 0
     }
@@ -184,11 +186,19 @@ pub struct Sm83 {
     joypad: JoypadPeripheral,
     ime: ImeState,
     halted: bool,
-    /// Cycle counter incremented by 4 on each M-cycle (bus_read/bus_write/tick_cycle).
+    /// Total committed T-cycles. Current-instruction M-cycles are batched in
+    /// `pending_cycle_counter` and flushed once per `tick()`.
     cycle_counter: u64,
+    /// Unflushed T-cycles accrued inside the current instruction or direct
+    /// internal M-cycle helpers. This keeps the hot path on a small integer
+    /// add instead of touching the `u64` total on every M-cycle.
+    pending_cycle_counter: u16,
     /// Pending OAM DMA transfer. When Some, holds the source page and number of
     /// bytes already copied. Each M-cycle advances the transfer by one byte.
     dma: Option<DmaState>,
+    /// Cached blockers for the idle M-cycle fast path so hot fetches do not
+    /// have to rescan DMA/serial/bus-event state on every call.
+    idle_m_cycle_blockers: u8,
     /// Stable front buffer: snapshotted from the PPU at VBlank so callers always
     /// read a fully-rendered frame rather than one mid-render.
     front_buffer: [u8; FRAMEBUFFER_SIZE],
@@ -213,6 +223,11 @@ struct DmaState {
     progress: u8,
 }
 
+const IDLE_M_CYCLE_BLOCK_BUS_EVENTS: u8 = 1 << 0;
+const IDLE_M_CYCLE_BLOCK_DMA: u8 = 1 << 1;
+const IDLE_M_CYCLE_BLOCK_SERIAL: u8 = 1 << 2;
+const IDLE_M_CYCLE_BLOCK_RTC: u8 = 1 << 3;
+
 impl Sm83 {
     pub fn new(memory: Box<GameBoyMemory>, opcode_decoder: Box<dyn Decoder>) -> Self {
         let joypad = JoypadPeripheral::new();
@@ -229,7 +244,9 @@ impl Sm83 {
             ime: ImeState::Disabled,
             halted: false,
             cycle_counter: 0,
+            pending_cycle_counter: 0,
             dma: None,
+            idle_m_cycle_blockers: 0,
             front_buffer: [0u8; FRAMEBUFFER_SIZE],
             pending_apu_cycles: PendingApuCycles::default(),
             pending_bus_events: Vec::with_capacity(4),
@@ -255,6 +272,7 @@ impl Sm83 {
             sm83.memory.write_io(addr, sm83.apu.read_wave_ram(offset));
         }
         sm83.cache.sync(&sm83.memory);
+        sm83.refresh_idle_m_cycle_fast_path_blockers();
         sm83
     }
 
@@ -313,6 +331,7 @@ impl Sm83 {
     /// Returns a reference to the PPU framebuffer (160x144 pixels, 2-bit shade per pixel).
     pub fn cycle_counter(&self) -> u64 {
         self.cycle_counter
+            .wrapping_add(self.pending_cycle_counter as u64)
     }
 
     pub fn framebuffer(&self) -> &[u8; FRAMEBUFFER_SIZE] {
@@ -364,7 +383,9 @@ impl Sm83 {
             d: self.registers.d, e: self.registers.e, h: self.registers.h,
             l: self.registers.l, f: self.registers.f,
             sp: self.registers.sp, pc: self.registers.pc,
-            ime: self.ime, halted: self.halted, cycle_counter: self.cycle_counter,
+            ime: self.ime,
+            halted: self.halted,
+            cycle_counter: self.cycle_counter(),
         };
         SaveState::serialize(cpu, self.timer.to_save_state(), self.ppu.to_save_state(), &self.memory)
     }
@@ -380,10 +401,12 @@ impl Sm83 {
         self.ime           = state.cpu.ime;
         self.halted        = state.cpu.halted;
         self.cycle_counter = state.cpu.cycle_counter;
+        self.pending_cycle_counter = 0;
         self.timer.load_state(state.timer);
         self.ppu.load_state(state.ppu);
         self.memory.load_state(&state);
         self.cache.sync(&self.memory);
+        self.refresh_idle_m_cycle_fast_path_blockers();
         Ok(())
     }
 
@@ -451,40 +474,65 @@ impl Sm83 {
 
     /// Fast path for opcode/immediate fetches when `PC` is in cartridge ROM.
     ///
-    /// This preserves the exact same M-cycle-side effects as `bus_read`.
-    /// When the M-cycle is otherwise idle, we bypass the generic helper stack
-    /// entirely and run the straight-line common case directly.
+    /// This preserves the exact same M-cycle-side effects as `bus_read`,
+    /// but only for ROM fetches that still need the full generic M-cycle path.
     #[cfg_attr(target_arch = "arm", link_section = ".data")]
     #[inline(always)]
     fn read_pc_rom_fast(&mut self, addr: u16) -> u8 {
+        self.tick_cycle();
+        #[cfg(feature = "perf")]
+        let t_read = cyccnt();
+        let value = self.read_pc_rom_byte_fast(addr);
+        #[cfg(feature = "perf")]
+        {
+            let dt = cyccnt().wrapping_sub(t_read);
+            self.perf.record_mem_read(dt);
+            self.perf.record_pc_fetch_rom_read(dt);
+        }
+        value
+    }
+
+    #[cfg_attr(target_arch = "arm", link_section = ".data")]
+    #[inline(always)]
+    fn read_pc_rom_byte_fast(&self, addr: u16) -> u8 {
+        if addr <= 0x3FFF {
+            self.memory.read_rom_fixed_fast(addr)
+        } else {
+            self.memory.read_rom_banked_fast(addr)
+        }
+    }
+
+    /// Fused common-case ROM `PC` fetch. This collapses the hot idle-ROM path
+    /// into one straight-line helper so `read_next_pc()` does not pay another
+    /// layer of dispatch and bookkeeping on the overwhelmingly common case.
+    #[cfg_attr(target_arch = "arm", link_section = ".data")]
+    #[inline(always)]
+    fn read_next_pc_rom_idle_fast(&mut self, addr: u16) -> u8 {
         #[cfg(feature = "perf")]
         let nested0 = self.perf.nested_snapshot();
         #[cfg(feature = "perf")]
         let t0 = cyccnt();
-        if self.can_use_idle_m_cycle_fast_path() {
-            self.run_idle_m_cycle();
-            #[cfg(feature = "perf")]
-            let t_read = cyccnt();
-            let value = self.memory.read_rom_fast(addr);
-            #[cfg(feature = "perf")]
-            {
-                let t1 = cyccnt();
-                self.perf.record_mem_read(t1.wrapping_sub(t_read));
-                self.perf.record_pc_fetch_rom_idle(
-                    t1.wrapping_sub(t0)
-                        .wrapping_sub(self.perf.nested_cycles_since(nested0)),
-                );
-            }
-            return value;
-        }
-
-        self.tick_cycle();
+        self.run_idle_m_cycle();
         #[cfg(feature = "perf")]
         let t_read = cyccnt();
-        let value = self.memory.read_rom_fast(addr);
+        let value = self.read_pc_rom_byte_fast(addr);
+        #[cfg(feature = "perf")]
+        let t_after_read = cyccnt();
+        self.registers.pc = self.registers.pc.wrapping_add(1);
         #[cfg(feature = "perf")]
         {
-            self.perf.record_mem_read(cyccnt().wrapping_sub(t_read));
+            let t_after_pc = cyccnt();
+            let nested = self.perf.nested_cycles_since(nested0);
+            let rom_read_dt = t_after_read.wrapping_sub(t_read);
+            self.perf.record_mem_read(rom_read_dt);
+            self.perf.record_pc_fetch_rom_read(rom_read_dt);
+            self.perf.record_pc_fetch_rom_idle(
+                t_after_read.wrapping_sub(t0).wrapping_sub(nested),
+            );
+            self.perf
+                .record_pc_fetch_wrapper(t_after_pc.wrapping_sub(t_after_read));
+            self.perf
+                .record_pc_fetch(addr, t_after_pc.wrapping_sub(t0).wrapping_sub(nested));
         }
         value
     }
@@ -529,6 +577,7 @@ impl Sm83 {
                     address: addr,
                     value,
                 });
+                self.set_idle_m_cycle_blocker(IDLE_M_CYCLE_BLOCK_BUS_EVENTS);
                 #[cfg(feature = "perf")]
                 {
                     self.perf.record_mem_write_enqueue(cyccnt().wrapping_sub(t_enqueue));
@@ -581,6 +630,11 @@ impl Sm83 {
         } else {
             None
         };
+        if self.dma.is_some() {
+            self.set_idle_m_cycle_blocker(IDLE_M_CYCLE_BLOCK_DMA);
+        } else {
+            self.clear_idle_m_cycle_blocker(IDLE_M_CYCLE_BLOCK_DMA);
+        }
     }
 
     #[cfg_attr(target_arch = "arm", link_section = ".data")]
@@ -609,6 +663,11 @@ impl Sm83 {
             let if_val = self.memory.read_io(IF_ADDR);
             self.memory.write_io(IF_ADDR, if_val | (1 << SERIAL_INTERRUPT_BIT));
         }
+        if self.serial.is_idle() {
+            self.clear_idle_m_cycle_blocker(IDLE_M_CYCLE_BLOCK_SERIAL);
+        } else {
+            self.set_idle_m_cycle_blocker(IDLE_M_CYCLE_BLOCK_SERIAL);
+        }
     }
 
     /// Tick peripherals through the first 3 T-cycles of an M-cycle (T1–T3),
@@ -627,7 +686,7 @@ impl Sm83 {
 
     #[cfg_attr(target_arch = "arm", link_section = ".data")]
     fn begin_m_cycle(&mut self) {
-        self.cycle_counter += 4;
+        self.pending_cycle_counter += 4;
         self.flush_apu_before_bus_events();
         self.route_bus_events();
         self.advance_dma();
@@ -636,16 +695,13 @@ impl Sm83 {
     #[cfg_attr(target_arch = "arm", link_section = ".data")]
     #[inline(always)]
     fn can_use_idle_m_cycle_fast_path(&self) -> bool {
-        self.pending_bus_events.is_empty()
-            && self.dma.is_none()
-            && self.serial.is_idle()
-            && !self.memory.has_rtc()
+        self.idle_m_cycle_blockers == 0
     }
 
     #[cfg_attr(target_arch = "arm", link_section = ".data")]
     #[inline(always)]
     fn run_idle_m_cycle(&mut self) {
-        self.cycle_counter += 4;
+        self.pending_cycle_counter += 4;
         self.advance_ppu(4);
         self.advance_timer(4);
         self.queue_apu_cycles(4);
@@ -653,10 +709,37 @@ impl Sm83 {
 
     #[cfg_attr(target_arch = "arm", link_section = ".data")]
     fn begin_t3_sensitive_m_cycle(&mut self) {
-        self.cycle_counter += 4;
+        self.pending_cycle_counter += 4;
         self.flush_pending_apu_cycles();
         self.route_bus_events();
         self.advance_dma();
+    }
+
+    #[inline(always)]
+    fn set_idle_m_cycle_blocker(&mut self, blocker: u8) {
+        self.idle_m_cycle_blockers |= blocker;
+    }
+
+    #[inline(always)]
+    fn clear_idle_m_cycle_blocker(&mut self, blocker: u8) {
+        self.idle_m_cycle_blockers &= !blocker;
+    }
+
+    fn refresh_idle_m_cycle_fast_path_blockers(&mut self) {
+        let mut blockers = 0;
+        if !self.pending_bus_events.is_empty() {
+            blockers |= IDLE_M_CYCLE_BLOCK_BUS_EVENTS;
+        }
+        if self.dma.is_some() {
+            blockers |= IDLE_M_CYCLE_BLOCK_DMA;
+        }
+        if !self.serial.is_idle() {
+            blockers |= IDLE_M_CYCLE_BLOCK_SERIAL;
+        }
+        if self.memory.has_rtc() {
+            blockers |= IDLE_M_CYCLE_BLOCK_RTC;
+        }
+        self.idle_m_cycle_blockers = blockers;
     }
 
     #[cfg_attr(target_arch = "arm", link_section = ".data")]
@@ -702,6 +785,7 @@ impl Sm83 {
             self.handle_bus_event(e.address, e.value);
         }
         self.pending_bus_events.clear();
+        self.clear_idle_m_cycle_blocker(IDLE_M_CYCLE_BLOCK_BUS_EVENTS);
         #[cfg(feature = "perf")]
         {
             self.perf.record_mem_write_route(cyccnt().wrapping_sub(t0));
@@ -718,6 +802,11 @@ impl Sm83 {
             a if a == SC_ADDR => {
                 let sb = self.memory.read_io(SB_ADDR);
                 self.serial.handle_sc_write(value, sb);
+                if self.serial.is_idle() {
+                    self.clear_idle_m_cycle_blocker(IDLE_M_CYCLE_BLOCK_SERIAL);
+                } else {
+                    self.set_idle_m_cycle_blocker(IDLE_M_CYCLE_BLOCK_SERIAL);
+                }
             }
             a if a == DIV_ADDR => {
                 self.timer.reset_div();
@@ -726,6 +815,7 @@ impl Sm83 {
             a if a == LY_ADDR => self.ppu.reset_ly(),
             a if a == DMA_ADDR => {
                 self.dma = Some(DmaState { source: (value as u16) << 8, progress: 0 });
+                self.set_idle_m_cycle_blocker(IDLE_M_CYCLE_BLOCK_DMA);
             }
             a if (NR10_ADDR..=NR52_ADDR).contains(&a) => self.write_apu_register(a, value),
             // Unused APU addresses 0xFF27-0xFF2F always read as 0xFF
@@ -876,9 +966,14 @@ impl Sm83 {
     }
 
     #[cfg_attr(target_arch = "arm", link_section = ".data")]
-    fn finish_tick(&mut self, start_cycles: u64) -> u8 {
+    fn finish_tick(&mut self) -> u8 {
         self.flush_pending_apu_cycles();
-        (self.cycle_counter - start_cycles) as u8
+        let cycles = self.pending_cycle_counter as u8;
+        self.cycle_counter = self
+            .cycle_counter
+            .wrapping_add(self.pending_cycle_counter as u64);
+        self.pending_cycle_counter = 0;
+        cycles
     }
 
     #[cfg_attr(target_arch = "arm", link_section = ".data")]
@@ -919,6 +1014,9 @@ impl Sm83 {
     #[cfg_attr(target_arch = "arm", link_section = ".data")]
     fn read_next_pc(&mut self) -> Result<u8, MemoryError> {
         let addr = self.registers.pc;
+        if addr <= 0x7FFF && self.can_use_idle_m_cycle_fast_path() {
+            return Ok(self.read_next_pc_rom_idle_fast(addr));
+        }
         #[cfg(feature = "perf")]
         let nested0 = self.perf.nested_snapshot();
         #[cfg(feature = "perf")]
@@ -928,12 +1026,17 @@ impl Sm83 {
         } else {
             self.bus_read(addr)?
         };
+        #[cfg(feature = "perf")]
+        let t_after_fetch = cyccnt();
         self.registers.pc = self.registers.pc.wrapping_add(1);
         #[cfg(feature = "perf")]
         {
+            let t_after_pc = cyccnt();
+            self.perf
+                .record_pc_fetch_wrapper(t_after_pc.wrapping_sub(t_after_fetch));
             self.perf.record_pc_fetch(
                 addr,
-                cyccnt()
+                t_after_pc
                     .wrapping_sub(t0)
                     .wrapping_sub(self.perf.nested_cycles_since(nested0)),
             );
@@ -1100,7 +1203,12 @@ impl Sm83 {
     #[cfg_attr(target_arch = "arm", link_section = ".data")]
     #[inline(always)]
     fn tick_impl(&mut self) -> Result<u8, CpuError> {
-        let start_cycles = self.cycle_counter;
+        if self.pending_cycle_counter != 0 {
+            self.cycle_counter = self
+                .cycle_counter
+                .wrapping_add(self.pending_cycle_counter as u64);
+            self.pending_cycle_counter = 0;
+        }
 
         if self.halted {
             self.tick_cycle(); // 1 M-cycle while halted
@@ -1114,10 +1222,10 @@ impl Sm83 {
                     if let Some(bit) = self.take_pending_interrupt() {
                         self.dispatch_interrupt(bit)?;
                     }
-                    return Ok(self.finish_tick(start_cycles));
+                    return Ok(self.finish_tick());
                 }
             } else {
-                return Ok(self.finish_tick(start_cycles));
+                return Ok(self.finish_tick());
             }
         }
 
@@ -1183,7 +1291,7 @@ impl Sm83 {
             });
         }
 
-        Ok(self.finish_tick(start_cycles))
+        Ok(self.finish_tick())
     }
 }
 
@@ -2903,6 +3011,8 @@ mod tests {
         assert_eq!(perf.pc_fetch_calls, 1);
         assert_eq!(perf.pc_fetch_rom_calls, 1);
         assert_eq!(perf.pc_fetch_rom_idle_calls, 1);
+        assert_eq!(perf.pc_fetch_wrapper_calls, 1);
+        assert_eq!(perf.pc_fetch_rom_read_calls, 1);
         assert_eq!(perf.bus_read_calls, 0);
     }
 
@@ -2924,6 +3034,8 @@ mod tests {
         assert_eq!(perf.pc_fetch_calls, 1);
         assert_eq!(perf.pc_fetch_rom_calls, 0);
         assert_eq!(perf.pc_fetch_rom_idle_calls, 0);
+        assert_eq!(perf.pc_fetch_wrapper_calls, 1);
+        assert_eq!(perf.pc_fetch_rom_read_calls, 0);
         assert_eq!(perf.bus_read_calls, 1);
     }
 
@@ -2934,6 +3046,7 @@ mod tests {
             ..Default::default()
         });
         cpu.dma = Some(DmaState { source: 0x0000, progress: 0 });
+        cpu.refresh_idle_m_cycle_fast_path_blockers();
 
         let cycles = cpu.tick().unwrap();
         let perf = cpu.take_perf_profile();
@@ -2942,7 +3055,33 @@ mod tests {
         assert_eq!(perf.pc_fetch_calls, 1);
         assert_eq!(perf.pc_fetch_rom_calls, 1);
         assert_eq!(perf.pc_fetch_rom_idle_calls, 0);
+        assert_eq!(perf.pc_fetch_wrapper_calls, 1);
+        assert_eq!(perf.pc_fetch_rom_read_calls, 1);
         assert_eq!(cpu.dma.as_ref().map(|d| d.progress), Some(1));
+    }
+
+    #[cfg(feature = "perf")]
+    #[test]
+    fn test_rom_pc_fetch_skips_idle_fast_path_when_bus_events_are_pending() {
+        let mut cpu = make_test_cpu(vec![0x00]).with_registers(Registers {
+            ..Default::default()
+        });
+        cpu.pending_bus_events.push(BusEvent {
+            address: JOYP_ADDR,
+            value: 0x20,
+        });
+        cpu.refresh_idle_m_cycle_fast_path_blockers();
+
+        let cycles = cpu.tick().unwrap();
+        let perf = cpu.take_perf_profile();
+
+        assert_eq!(cycles, 4);
+        assert_eq!(perf.pc_fetch_calls, 1);
+        assert_eq!(perf.pc_fetch_rom_calls, 1);
+        assert_eq!(perf.pc_fetch_rom_idle_calls, 0);
+        assert_eq!(perf.pc_fetch_wrapper_calls, 1);
+        assert_eq!(perf.pc_fetch_rom_read_calls, 1);
+        assert!(cpu.pending_bus_events.is_empty());
     }
 
     /// HALT (0x76): returns 4 cycles without crashing.
@@ -3761,9 +3900,11 @@ mod tests {
 
         cpu.tick_cycle();
         assert_eq!(cpu.pending_apu_cycles.cycles, 4);
+        assert_eq!(cpu.cycle_counter(), 4);
 
         cpu.tick_cycle_to_t3();
 
         assert_eq!(cpu.pending_apu_cycles.cycles, 3);
+        assert_eq!(cpu.cycle_counter(), 8);
     }
 }

--- a/core/src/memory/cartridge.rs
+++ b/core/src/memory/cartridge.rs
@@ -182,13 +182,11 @@ impl NoMbc {
 
 impl Cartridge for NoMbc {
     fn rom_windows(&self) -> Option<CartridgeRomWindows> {
-        let (fixed_ptr, fixed_len) = rom_window(&self.rom, 0);
-        let (banked_ptr, banked_len) = rom_window(&self.rom, 0x4000);
         Some(CartridgeRomWindows {
-            fixed_ptr,
-            fixed_len,
-            banked_ptr,
-            banked_len,
+            fixed_ptr: rom_window(&self.rom, 0).0,
+            fixed_len: rom_window(&self.rom, 0).1,
+            banked_ptr: rom_window(&self.rom, 0x4000).0,
+            banked_len: rom_window(&self.rom, 0x4000).1,
         })
     }
 

--- a/core/src/memory/memory.rs
+++ b/core/src/memory/memory.rs
@@ -88,6 +88,9 @@ impl RegionMapping {
 pub struct GameBoyMemory {
     cartridge: Box<dyn Cartridge>,
     cartridge_has_rtc: bool,
+    cartridge_has_rom_windows: bool,
+    rom_fixed_full_window: bool,
+    rom_banked_full_window: bool,
     rom_fixed_ptr: *const u8,
     rom_fixed_len: usize,
     rom_banked_ptr: *const u8,
@@ -104,9 +107,15 @@ pub struct GameBoyMemory {
 impl GameBoyMemory {
     pub fn new() -> Self {
         let cartridge: Box<dyn Cartridge> = Box::new(NoMbc::new(vec![0u8; 0x8000]));
-        let rom_windows = cartridge.rom_windows().unwrap_or(CartridgeRomWindows::EMPTY);
+        let (cartridge_has_rom_windows, rom_windows) = match cartridge.rom_windows() {
+            Some(rom_windows) => (true, rom_windows),
+            None => (false, CartridgeRomWindows::EMPTY),
+        };
         Self {
             cartridge_has_rtc: cartridge.has_rtc(),
+            cartridge_has_rom_windows,
+            rom_fixed_full_window: rom_windows.fixed_len == 0x4000,
+            rom_banked_full_window: rom_windows.banked_len == 0x4000,
             rom_fixed_ptr: rom_windows.fixed_ptr,
             rom_fixed_len: rom_windows.fixed_len,
             rom_banked_ptr: rom_windows.banked_ptr,
@@ -125,9 +134,15 @@ impl GameBoyMemory {
     /// Construct memory backed by a pre-built cartridge implementation.
     pub fn with_cartridge(cart: Box<dyn Cartridge>) -> Self {
         let cartridge_has_rtc = cart.has_rtc();
-        let rom_windows = cart.rom_windows().unwrap_or(CartridgeRomWindows::EMPTY);
+        let (cartridge_has_rom_windows, rom_windows) = match cart.rom_windows() {
+            Some(rom_windows) => (true, rom_windows),
+            None => (false, CartridgeRomWindows::EMPTY),
+        };
         Self {
             cartridge_has_rtc,
+            cartridge_has_rom_windows,
+            rom_fixed_full_window: rom_windows.fixed_len == 0x4000,
+            rom_banked_full_window: rom_windows.banked_len == 0x4000,
             rom_fixed_ptr: rom_windows.fixed_ptr,
             rom_fixed_len: rom_windows.fixed_len,
             rom_banked_ptr: rom_windows.banked_ptr,
@@ -147,9 +162,15 @@ impl GameBoyMemory {
     /// from the ROM header (byte 0x0147) to select the correct MBC.
     pub fn with_rom(data: Vec<u8>) -> Self {
         let cartridge = cartridge::from_rom(data);
-        let rom_windows = cartridge.rom_windows().unwrap_or(CartridgeRomWindows::EMPTY);
+        let (cartridge_has_rom_windows, rom_windows) = match cartridge.rom_windows() {
+            Some(rom_windows) => (true, rom_windows),
+            None => (false, CartridgeRomWindows::EMPTY),
+        };
         Self {
             cartridge_has_rtc: cartridge.has_rtc(),
+            cartridge_has_rom_windows,
+            rom_fixed_full_window: rom_windows.fixed_len == 0x4000,
+            rom_banked_full_window: rom_windows.banked_len == 0x4000,
             rom_fixed_ptr: rom_windows.fixed_ptr,
             rom_fixed_len: rom_windows.fixed_len,
             rom_banked_ptr: rom_windows.banked_ptr,
@@ -181,7 +202,13 @@ impl GameBoyMemory {
 
     #[inline(always)]
     fn refresh_rom_windows(&mut self) {
-        let rom_windows = self.cartridge.rom_windows().unwrap_or(CartridgeRomWindows::EMPTY);
+        let (cartridge_has_rom_windows, rom_windows) = match self.cartridge.rom_windows() {
+            Some(rom_windows) => (true, rom_windows),
+            None => (false, CartridgeRomWindows::EMPTY),
+        };
+        self.cartridge_has_rom_windows = cartridge_has_rom_windows;
+        self.rom_fixed_full_window = rom_windows.fixed_len == 0x4000;
+        self.rom_banked_full_window = rom_windows.banked_len == 0x4000;
         self.rom_fixed_ptr = rom_windows.fixed_ptr;
         self.rom_fixed_len = rom_windows.fixed_len;
         self.rom_banked_ptr = rom_windows.banked_ptr;
@@ -189,13 +216,20 @@ impl GameBoyMemory {
     }
 
     #[inline(always)]
-    fn read_cached_rom(ptr: *const u8, len: usize, offset: usize) -> u8 {
-        if offset >= len {
+    fn read_cached_rom_window(ptr: *const u8, len: usize, offset: usize) -> u8 {
+        const ROM_WINDOW_BYTES: usize = 0x4000;
+        if len == ROM_WINDOW_BYTES {
+            // Full ROM windows dominate real cartridge fetches. Skip the bounds
+            // compare on the common case and go straight to the cached pointer.
+            unsafe { *ptr.add(offset) }
+        } else if offset >= len {
             return 0xFF;
+        } else {
+            // The cached ROM window length is derived from a live
+            // cartridge-backed slice, so offsets below `len` are valid for
+            // direct reads.
+            unsafe { *ptr.add(offset) }
         }
-        // The cached ROM window length is derived from a live cartridge-backed
-        // slice, so offsets below `len` are valid for direct reads.
-        unsafe { *ptr.add(offset) }
     }
 
     /// Returns the currently mapped ROM bank number for the switchable window.
@@ -241,25 +275,37 @@ impl GameBoyMemory {
     #[inline(always)]
     pub fn read_rom_fast(&self, address: u16) -> u8 {
         match address {
-            0x0000..=0x3FFF => {
-                if self.rom_fixed_len != 0 {
-                    Self::read_cached_rom(self.rom_fixed_ptr, self.rom_fixed_len, address as usize)
-                } else {
-                    self.cartridge.read_rom(address)
-                }
-            }
-            0x4000..=0x7FFF => {
-                if self.rom_banked_len != 0 {
-                    Self::read_cached_rom(
-                        self.rom_banked_ptr,
-                        self.rom_banked_len,
-                        (address - 0x4000) as usize,
-                    )
-                } else {
-                    self.cartridge.read_rom(address)
-                }
-            }
+            0x0000..=0x3FFF => self.read_rom_fixed_fast(address),
+            0x4000..=0x7FFF => self.read_rom_banked_fast(address),
             _ => 0xFF,
+        }
+    }
+
+    #[inline(always)]
+    pub fn read_rom_fixed_fast(&self, address: u16) -> u8 {
+        debug_assert!(address <= 0x3FFF);
+        if self.rom_fixed_full_window {
+            unsafe { *self.rom_fixed_ptr.add(address as usize) }
+        } else if self.cartridge_has_rom_windows {
+            Self::read_cached_rom_window(self.rom_fixed_ptr, self.rom_fixed_len, address as usize)
+        } else {
+            self.cartridge.read_rom(address)
+        }
+    }
+
+    #[inline(always)]
+    pub fn read_rom_banked_fast(&self, address: u16) -> u8 {
+        debug_assert!((0x4000..=0x7FFF).contains(&address));
+        if self.rom_banked_full_window {
+            unsafe { *self.rom_banked_ptr.add((address - 0x4000) as usize) }
+        } else if self.cartridge_has_rom_windows {
+            Self::read_cached_rom_window(
+                self.rom_banked_ptr,
+                self.rom_banked_len,
+                (address - 0x4000) as usize,
+            )
+        } else {
+            self.cartridge.read_rom(address)
         }
     }
 
@@ -541,6 +587,16 @@ mod tests {
 
         mem.write_fast(0x2000, 0x02);
         assert_eq!(mem.read_fast(0x4000), 0x02);
+    }
+
+    #[test]
+    fn test_read_fast_short_rom_keeps_open_bus_semantics() {
+        let mem = GameBoyMemory::with_rom(vec![0x11, 0x22, 0x33]);
+
+        assert_eq!(mem.read_fast(0x0000), 0x11);
+        assert_eq!(mem.read_fast(0x0002), 0x33);
+        assert_eq!(mem.read_fast(0x0003), 0xFF);
+        assert_eq!(mem.read_fast(0x4000), 0xFF);
     }
 
     // --- VRAM (0x8000–0x9FFF) ---

--- a/core/src/memory/memory.rs
+++ b/core/src/memory/memory.rs
@@ -180,13 +180,18 @@ impl GameBoyMemory {
 
     #[inline(always)]
     fn read_region_fast<const N: usize>(region: &[u8; N], offset: u16) -> u8 {
-        // The caller's address decode guarantees the offset is valid.
+        // Callers only pass offsets produced by a matching address-range decode
+        // (for example `0x8000..=0x9FFF => address - 0x8000` for VRAM), so
+        // `offset as usize` is always in `0..N`.
         unsafe { *region.get_unchecked(offset as usize) }
     }
 
     #[inline(always)]
     fn write_region_fast<const N: usize>(region: &mut [u8; N], offset: u16, value: u8) {
-        // The caller's address decode guarantees the offset is valid.
+        // Callers only pass offsets produced by a matching address-range decode,
+        // so `offset as usize` is always in bounds for `region`. The `&mut`
+        // borrow also guarantees this unchecked write is the only active access
+        // to the destination element.
         unsafe {
             *region.get_unchecked_mut(offset as usize) = value;
         }
@@ -210,6 +215,12 @@ impl GameBoyMemory {
         if offset >= len {
             return 0xFF;
         }
+        // `refresh_rom_windows()` only caches pointer/length pairs returned by
+        // the cartridge for stable ROM storage, and every ROM-control write
+        // refreshes those cached windows before the next fast-path read. The
+        // guard above proves `offset < len`, so `ptr.add(offset)` stays within
+        // the advertised window. When `len == 0` we return early and never
+        // dereference the pointer.
         unsafe { *ptr.add(offset) }
     }
 

--- a/core/src/memory/memory.rs
+++ b/core/src/memory/memory.rs
@@ -89,8 +89,6 @@ pub struct GameBoyMemory {
     cartridge: Box<dyn Cartridge>,
     cartridge_has_rtc: bool,
     cartridge_has_rom_windows: bool,
-    rom_fixed_full_window: bool,
-    rom_banked_full_window: bool,
     rom_fixed_ptr: *const u8,
     rom_fixed_len: usize,
     rom_banked_ptr: *const u8,
@@ -114,8 +112,6 @@ impl GameBoyMemory {
         Self {
             cartridge_has_rtc: cartridge.has_rtc(),
             cartridge_has_rom_windows,
-            rom_fixed_full_window: rom_windows.fixed_len == 0x4000,
-            rom_banked_full_window: rom_windows.banked_len == 0x4000,
             rom_fixed_ptr: rom_windows.fixed_ptr,
             rom_fixed_len: rom_windows.fixed_len,
             rom_banked_ptr: rom_windows.banked_ptr,
@@ -141,8 +137,6 @@ impl GameBoyMemory {
         Self {
             cartridge_has_rtc,
             cartridge_has_rom_windows,
-            rom_fixed_full_window: rom_windows.fixed_len == 0x4000,
-            rom_banked_full_window: rom_windows.banked_len == 0x4000,
             rom_fixed_ptr: rom_windows.fixed_ptr,
             rom_fixed_len: rom_windows.fixed_len,
             rom_banked_ptr: rom_windows.banked_ptr,
@@ -169,8 +163,6 @@ impl GameBoyMemory {
         Self {
             cartridge_has_rtc: cartridge.has_rtc(),
             cartridge_has_rom_windows,
-            rom_fixed_full_window: rom_windows.fixed_len == 0x4000,
-            rom_banked_full_window: rom_windows.banked_len == 0x4000,
             rom_fixed_ptr: rom_windows.fixed_ptr,
             rom_fixed_len: rom_windows.fixed_len,
             rom_banked_ptr: rom_windows.banked_ptr,
@@ -207,8 +199,6 @@ impl GameBoyMemory {
             None => (false, CartridgeRomWindows::EMPTY),
         };
         self.cartridge_has_rom_windows = cartridge_has_rom_windows;
-        self.rom_fixed_full_window = rom_windows.fixed_len == 0x4000;
-        self.rom_banked_full_window = rom_windows.banked_len == 0x4000;
         self.rom_fixed_ptr = rom_windows.fixed_ptr;
         self.rom_fixed_len = rom_windows.fixed_len;
         self.rom_banked_ptr = rom_windows.banked_ptr;
@@ -217,19 +207,10 @@ impl GameBoyMemory {
 
     #[inline(always)]
     fn read_cached_rom_window(ptr: *const u8, len: usize, offset: usize) -> u8 {
-        const ROM_WINDOW_BYTES: usize = 0x4000;
-        if len == ROM_WINDOW_BYTES {
-            // Full ROM windows dominate real cartridge fetches. Skip the bounds
-            // compare on the common case and go straight to the cached pointer.
-            unsafe { *ptr.add(offset) }
-        } else if offset >= len {
+        if offset >= len {
             return 0xFF;
-        } else {
-            // The cached ROM window length is derived from a live
-            // cartridge-backed slice, so offsets below `len` are valid for
-            // direct reads.
-            unsafe { *ptr.add(offset) }
         }
+        unsafe { *ptr.add(offset) }
     }
 
     /// Returns the currently mapped ROM bank number for the switchable window.
@@ -284,9 +265,7 @@ impl GameBoyMemory {
     #[inline(always)]
     pub fn read_rom_fixed_fast(&self, address: u16) -> u8 {
         debug_assert!(address <= 0x3FFF);
-        if self.rom_fixed_full_window {
-            unsafe { *self.rom_fixed_ptr.add(address as usize) }
-        } else if self.cartridge_has_rom_windows {
+        if self.cartridge_has_rom_windows {
             Self::read_cached_rom_window(self.rom_fixed_ptr, self.rom_fixed_len, address as usize)
         } else {
             self.cartridge.read_rom(address)
@@ -296,9 +275,7 @@ impl GameBoyMemory {
     #[inline(always)]
     pub fn read_rom_banked_fast(&self, address: u16) -> u8 {
         debug_assert!((0x4000..=0x7FFF).contains(&address));
-        if self.rom_banked_full_window {
-            unsafe { *self.rom_banked_ptr.add((address - 0x4000) as usize) }
-        } else if self.cartridge_has_rom_windows {
+        if self.cartridge_has_rom_windows {
             Self::read_cached_rom_window(
                 self.rom_banked_ptr,
                 self.rom_banked_len,

--- a/docs/performance-roadmap.md
+++ b/docs/performance-roadmap.md
@@ -1,104 +1,155 @@
 # Performance Roadmap
 
-## Current state — post display/APU work and direct-XIP cartridge path
+## Current state — post decode/fetch follow-up
 
 ROM: Tetris, Pico2W @ 250 MHz.
 
-### Representative steady-state perf window (fps = 16)
+### Representative steady-state perf window (fps = 18)
 
 | Bucket | Cycles / 60 frames | Notes |
 |---|---|---|
-| total | 825M–838M | Perf build, Tetris |
-| decode / dispatch | 461M–466M | Now the clearest CPU wall |
-| ppu | 224M–226M | Still substantial but secondary |
-| apu | 83M–90M | APU batching landed successfully |
-| mem_read | 34M–35M | Slightly higher after direct XIP, still small |
-| mem_write | 3M–4M | Bank-switch copy cost is gone |
+| total | 734M–737M | Perf build, Tetris |
+| decode / dispatch | 383M–385M | Still the largest CPU-side bucket |
+| ppu | 225M–226M | Now the next big opaque wall |
+| apu | 85M–87M | Stable, but still substantial |
+| mem_read | 18M–18.3M | Small compared to fetch wrapper cost |
+| mem_write | 3M–4M | Still well under control |
 | timer | ~18M | Stable |
+| display | ~247 ms / 60f | Scaling still dominates display time |
 
-### Display status
+### Representative decode hotspot window
 
-- `fill` is now ~1 ms / 60f after the async transfer work.
-- `scale` is still ~224 ms / 60f, but display is no longer the main ceiling.
-- The performance story is now mostly CPU-side again.
+| Bucket | Cycles / 60 frames | Notes |
+|---|---|---|
+| pc_fetch | 85M–86M | Full `read_next_pc()` cost |
+| rom_pc_fetch | 82M–83M | ROM-only subset of `pc_fetch` |
+| rom_pc_fetch_idle | 77M–78M | Common-case idle ROM fetch path |
+| rom_pc_fetch_read | 11.2M–11.3M | Raw ROM-byte read inside ROM fetch |
+| bus_read | 27M–28M | Generic non-wave `bus_read()` |
+| opcode | 16M–18M | Opcode table lookup is not the wall |
 
----
+### Summary
 
-## Landed — Direct-XIP ROM path for staged flash
-
-The Pico now uses a direct-XIP cartridge path instead of refilling a 16 KiB SRAM
-bank cache on every ROM bank switch.
-
-Measured result on Tetris:
-
-- `fps` improved from 13–14 to 16
-- `total` dropped from ~976M–1009M to ~825M–838M cycles / 60f
-- `mem_write` dropped from ~140M–169M to ~3M–4M cycles / 60f
-- Cartridge perf counters now show tiny ROM control-write cost and zero bank-reload work
-
-This change paid off immediately and should stay.
+- The decode/fetch work paid off.
+- `pc_fetch` and `rom_pc_fetch` are down enough that they no longer look like
+  the best next target.
+- The next optimization pass should move to the still-large opaque `ppu` bucket,
+  not back to opcode dispatch or another micro-tuning pass on ROM fetch.
 
 ---
 
-## Priority 1 — Decode / ROM fetch fast path
+## Landed — Decode / ROM fetch hot-path work
 
-**Expected impact: still likely the next broad CPU win after the cartridge path**
+The Pico now has:
 
-Now that the cartridge bank-switch path is addressed, `decode` remains the biggest
-bucket by a wide margin.
+- finer-grained decode perf counters around `read_next_pc`, ROM-only fetches,
+  generic `bus_read`, opcode dispatch, `0xCB` handling, and operand helpers
+- a ROM `PC` fetch fast path
+- an idle M-cycle fast path for common instruction fetches
+- cached cartridge ROM windows plus full-window shortcuts for hot ROM reads
+- cheaper M-cycle cycle-counter accounting by batching `cycle_counter` updates
+  per instruction instead of touching the `u64` total on every M-cycle
+
+Measured result on Tetris, relative to the first post-instrumentation decode
+baseline:
+
+- `fps` improved from 15 to 18
+- `total` dropped from ~900M–906M to ~734M–737M cycles / 60f
+- `decode` dropped from ~535M–539M to ~383M–385M
+- `pc_fetch` dropped from ~264M–266M to ~85M–86M
+- generic `bus_read` dropped from ~238M–239M to ~27M–28M
+
+This line of work clearly paid off. It is no longer the best place to spend the
+next iteration.
+
+---
+
+## Priority 1 — PPU residual split
+
+**Expected impact: highest next CPU-side upside**
+
+`ppu` is now about `225M–226M` cycles / 60f, but the current PPU counters only
+explain a minority of that bucket. The visible breakdown (`render_bg`,
+`render_window`, `render_sprites`, `build_stat`) leaves a large residual, so the
+next job is observability.
 
 ### What to do
 
-1. Revisit a ROM opcode-fetch fast path after the cartridge work lands.
-2. Prefer this over instruction-level tick batching unless timing evidence says
-   batching is required; the ROM fast path is less invasive.
+1. Add perf counters around the PPU mode/state-machine shell in `ppu.rs`,
+   especially:
+   - OAM-scan stepping
+   - pixel-transfer shell outside the already-counted render helpers
+   - HBlank / VBlank transition handling
+   - LY / dot bookkeeping
+   - STAT / VBlank interrupt generation and related writeback work
+2. Surface those counters in Pico RTT perf logging next to the current PPU
+   breakdown.
+3. Re-run the Pico `perf` build on hardware and capture a fresh 60-frame window.
+4. Optimize the dominant residual PPU sub-bucket before touching fetch again.
+
+### Guardrails
+
+- Do not reintroduce the old `build_stat` cache complexity unless new
+  measurements prove it is worth it.
+- Keep the current fetch path stable while measuring PPU; fetch is no longer the
+  least-understood hotspot.
+
+### Success criteria
+
+- Most of the `ppu` bucket is explained by sub-counters rather than residual
+  time.
+- The next PPU optimization target is obvious from hardware data.
 
 ---
 
-## Priority 2 — PPU work that is actually hot
+## Priority 2 — APU residual split
 
-**Expected impact: moderate; only worth revisiting with a simpler design**
+**Expected impact: moderate; only after PPU is understood**
 
-The attempted `build_stat` cache did not pay off and added invalidation complexity.
-Keep the simple implementation unless we move to a more event-driven STAT update
-model later.
+`apu` is still about `85M–87M` cycles / 60f. The current APU counters
+(`frame_seq`, `pulse`, `wave`, `noise`, `mix`) explain only part of that cost.
+If PPU work stops paying off, APU is the next profiling target.
 
 ### What to do
 
-1. Leave `build_stat` alone for now.
-2. If PPU optimization comes back onto the critical path, look for a transition-based
-   design rather than another tiny hot-path cache.
+1. Add APU-side counters around the remaining shell work that is not currently
+   attributed.
+2. Re-profile on hardware.
+3. Only then decide whether more batching or mixer-side work is justified.
 
 ---
 
-## Priority 3 — Display scaler cleanup
+## Priority 3 — Display scaler / Core 1 work
 
-**Expected impact: useful but no longer urgent**
+**Expected impact: useful, but no longer the first move**
 
-The remaining display cost is mostly scaling (`~224 ms / 60f`). That matters, but
-it is smaller than the current CPU hotspots.
+Display scaling is still about `247 ms / 60f`, but SPI transfer is already
+overlapped with emulation. The clean multicore candidate is framebuffer scaling,
+not CPU/PPU/APU execution.
 
 ### What to do
 
-Look at scaler-specific wins only after the cartridge and decode work, or if a
-non-invasive scaler cleanup becomes obvious.
+1. Leave display scaling alone while CPU-side profiling is still yielding wins.
+2. If emulator-core gains flatten out, revisit a scaler worker on core 1.
+3. Do not try to split SM83/PPU/APU timing across cores.
 
 ---
 
-## Priority 4 — Deprioritized experiments
+## Deprioritized for now
 
-- `pending_bus_events` fixed-size array: measured cost is noise compared to
-  `write_fast` and should not be a near-term priority.
-- `PPU build_stat` cache: tried and reverted; complexity was not justified by the
-  measurements.
+- More `pc_fetch` / `rom_pc_fetch` micro-optimizations
+- Another opcode-dispatch rewrite
+- Generic `bus_read()` tuning as a primary target
+- Reviving the old `build_stat` cache experiment
+
+The reason is simple: those areas are no longer the largest or least-understood
+costs in the profile.
 
 ---
 
-## Summary table
+## Immediate next move
 
-| # | Change | Est. savings | Effort | Unblocks |
-|---|---|---|---|---|
-| 1 | ROM fetch / decode fast path | large | Medium | — |
-| 2 | Event-driven PPU STAT work | moderate | Medium | — |
-| 3 | Display scaler cleanup | small/moderate | Medium | — |
-| 4 | Fixed `pending_bus_events` / tiny caches | small | Small | — |
+1. Add PPU-side perf splits around the large residual inside the current `ppu`
+   bucket.
+2. Re-run the Pico `perf` build and capture a fresh 60-frame hardware window.
+3. Pick the top PPU sub-bucket and optimize that next.

--- a/platform/pico2w/src/perf.rs
+++ b/platform/pico2w/src/perf.rs
@@ -66,20 +66,24 @@ impl PerfTracker {
                 p.total, p.ppu, p.timer, p.apu, cpu_exec, p.mem_read, p.mem_write, decode
             );
             info!(
-                "decode hotspots/60f (nested) — pc_fetch={} rom_pc_fetch={} rom_pc_fetch_idle={} bus_read={} opcode={} cb_prefix={} operand8={}",
+                "decode hotspots/60f (nested) — pc_fetch={} pc_fetch_wrapper={} rom_pc_fetch={} rom_pc_fetch_idle={} rom_pc_fetch_read={} bus_read={} opcode={} cb_prefix={} operand8={}",
                 p.pc_fetch,
+                p.pc_fetch_wrapper,
                 p.pc_fetch_rom,
                 p.pc_fetch_rom_idle,
+                p.pc_fetch_rom_read,
                 p.bus_read,
                 p.opcode_dispatch,
                 p.cb_prefix,
                 p.operand8
             );
             info!(
-                "decode hotspot calls/60f — pc_fetch={} rom_pc_fetch={} rom_pc_fetch_idle={} bus_read={} opcode={} cb_prefix={} operand8={}",
+                "decode hotspot calls/60f — pc_fetch={} pc_fetch_wrapper={} rom_pc_fetch={} rom_pc_fetch_idle={} rom_pc_fetch_read={} bus_read={} opcode={} cb_prefix={} operand8={}",
                 p.pc_fetch_calls,
+                p.pc_fetch_wrapper_calls,
                 p.pc_fetch_rom_calls,
                 p.pc_fetch_rom_idle_calls,
+                p.pc_fetch_rom_read_calls,
                 p.bus_read_calls,
                 p.opcode_dispatch_calls,
                 p.cb_prefix_calls,


### PR DESCRIPTION
## Summary

This PR continues the SM83 fetch/decode follow-up on Pico and refreshes the performance roadmap to match the latest hardware profile.

It includes:
- two finer-grained decode perf counters for `pc_fetch_wrapper` and `rom_pc_fetch_read`
- a fused common-case idle ROM `PC` fetch path
- cached full-window ROM fast paths in `GameBoyMemory`
- batched `cycle_counter` accounting so hot M-cycles stop touching the `u64` total every time
- updated Pico RTT perf logging for the new fetch counters
- a roadmap refresh with the current steady-state numbers and next-step recommendation

## Why

The fetch-side work is still paying off, but the latest measurements show it is no longer the best next target by itself.

On current Pico hardware runs, steady-state windows are about:
- `fps`: 18
- `total`: 734M–737M cycles / 60f
- `decode`: 383M–385M
- `pc_fetch`: 85M–86M
- `rom_pc_fetch`: 82M–83M
- `rom_pc_fetch_idle`: 77M–78M
- `rom_pc_fetch_read`: 11.2M–11.3M

Relative to the previous diagnostic fetch run, this cut:
- `pc_fetch` by about 15%
- `rom_pc_fetch` by about 15%
- `rom_pc_fetch_idle` by about 16%
- `rom_pc_fetch_read` by about 30%

The roadmap update reflects the new conclusion: PPU observability is now the best next pass.

## Validation

Passed:
- `env CARGO_TARGET_DIR=/tmp/rb-core-target cargo test -p rustyboy-core --features perf --lib --target x86_64-unknown-linux-gnu`
- `env CARGO_TARGET_DIR=/tmp/rb-core-target cargo test -p rustyboy-core --features perf --target x86_64-unknown-linux-gnu --test blargg_instr_timing --test blargg_mem_timing -- --ignored`
- `cargo check --features perf` in `platform/pico2w`

Hardware:
- Flashed and profiled on Pico 2W via `cargo run --release --features perf`
