### PR TITLE
Add Pico core1 peripheral island runtime

### DIFF
--- a/core/src/cpu/peripheral/apu.rs
+++ b/core/src/cpu/peripheral/apu.rs
@@ -67,8 +67,20 @@ pub struct ApuOutput {
     pub nr52: u8,
 }
 
+pub trait ApuBackend {
+    fn read_register(&mut self, address: u16) -> u8;
+    fn write_register(&mut self, address: u16, value: u8);
+    fn read_wave_ram(&mut self, offset: u8) -> u8;
+    fn write_wave_ram(&mut self, offset: u8, value: u8);
+    fn tick(&mut self, cycles: u16, div_counter: u16) -> ApuOutput;
+    fn drain_samples(&mut self) -> alloc::vec::Vec<f32>;
+    fn clear_samples(&mut self);
+    #[cfg(feature = "perf")]
+    fn take_perf_profile(&mut self) -> ApuPerfProfile;
+}
+
 #[cfg(feature = "perf")]
-#[derive(Default)]
+#[derive(Clone, Copy, Default)]
 pub struct ApuPerfProfile {
     pub frame_seq: u32,
     pub pulse: u32,
@@ -1172,6 +1184,41 @@ impl ApuPeripheral {
             self.channel3.wave_ram[2] = self.channel3.wave_ram[block_start + 2];
             self.channel3.wave_ram[3] = self.channel3.wave_ram[block_start + 3];
         }
+    }
+}
+
+impl ApuBackend for ApuPeripheral {
+    fn read_register(&mut self, address: u16) -> u8 {
+        Self::read_register(self, address)
+    }
+
+    fn write_register(&mut self, address: u16, value: u8) {
+        Self::write_register(self, address, value);
+    }
+
+    fn read_wave_ram(&mut self, offset: u8) -> u8 {
+        Self::read_wave_ram(self, offset)
+    }
+
+    fn write_wave_ram(&mut self, offset: u8, value: u8) {
+        Self::write_wave_ram(self, offset, value);
+    }
+
+    fn tick(&mut self, cycles: u16, div_counter: u16) -> ApuOutput {
+        Self::tick(self, cycles, div_counter)
+    }
+
+    fn drain_samples(&mut self) -> alloc::vec::Vec<f32> {
+        Self::drain_samples(self)
+    }
+
+    fn clear_samples(&mut self) {
+        Self::clear_samples(self);
+    }
+
+    #[cfg(feature = "perf")]
+    fn take_perf_profile(&mut self) -> ApuPerfProfile {
+        Self::take_perf_profile(self)
     }
 }
 

--- a/core/src/cpu/peripheral/island.rs
+++ b/core/src/cpu/peripheral/island.rs
@@ -1,0 +1,287 @@
+use alloc::{boxed::Box, vec::Vec};
+
+use super::apu::{ApuOutput, ApuPeripheral, NR52_ADDR};
+#[cfg(feature = "perf")]
+use super::apu::ApuPerfProfile;
+use super::ppu::{
+    PpuBackend, PpuInput, PpuOutput, PpuPeripheral, FRAMEBUFFER_SIZE,
+};
+#[cfg(feature = "perf")]
+use super::ppu::PpuPerfProfile;
+use super::timer::{TimerInput, TimerOutput, TimerPeripheral};
+use crate::cpu::save_state::{PpuState, TimerState};
+
+pub struct PeripheralRegs<'a> {
+    pub lcdc: u8,
+    pub stat: u8,
+    pub scy: u8,
+    pub scx: u8,
+    pub lyc: u8,
+    pub bgp: u8,
+    pub obp0: u8,
+    pub obp1: u8,
+    pub wy: u8,
+    pub wx: u8,
+    pub tima: u8,
+    pub tma: u8,
+    pub tac: u8,
+    pub ly: u8,
+    pub vram: &'a [u8],
+    pub oam: &'a [u8],
+}
+
+pub struct PeripheralAdvanceOutput {
+    pub ly: u8,
+    pub stat: u8,
+    pub vblank_interrupt: bool,
+    pub stat_interrupt: bool,
+    pub tima: u8,
+    pub div: u8,
+    pub timer_interrupt: bool,
+    pub nr52: u8,
+}
+
+pub struct PeripheralShadowState {
+    pub completed_seq: u32,
+    pub ly: u8,
+    pub stat: u8,
+    pub tima: u8,
+    pub div: u8,
+    pub nr52: u8,
+    pub vblank_count: u32,
+    pub stat_interrupt_count: u32,
+    pub timer_interrupt_count: u32,
+}
+
+pub trait PeripheralBackend {
+    fn advance(
+        &mut self,
+        ppu_cycles: u16,
+        timer_cycles: u16,
+        apu_cycles: u16,
+        regs: PeripheralRegs<'_>,
+    ) -> PeripheralAdvanceOutput;
+    fn supports_queued_advance(&self) -> bool {
+        false
+    }
+    fn try_queue_advance(
+        &mut self,
+        ppu_cycles: u16,
+        timer_cycles: u16,
+        apu_cycles: u16,
+        regs: PeripheralRegs<'_>,
+    ) -> bool {
+        let _ = (ppu_cycles, timer_cycles, apu_cycles, regs);
+        false
+    }
+    fn try_take_queued_shadow_state(&mut self, min_completed_seq: u32) -> Option<PeripheralShadowState> {
+        let _ = min_completed_seq;
+        None
+    }
+    fn wait_queued_shadow_state(&mut self, min_completed_seq: u32) -> PeripheralShadowState {
+        let _ = min_completed_seq;
+        panic!("queued shadow state requested from a synchronous peripheral backend")
+    }
+    fn reset_div(&mut self);
+    fn reset_ly(&mut self);
+    fn read_apu_register(&mut self, address: u16) -> u8;
+    fn write_apu_register(&mut self, address: u16, value: u8);
+    fn read_wave_ram(&mut self, offset: u8) -> u8;
+    fn write_wave_ram(&mut self, offset: u8, value: u8);
+    fn on_vram_write(&mut self, _offset: u16, _value: u8) {}
+    fn on_oam_write(&mut self, _offset: u16, _value: u8) {}
+    fn on_oam_dma_byte(&mut self, offset: u8, value: u8) {
+        self.on_oam_write(offset as u16, value);
+    }
+    fn sync_memory(&mut self, _vram: &[u8], _oam: &[u8]) {}
+    fn snapshot_framebuffer_into(&mut self, dst: &mut [u8; FRAMEBUFFER_SIZE]);
+    fn drain_samples(&mut self) -> Vec<f32>;
+    fn clear_samples(&mut self);
+    fn timer_state(&self) -> TimerState;
+    fn ppu_state(&self) -> PpuState;
+    fn load_state(&mut self, timer: TimerState, ppu: PpuState, vram: &[u8], oam: &[u8]);
+    #[cfg(feature = "perf")]
+    fn take_ppu_perf_profile(&mut self) -> PpuPerfProfile;
+    #[cfg(feature = "perf")]
+    fn take_apu_perf_profile(&mut self) -> ApuPerfProfile;
+}
+
+pub struct LocalPeripheralBackend {
+    timer: TimerPeripheral,
+    ppu: PpuPeripheral,
+    apu: ApuPeripheral,
+}
+
+impl LocalPeripheralBackend {
+    pub fn new() -> Self {
+        Self {
+            timer: TimerPeripheral::new(),
+            ppu: PpuPeripheral::new(),
+            apu: ApuPeripheral::new(),
+        }
+    }
+
+    pub unsafe fn init_in_place(dst: *mut Self) {
+        core::ptr::addr_of_mut!((*dst).timer).write(TimerPeripheral::new());
+        PpuPeripheral::init_in_place(core::ptr::addr_of_mut!((*dst).ppu));
+        core::ptr::addr_of_mut!((*dst).apu).write(ApuPeripheral::new());
+    }
+}
+
+impl Default for LocalPeripheralBackend {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl PeripheralBackend for LocalPeripheralBackend {
+    fn advance(
+        &mut self,
+        ppu_cycles: u16,
+        timer_cycles: u16,
+        apu_cycles: u16,
+        regs: PeripheralRegs<'_>,
+    ) -> PeripheralAdvanceOutput {
+        let ppu_output = if ppu_cycles == 0 {
+            PpuOutput {
+                ly: regs.ly,
+                stat: regs.stat,
+                vblank_interrupt: false,
+                stat_interrupt: false,
+            }
+        } else {
+            self.ppu.tick(
+                ppu_cycles,
+                PpuInput {
+                    lcdc: regs.lcdc,
+                    stat: regs.stat,
+                    scy: regs.scy,
+                    scx: regs.scx,
+                    lyc: regs.lyc,
+                    bgp: regs.bgp,
+                    obp0: regs.obp0,
+                    obp1: regs.obp1,
+                    wy: regs.wy,
+                    wx: regs.wx,
+                    vram: regs.vram,
+                    oam: regs.oam,
+                },
+            )
+        };
+
+        let timer_output = if timer_cycles == 0 {
+            TimerOutput {
+                tima: regs.tima,
+                div: self.timer.div(),
+                interrupt: false,
+            }
+        } else {
+            self.timer.tick(
+                timer_cycles,
+                TimerInput {
+                    tima: regs.tima,
+                    tma: regs.tma,
+                    tac: regs.tac,
+                },
+            )
+        };
+
+        let apu_output = if apu_cycles == 0 {
+            ApuOutput {
+                nr52: self.apu.read_register(NR52_ADDR),
+            }
+        } else {
+            self.apu.tick(apu_cycles, self.timer.internal_counter())
+        };
+
+        PeripheralAdvanceOutput {
+            ly: ppu_output.ly,
+            stat: ppu_output.stat,
+            vblank_interrupt: ppu_output.vblank_interrupt,
+            stat_interrupt: ppu_output.stat_interrupt,
+            tima: timer_output.tima,
+            div: timer_output.div,
+            timer_interrupt: timer_output.interrupt,
+            nr52: apu_output.nr52,
+        }
+    }
+
+    fn reset_div(&mut self) {
+        self.timer.reset_div();
+    }
+
+    fn reset_ly(&mut self) {
+        self.ppu.reset_ly();
+    }
+
+    fn read_apu_register(&mut self, address: u16) -> u8 {
+        self.apu.read_register(address)
+    }
+
+    fn write_apu_register(&mut self, address: u16, value: u8) {
+        self.apu.write_register(address, value);
+    }
+
+    fn read_wave_ram(&mut self, offset: u8) -> u8 {
+        self.apu.read_wave_ram(offset)
+    }
+
+    fn write_wave_ram(&mut self, offset: u8, value: u8) {
+        self.apu.write_wave_ram(offset, value);
+    }
+
+    fn snapshot_framebuffer_into(&mut self, dst: &mut [u8; FRAMEBUFFER_SIZE]) {
+        dst.copy_from_slice(self.ppu.framebuffer());
+    }
+
+    fn drain_samples(&mut self) -> Vec<f32> {
+        self.apu.drain_samples()
+    }
+
+    fn clear_samples(&mut self) {
+        self.apu.clear_samples();
+    }
+
+    fn timer_state(&self) -> TimerState {
+        self.timer.to_save_state()
+    }
+
+    fn ppu_state(&self) -> PpuState {
+        self.ppu.to_save_state()
+    }
+
+    fn load_state(&mut self, timer: TimerState, ppu: PpuState, vram: &[u8], oam: &[u8]) {
+        self.timer.load_state(timer);
+        self.ppu.load_state(ppu);
+        self.ppu.sync_memory(vram, oam);
+        self.apu.clear_samples();
+    }
+
+    fn on_vram_write(&mut self, offset: u16, value: u8) {
+        self.ppu.on_vram_write(offset, value);
+    }
+
+    fn on_oam_write(&mut self, offset: u16, value: u8) {
+        self.ppu.on_oam_write(offset, value);
+    }
+
+    fn sync_memory(&mut self, vram: &[u8], oam: &[u8]) {
+        self.ppu.sync_memory(vram, oam);
+    }
+
+    #[cfg(feature = "perf")]
+    fn take_ppu_perf_profile(&mut self) -> PpuPerfProfile {
+        self.ppu.take_perf_profile()
+    }
+
+    #[cfg(feature = "perf")]
+    fn take_apu_perf_profile(&mut self) -> ApuPerfProfile {
+        self.apu.take_perf_profile()
+    }
+}
+
+impl From<LocalPeripheralBackend> for Box<dyn PeripheralBackend> {
+    fn from(value: LocalPeripheralBackend) -> Self {
+        Box::new(value)
+    }
+}

--- a/core/src/cpu/peripheral/mod.rs
+++ b/core/src/cpu/peripheral/mod.rs
@@ -1,4 +1,5 @@
 pub mod apu;
+pub mod island;
 pub mod joypad;
 pub mod ppu;
 pub mod serial;

--- a/core/src/cpu/peripheral/ppu.rs
+++ b/core/src/cpu/peripheral/ppu.rs
@@ -89,9 +89,30 @@ pub struct PpuOutput {
     pub stat_interrupt: bool,
 }
 
+pub trait PpuBackend {
+    fn tick(&mut self, cycles: u16, input: PpuInput<'_>) -> PpuOutput;
+    fn reset_ly(&mut self);
+    fn on_vram_write(&mut self, _offset: u16, _value: u8) {}
+    fn on_oam_write(&mut self, _offset: u16, _value: u8) {}
+    fn on_oam_dma_byte(&mut self, offset: u8, value: u8) {
+        self.on_oam_write(offset as u16, value);
+    }
+    fn sync_memory(&mut self, _vram: &[u8], _oam: &[u8]) {}
+    fn snapshot_framebuffer_into(&mut self, dst: &mut [u8; FRAMEBUFFER_SIZE]);
+    fn to_save_state(&self) -> crate::cpu::save_state::PpuState;
+    fn load_state(
+        &mut self,
+        state: crate::cpu::save_state::PpuState,
+        vram: &[u8],
+        oam: &[u8],
+    );
+    #[cfg(feature = "perf")]
+    fn take_perf_profile(&mut self) -> PpuPerfProfile;
+}
+
 /// Scanline-based PPU peripheral.
 #[cfg(feature = "perf")]
-#[derive(Default)]
+#[derive(Clone, Copy, Default)]
 pub struct PpuPerfProfile {
     pub render_bg: u32,
     pub render_window: u32,
@@ -125,6 +146,26 @@ impl PpuPeripheral {
             #[cfg(feature = "perf")]
             perf_profile: PpuPerfProfile::default(),
         }
+    }
+
+    pub unsafe fn init_in_place(dst: *mut Self) {
+        core::ptr::addr_of_mut!((*dst).dot).write(0);
+        core::ptr::addr_of_mut!((*dst).ly).write(0);
+        core::ptr::addr_of_mut!((*dst).mode).write(PpuMode::OamScan);
+        core::ptr::addr_of_mut!((*dst).window_line_counter).write(0);
+        core::ptr::addr_of_mut!((*dst).prev_stat_line).write(false);
+        core::ptr::write_bytes(
+            core::ptr::addr_of_mut!((*dst).framebuffer).cast::<u8>(),
+            0,
+            FRAMEBUFFER_SIZE,
+        );
+        core::ptr::write_bytes(
+            core::ptr::addr_of_mut!((*dst).bg_color_indices).cast::<u8>(),
+            0,
+            SCREEN_WIDTH,
+        );
+        #[cfg(feature = "perf")]
+        core::ptr::addr_of_mut!((*dst).perf_profile).write(PpuPerfProfile::default());
     }
 
     #[cfg(feature = "perf")]
@@ -480,6 +521,38 @@ impl PpuPeripheral {
 
             self.framebuffer[row_start + sx] = apply_palette(palette, color_index);
         }
+    }
+}
+
+impl PpuBackend for PpuPeripheral {
+    fn tick(&mut self, cycles: u16, input: PpuInput<'_>) -> PpuOutput {
+        Self::tick(self, cycles, input)
+    }
+
+    fn reset_ly(&mut self) {
+        Self::reset_ly(self);
+    }
+
+    fn snapshot_framebuffer_into(&mut self, dst: &mut [u8; FRAMEBUFFER_SIZE]) {
+        dst.copy_from_slice(self.framebuffer());
+    }
+
+    fn to_save_state(&self) -> crate::cpu::save_state::PpuState {
+        Self::to_save_state(self)
+    }
+
+    fn load_state(
+        &mut self,
+        state: crate::cpu::save_state::PpuState,
+        _vram: &[u8],
+        _oam: &[u8],
+    ) {
+        Self::load_state(self, state);
+    }
+
+    #[cfg(feature = "perf")]
+    fn take_perf_profile(&mut self) -> PpuPerfProfile {
+        Self::take_perf_profile(self)
     }
 }
 

--- a/core/src/cpu/sm83.rs
+++ b/core/src/cpu/sm83.rs
@@ -30,19 +30,17 @@ use super::operations::inc_dec::{dec_u8, inc_u8};
 use super::operations::logic::{and_u8, or_u8, xor_u8};
 use super::operations::misc::daa_u8;
 use super::operations::sub::*;
-use super::peripheral::apu::{
-    ApuPeripheral, NR10_ADDR, NR52_ADDR, WAVE_RAM_START, WAVE_RAM_END,
+use super::peripheral::apu::{NR10_ADDR, NR52_ADDR, WAVE_RAM_START, WAVE_RAM_END};
+use super::peripheral::island::{
+    LocalPeripheralBackend, PeripheralBackend, PeripheralRegs, PeripheralShadowState,
 };
 use super::peripheral::joypad::{Button, JoypadPeripheral, JOYP_ADDR, JOYPAD_INTERRUPT_BIT};
 use super::peripheral::serial::{SerialPort, SERIAL_INTERRUPT_BIT};
 use super::peripheral::ppu::{
-    PpuInput, PpuPeripheral, FRAMEBUFFER_SIZE, LCDC_ADDR, STAT_ADDR, SCY_ADDR, SCX_ADDR,
-    LY_ADDR, LYC_ADDR, BGP_ADDR, OBP0_ADDR, OBP1_ADDR, WY_ADDR, WX_ADDR,
-    VBLANK_INTERRUPT_BIT, STAT_INTERRUPT_BIT,
+    FRAMEBUFFER_SIZE, LCDC_ADDR, STAT_ADDR, SCY_ADDR, SCX_ADDR, LY_ADDR, LYC_ADDR, BGP_ADDR,
+    OBP0_ADDR, OBP1_ADDR, WY_ADDR, WX_ADDR, VBLANK_INTERRUPT_BIT, STAT_INTERRUPT_BIT,
 };
-use super::peripheral::timer::{
-    TimerInput, TimerPeripheral, DIV_ADDR, TIMA_ADDR, TIMER_INTERRUPT_BIT, TMA_ADDR, TAC_ADDR,
-};
+use super::peripheral::timer::{DIV_ADDR, TIMA_ADDR, TIMER_INTERRUPT_BIT, TMA_ADDR, TAC_ADDR};
 #[cfg(feature = "perf")]
 use super::perf::{cyccnt, Sm83PerfRecorder};
 use super::registers::{Flags, Registers};
@@ -148,30 +146,29 @@ impl Sm83Cache {
     }
 }
 
-#[derive(Default)]
-struct PendingApuCycles {
-    cycles: u16,
+#[derive(Default, Clone, Copy)]
+struct PendingPeripheralCycles {
+    ppu: u16,
+    timer: u16,
+    apu: u16,
 }
 
-impl PendingApuCycles {
+impl PendingPeripheralCycles {
     #[inline(always)]
-    fn queue(&mut self, cycles: u16) {
-        debug_assert!(cycles != 0);
-        debug_assert!(
-            self.cycles <= u16::MAX - cycles,
-            "pending APU cycle batch overflow"
-        );
-        self.cycles = self.cycles.wrapping_add(cycles);
-    }
-
-    #[inline(always)]
-    fn take(&mut self) -> u16 {
-        core::mem::take(&mut self.cycles)
+    fn add(&mut self, ppu: u16, timer: u16, apu: u16) {
+        self.ppu = self.ppu.wrapping_add(ppu);
+        self.timer = self.timer.wrapping_add(timer);
+        self.apu = self.apu.wrapping_add(apu);
     }
 
     #[inline(always)]
     fn is_empty(&self) -> bool {
-        self.cycles == 0
+        self.ppu == 0 && self.timer == 0 && self.apu == 0
+    }
+
+    #[inline(always)]
+    fn take(&mut self) -> Self {
+        core::mem::take(self)
     }
 }
 
@@ -180,9 +177,7 @@ pub struct Sm83 {
     registers: Registers,
     opcodes: OpCodeTable,
     serial: SerialPort,
-    timer: TimerPeripheral,
-    ppu: PpuPeripheral,
-    apu: ApuPeripheral,
+    peripherals: Box<dyn PeripheralBackend>,
     joypad: JoypadPeripheral,
     ime: ImeState,
     halted: bool,
@@ -193,6 +188,23 @@ pub struct Sm83 {
     /// internal M-cycle helpers. This keeps the hot path on a small integer
     /// add instead of touching the `u64` total on every M-cycle.
     pending_cycle_counter: u16,
+    /// Deferred peripheral cycles for the current instruction. These are
+    /// flushed at observable boundaries instead of on every M-cycle.
+    pending_peripheral_cycles: PendingPeripheralCycles,
+    /// True when the backend supports queued peripheral advances, allowing the
+    /// CPU to submit remote work before it needs the result.
+    queued_peripheral_pipeline: bool,
+    /// Last queued advance sequence submitted to the remote peripheral island.
+    queued_peripheral_submitted_seq: u32,
+    /// Highest remote advance sequence already applied back into CPU-visible
+    /// MMIO state from the pushed shadow registers.
+    queued_peripheral_applied_seq: u32,
+    /// Last remote VBlank event count applied locally.
+    queued_peripheral_vblank_count: u32,
+    /// Last remote STAT interrupt event count applied locally.
+    queued_peripheral_stat_interrupt_count: u32,
+    /// Last remote timer interrupt event count applied locally.
+    queued_peripheral_timer_interrupt_count: u32,
     /// Pending OAM DMA transfer. When Some, holds the source page and number of
     /// bytes already copied. Each M-cycle advances the transfer by one byte.
     dma: Option<DmaState>,
@@ -202,9 +214,6 @@ pub struct Sm83 {
     /// Stable front buffer: snapshotted from the PPU at VBlank so callers always
     /// read a fully-rendered frame rather than one mid-render.
     front_buffer: [u8; FRAMEBUFFER_SIZE],
-    /// Accumulates APU T-cycles between timing-sensitive boundaries so normal
-    /// M-cycles can batch one `apu.tick(...)` per instruction instead of per cycle.
-    pending_apu_cycles: PendingApuCycles,
     /// CPU MMIO writes are routed here and applied on the next M-cycle.
     pending_bus_events: Vec<BusEvent>,
     pub cache: Sm83Cache,
@@ -227,9 +236,23 @@ const IDLE_M_CYCLE_BLOCK_BUS_EVENTS: u8 = 1 << 0;
 const IDLE_M_CYCLE_BLOCK_DMA: u8 = 1 << 1;
 const IDLE_M_CYCLE_BLOCK_SERIAL: u8 = 1 << 2;
 const IDLE_M_CYCLE_BLOCK_RTC: u8 = 1 << 3;
+const QUEUED_PERIPHERAL_SUBMIT_THRESHOLD: u16 = 16;
 
 impl Sm83 {
     pub fn new(memory: Box<GameBoyMemory>, opcode_decoder: Box<dyn Decoder>) -> Self {
+        Self::new_with_peripherals(
+            memory,
+            opcode_decoder,
+            Box::new(LocalPeripheralBackend::new()),
+        )
+    }
+
+    pub fn new_with_peripherals(
+        memory: Box<GameBoyMemory>,
+        opcode_decoder: Box<dyn Decoder>,
+        peripherals: Box<dyn PeripheralBackend>,
+    ) -> Self {
+        let queued_peripheral_pipeline = peripherals.supports_queued_advance();
         let joypad = JoypadPeripheral::new();
         let opcodes = OpCodeTable::from_decoder(&*opcode_decoder);
         let mut sm83 = Self {
@@ -237,18 +260,22 @@ impl Sm83 {
             registers: Registers::default(),
             opcodes,
             serial: SerialPort::new(),
-            timer: TimerPeripheral::new(),
-            ppu: PpuPeripheral::new(),
-            apu: ApuPeripheral::new(),
+            peripherals,
             joypad,
             ime: ImeState::Disabled,
             halted: false,
             cycle_counter: 0,
             pending_cycle_counter: 0,
+            pending_peripheral_cycles: PendingPeripheralCycles::default(),
+            queued_peripheral_pipeline,
+            queued_peripheral_submitted_seq: 0,
+            queued_peripheral_applied_seq: 0,
+            queued_peripheral_vblank_count: 0,
+            queued_peripheral_stat_interrupt_count: 0,
+            queued_peripheral_timer_interrupt_count: 0,
             dma: None,
             idle_m_cycle_blockers: 0,
             front_buffer: [0u8; FRAMEBUFFER_SIZE],
-            pending_apu_cycles: PendingApuCycles::default(),
             pending_bus_events: Vec::with_capacity(4),
             cache: Sm83Cache::default(),
             #[cfg(feature = "trace")]
@@ -261,7 +288,7 @@ impl Sm83 {
         // Seed IO memory with initial APU register read values so games
         // reading registers before any write see correct masked values.
         for addr in NR10_ADDR..=NR52_ADDR {
-            sm83.memory.write_io(addr, sm83.apu.read_register(addr));
+            sm83.memory.write_io(addr, sm83.peripherals.read_apu_register(addr));
         }
         // Unused APU addresses always read as 0xFF
         for addr in 0xFF27u16..WAVE_RAM_START {
@@ -269,8 +296,9 @@ impl Sm83 {
         }
         for addr in WAVE_RAM_START..=WAVE_RAM_END {
             let offset = (addr - WAVE_RAM_START) as u8;
-            sm83.memory.write_io(addr, sm83.apu.read_wave_ram(offset));
+            sm83.memory.write_io(addr, sm83.peripherals.read_wave_ram(offset));
         }
+        sm83.peripherals.sync_memory(sm83.memory.vram(), sm83.memory.oam());
         sm83.cache.sync(&sm83.memory);
         sm83.refresh_idle_m_cycle_fast_path_blockers();
         sm83
@@ -319,7 +347,10 @@ impl Sm83 {
     }
 
     /// Read a byte from the memory bus (for test/debug access).
-    pub fn read_memory(&self, address: u16) -> Result<u8, MemoryError> {
+    pub fn read_memory(&mut self, address: u16) -> Result<u8, MemoryError> {
+        if matches!(address, 0xFF00..=0xFF7F | 0xFFFF) {
+            self.flush_pending_peripherals();
+        }
         self.memory.read(address)
     }
 
@@ -338,25 +369,35 @@ impl Sm83 {
         &self.front_buffer
     }
 
+    /// Flush deferred peripheral work so external callers can observe the latest
+    /// framebuffer/audio/timer state without paying that cost every instruction.
+    pub fn sync_peripherals(&mut self) {
+        self.flush_pending_peripherals();
+    }
+
     /// Drain accumulated PCM audio samples since the last call.
     /// Returns interleaved stereo f32 samples [L, R, L, R, ...] at 48,000 Hz.
     pub fn drain_audio_samples(&mut self) -> alloc::vec::Vec<f32> {
-        self.apu.drain_samples()
+        self.flush_pending_peripherals();
+        self.peripherals.drain_samples()
     }
 
     #[cfg(feature = "perf")]
     pub fn take_perf_profile(&mut self) -> Sm83PerfProfile {
+        self.flush_pending_peripherals();
         self.perf.take_profile()
     }
 
     #[cfg(feature = "perf")]
     pub fn take_ppu_perf_profile(&mut self) -> super::peripheral::ppu::PpuPerfProfile {
-        self.ppu.take_perf_profile()
+        self.flush_pending_peripherals();
+        self.peripherals.take_ppu_perf_profile()
     }
 
     #[cfg(feature = "perf")]
     pub fn take_apu_perf_profile(&mut self) -> super::peripheral::apu::ApuPerfProfile {
-        self.apu.take_perf_profile()
+        self.flush_pending_peripherals();
+        self.peripherals.take_apu_perf_profile()
     }
 
     #[cfg(feature = "perf")]
@@ -377,7 +418,8 @@ impl Sm83 {
     }
 
     /// Serialize the full emulator state to an RBSS v1 blob.
-    pub fn save_state(&self) -> alloc::vec::Vec<u8> {
+    pub fn save_state(&mut self) -> alloc::vec::Vec<u8> {
+        self.flush_pending_peripherals();
         let cpu = CpuState {
             a: self.registers.a, b: self.registers.b, c: self.registers.c,
             d: self.registers.d, e: self.registers.e, h: self.registers.h,
@@ -387,7 +429,12 @@ impl Sm83 {
             halted: self.halted,
             cycle_counter: self.cycle_counter(),
         };
-        SaveState::serialize(cpu, self.timer.to_save_state(), self.ppu.to_save_state(), &self.memory)
+        SaveState::serialize(
+            cpu,
+            self.peripherals.timer_state(),
+            self.peripherals.ppu_state(),
+            &self.memory,
+        )
     }
 
     /// Restore emulator state from a parsed [`SaveState`].
@@ -397,14 +444,21 @@ impl Sm83 {
     /// well-formed `SaveState`. Returns `Ok(())` always; kept as `Result` for
     /// call-site symmetry and future extensibility.
     pub fn load_state(&mut self, state: SaveState) -> Result<(), &'static str> {
+        self.flush_pending_peripherals();
         self.registers     = state.cpu.to_registers();
         self.ime           = state.cpu.ime;
         self.halted        = state.cpu.halted;
         self.cycle_counter = state.cpu.cycle_counter;
         self.pending_cycle_counter = 0;
-        self.timer.load_state(state.timer);
-        self.ppu.load_state(state.ppu);
+        self.pending_peripheral_cycles = PendingPeripheralCycles::default();
+        self.queued_peripheral_submitted_seq = 0;
+        self.queued_peripheral_applied_seq = 0;
         self.memory.load_state(&state);
+        self.peripherals
+            .load_state(state.timer, state.ppu, self.memory.vram(), self.memory.oam());
+        self.queued_peripheral_vblank_count = 0;
+        self.queued_peripheral_stat_interrupt_count = 0;
+        self.queued_peripheral_timer_interrupt_count = 0;
         self.cache.sync(&self.memory);
         self.refresh_idle_m_cycle_fast_path_blockers();
         Ok(())
@@ -427,9 +481,9 @@ impl Sm83 {
         self.memory.write_io(OBP0_ADDR, 0xFF); // obj palette 0
         self.memory.write_io(OBP1_ADDR, 0xFF); // obj palette 1
         // APU post-boot state (Pan Docs)
-        self.write_apu_register(0xFF26, 0xF1); // NR52: APU on, ch1 active
-        self.write_apu_register(0xFF25, 0xF3); // NR51: ch1-3 right, ch1-4 left
-        self.write_apu_register(0xFF24, 0x77); // NR50: max volume both sides
+        self.write_apu_register(0xFF26, 0xF1);
+        self.write_apu_register(0xFF25, 0xF3);
+        self.write_apu_register(0xFF24, 0x77);
         self.cache.sync(&self.memory);
         self
     }
@@ -447,9 +501,8 @@ impl Sm83 {
             // at T3 within the M-cycle on real hardware.
             self.tick_cycle_to_t3();
             let offset = (addr - WAVE_RAM_START) as u8;
-            let value = self.apu.read_wave_ram(offset);
-            self.advance_timer(1);
-            self.queue_apu_cycles(1);
+            let value = self.peripherals.read_wave_ram(offset);
+            self.advance_peripherals_split(0, 1, 1);
             return Ok(value);
         }
         #[cfg(feature = "perf")]
@@ -457,6 +510,9 @@ impl Sm83 {
         #[cfg(feature = "perf")]
         let t0 = cyccnt();
         self.tick_cycle();
+        if matches!(addr, 0xFF00..=0xFF7F | 0xFFFF) {
+            self.flush_pending_peripherals();
+        }
         #[cfg(feature = "perf")]
         let t_read = cyccnt();
         let value = self.memory.read_fast(addr);
@@ -547,15 +603,13 @@ impl Sm83 {
         if (NR10_ADDR..=NR52_ADDR).contains(&addr) {
             self.tick_cycle_to_t3();
             self.write_apu_register(addr, value);
-            self.advance_timer(1);
-            self.queue_apu_cycles(1);
+            self.advance_peripherals_split(0, 1, 1);
             return Ok(());
         }
         if (WAVE_RAM_START..=WAVE_RAM_END).contains(&addr) {
             self.tick_cycle_to_t3();
             self.write_wave_ram(addr, value);
-            self.advance_timer(1);
-            self.queue_apu_cycles(1);
+            self.advance_peripherals_split(0, 1, 1);
             return Ok(());
         }
         self.tick_cycle();
@@ -586,9 +640,17 @@ impl Sm83 {
             }
             0xE000..=0xFDFF => Err(MemoryError::ReadOnly(addr)),
             _ => {
+                if matches!(addr, 0x8000..=0x9FFF | 0xFE00..=0xFE9F) {
+                    self.flush_pending_peripherals();
+                }
                 #[cfg(feature = "perf")]
                 let t_fast = cyccnt();
                 self.memory.write_fast(addr, value);
+                match addr {
+                    0x8000..=0x9FFF => self.peripherals.on_vram_write(addr - 0x8000, value),
+                    0xFE00..=0xFE9F => self.peripherals.on_oam_write(addr - 0xFE00, value),
+                    _ => {}
+                }
                 #[cfg(feature = "perf")]
                 {
                     self.perf.record_mem_write_fast(addr, cyccnt().wrapping_sub(t_fast));
@@ -624,6 +686,7 @@ impl Sm83 {
         };
         let byte = self.memory.read_fast(source + progress as u16);
         self.memory.write_fast(0xFE00 + progress as u16, byte);
+        self.peripherals.on_oam_dma_byte(progress, byte);
         let next = progress + 1;
         self.dma = if next < 160 {
             Some(DmaState { source, progress: next })
@@ -639,9 +702,7 @@ impl Sm83 {
 
     #[cfg_attr(target_arch = "arm", link_section = ".data")]
     fn advance_peripherals(&mut self, cycles: u16) {
-        self.advance_ppu(cycles);
-        self.advance_timer(cycles);
-        self.queue_apu_cycles(cycles);
+        self.advance_peripherals_split(cycles, cycles, cycles);
         if self.memory.has_rtc() {
             self.memory.tick_rtc(cycles as u32);
         }
@@ -672,14 +733,12 @@ impl Sm83 {
 
     /// Tick peripherals through the first 3 T-cycles of an M-cycle (T1–T3),
     /// stopping so the caller can perform a time-sensitive APU read or write at T3.
-    /// The caller must account for T4 afterwards with `advance_timer(1)` plus
-    /// one queued APU cycle.
+    /// The caller must account for T4 afterwards with `advance_peripherals_split(0, 1, 1)`.
     #[cfg_attr(target_arch = "arm", link_section = ".data")]
     fn tick_cycle_to_t3(&mut self) {
         self.begin_t3_sensitive_m_cycle();
-        self.advance_ppu(4);
-        self.advance_timer(3);
-        self.queue_apu_cycles(3);
+        self.advance_peripherals_split(4, 3, 3);
+        self.flush_pending_peripherals();
     }
 
     // ── Tick phase helpers ──────────────────────────────────────────────────
@@ -687,7 +746,7 @@ impl Sm83 {
     #[cfg_attr(target_arch = "arm", link_section = ".data")]
     fn begin_m_cycle(&mut self) {
         self.pending_cycle_counter += 4;
-        self.flush_apu_before_bus_events();
+        self.flush_pending_peripherals();
         self.route_bus_events();
         self.advance_dma();
     }
@@ -702,15 +761,18 @@ impl Sm83 {
     #[inline(always)]
     fn run_idle_m_cycle(&mut self) {
         self.pending_cycle_counter += 4;
-        self.advance_ppu(4);
-        self.advance_timer(4);
-        self.queue_apu_cycles(4);
+        self.advance_peripherals_split(4, 4, 4);
+        if self.queued_peripheral_applied_seq != self.queued_peripheral_submitted_seq
+            || (self.queued_peripheral_pipeline && self.ime != ImeState::Enabled)
+        {
+            self.try_submit_pending_peripherals(false);
+        }
     }
 
     #[cfg_attr(target_arch = "arm", link_section = ".data")]
     fn begin_t3_sensitive_m_cycle(&mut self) {
         self.pending_cycle_counter += 4;
-        self.flush_pending_apu_cycles();
+        self.flush_pending_peripherals();
         self.route_bus_events();
         self.advance_dma();
     }
@@ -747,27 +809,6 @@ impl Sm83 {
         if self.ime == ImeState::Pending {
             self.ime = ImeState::Enabled;
         }
-    }
-
-    #[cfg_attr(target_arch = "arm", link_section = ".data")]
-    fn flush_apu_before_bus_events(&mut self) {
-        if self.pending_apu_cycles.is_empty() || !self.pending_bus_events_require_apu_flush() {
-            return;
-        }
-        self.flush_pending_apu_cycles();
-    }
-
-    fn pending_bus_events_require_apu_flush(&self) -> bool {
-        self.pending_bus_events
-            .iter()
-            .copied()
-            .any(Self::bus_event_requires_apu_flush)
-    }
-
-    fn bus_event_requires_apu_flush(event: BusEvent) -> bool {
-        event.address == DIV_ADDR
-            || (NR10_ADDR..=NR52_ADDR).contains(&event.address)
-            || (WAVE_RAM_START..=WAVE_RAM_END).contains(&event.address)
     }
 
     #[cfg_attr(target_arch = "arm", link_section = ".data")]
@@ -809,10 +850,13 @@ impl Sm83 {
                 }
             }
             a if a == DIV_ADDR => {
-                self.timer.reset_div();
+                self.peripherals.reset_div();
                 self.cache.div = 0xFF;
             }
-            a if a == LY_ADDR => self.ppu.reset_ly(),
+            a if a == LY_ADDR => {
+                self.peripherals.reset_ly();
+                self.cache.ly = 0xFF;
+            }
             a if a == DMA_ADDR => {
                 self.dma = Some(DmaState { source: (value as u16) << 8, progress: 0 });
                 self.set_idle_m_cycle_blocker(IDLE_M_CYCLE_BLOCK_DMA);
@@ -842,13 +886,13 @@ impl Sm83 {
     /// NR52 writes may power off all channels, so all registers are resynced.
     #[cfg_attr(target_arch = "arm", link_section = ".data")]
     fn write_apu_register(&mut self, addr: u16, value: u8) {
-        self.apu.write_register(addr, value);
+        self.peripherals.write_apu_register(addr, value);
         if addr == NR52_ADDR {
             for a in NR10_ADDR..=NR52_ADDR {
-                self.memory.write_io(a, self.apu.read_register(a));
+                self.memory.write_io(a, self.peripherals.read_apu_register(a));
             }
         } else {
-            self.memory.write_io(addr, self.apu.read_register(addr));
+            self.memory.write_io(addr, self.peripherals.read_apu_register(addr));
         }
     }
 
@@ -856,31 +900,12 @@ impl Sm83 {
     #[cfg_attr(target_arch = "arm", link_section = ".data")]
     fn write_wave_ram(&mut self, addr: u16, value: u8) {
         let offset = (addr - WAVE_RAM_START) as u8;
-        self.apu.write_wave_ram(offset, value);
-        self.memory.write_io(addr, self.apu.read_wave_ram(offset));
+        self.peripherals.write_wave_ram(offset, value);
+        self.memory.write_io(addr, self.peripherals.read_wave_ram(offset));
     }
 
     #[cfg_attr(target_arch = "arm", link_section = ".data")]
-    fn advance_ppu(&mut self, cycles: u16) {
-        #[cfg(feature = "perf")]
-        let t0 = cyccnt();
-        let output = self.ppu.tick(
-            cycles,
-            PpuInput {
-                lcdc: self.cache.lcdc,
-                stat: self.cache.stat,
-                scy: self.cache.scy,
-                scx: self.cache.scx,
-                lyc: self.cache.lyc,
-                bgp: self.cache.bgp,
-                obp0: self.cache.obp0,
-                obp1: self.cache.obp1,
-                wy: self.cache.wy,
-                wx: self.cache.wx,
-                vram: self.memory.vram(),
-                oam: self.memory.oam(),
-            },
-        );
+    fn apply_peripheral_output(&mut self, output: super::peripheral::island::PeripheralAdvanceOutput) {
         if output.ly != self.cache.ly {
             self.cache.ly = output.ly;
             self.memory.write_io(LY_ADDR, output.ly);
@@ -892,7 +917,8 @@ impl Sm83 {
         if output.vblank_interrupt {
             // Snapshot the completed frame into the front buffer before the PPU
             // starts overwriting scanlines for the next frame.
-            self.front_buffer.copy_from_slice(self.ppu.framebuffer());
+            self.peripherals
+                .snapshot_framebuffer_into(&mut self.front_buffer);
             let if_val = self.memory.read_io(IF_ADDR);
             self.memory.write_io(IF_ADDR, if_val | (1 << VBLANK_INTERRUPT_BIT));
         }
@@ -900,24 +926,6 @@ impl Sm83 {
             let if_val = self.memory.read_io(IF_ADDR);
             self.memory.write_io(IF_ADDR, if_val | (1 << STAT_INTERRUPT_BIT));
         }
-        #[cfg(feature = "perf")]
-        {
-            self.perf.record_ppu(cyccnt().wrapping_sub(t0));
-        }
-    }
-
-    #[cfg_attr(target_arch = "arm", link_section = ".data")]
-    fn advance_timer(&mut self, cycles: u16) {
-        #[cfg(feature = "perf")]
-        let t0 = cyccnt();
-        let output = self.timer.tick(
-            cycles,
-            TimerInput {
-                tima: self.cache.tima,
-                tma: self.cache.tma,
-                tac: self.cache.tac,
-            },
-        );
         if output.tima != self.cache.tima {
             self.cache.tima = output.tima;
             self.memory.write_io(TIMA_ADDR, output.tima);
@@ -926,48 +934,195 @@ impl Sm83 {
             self.cache.div = output.div;
             self.memory.write_io(DIV_ADDR, output.div);
         }
-        if output.interrupt {
+        if output.timer_interrupt {
             let if_val = self.memory.read_io(IF_ADDR);
             self.memory.write_io(IF_ADDR, if_val | (1 << TIMER_INTERRUPT_BIT));
         }
-        #[cfg(feature = "perf")]
-        {
-            self.perf.record_timer(cyccnt().wrapping_sub(t0));
-        }
-    }
-
-    #[cfg_attr(target_arch = "arm", link_section = ".data")]
-    fn queue_apu_cycles(&mut self, cycles: u16) {
-        self.pending_apu_cycles.queue(cycles);
-    }
-
-    #[cfg_attr(target_arch = "arm", link_section = ".data")]
-    fn flush_pending_apu_cycles(&mut self) {
-        let cycles = self.pending_apu_cycles.take();
-        if cycles == 0 {
-            return;
-        }
-        self.tick_apu(cycles);
-    }
-
-    #[cfg_attr(target_arch = "arm", link_section = ".data")]
-    fn tick_apu(&mut self, cycles: u16) {
-        #[cfg(feature = "perf")]
-        let t0 = cyccnt();
-        let output = self.apu.tick(cycles, self.timer.internal_counter());
         if output.nr52 != self.cache.nr52 {
             self.cache.nr52 = output.nr52;
             self.memory.write_io(NR52_ADDR, output.nr52);
         }
-        #[cfg(feature = "perf")]
+    }
+
+    #[cfg_attr(target_arch = "arm", link_section = ".data")]
+    fn apply_queued_shadow_state(&mut self, shadow: PeripheralShadowState) {
+        if shadow.ly != self.cache.ly {
+            self.cache.ly = shadow.ly;
+            self.memory.write_io(LY_ADDR, shadow.ly);
+        }
+        if shadow.stat != self.cache.stat {
+            self.cache.stat = shadow.stat;
+            self.memory.write_io(STAT_ADDR, shadow.stat);
+        }
+        if shadow.tima != self.cache.tima {
+            self.cache.tima = shadow.tima;
+            self.memory.write_io(TIMA_ADDR, shadow.tima);
+        }
+        if shadow.div != self.cache.div {
+            self.cache.div = shadow.div;
+            self.memory.write_io(DIV_ADDR, shadow.div);
+        }
+        if shadow.nr52 != self.cache.nr52 {
+            self.cache.nr52 = shadow.nr52;
+            self.memory.write_io(NR52_ADDR, shadow.nr52);
+        }
+        if shadow.vblank_count != self.queued_peripheral_vblank_count {
+            self.queued_peripheral_vblank_count = shadow.vblank_count;
+            self.peripherals
+                .snapshot_framebuffer_into(&mut self.front_buffer);
+            let if_val = self.memory.read_io(IF_ADDR);
+            self.memory.write_io(IF_ADDR, if_val | (1 << VBLANK_INTERRUPT_BIT));
+        }
+        if shadow.stat_interrupt_count != self.queued_peripheral_stat_interrupt_count {
+            self.queued_peripheral_stat_interrupt_count = shadow.stat_interrupt_count;
+            let if_val = self.memory.read_io(IF_ADDR);
+            self.memory.write_io(IF_ADDR, if_val | (1 << STAT_INTERRUPT_BIT));
+        }
+        if shadow.timer_interrupt_count != self.queued_peripheral_timer_interrupt_count {
+            self.queued_peripheral_timer_interrupt_count = shadow.timer_interrupt_count;
+            let if_val = self.memory.read_io(IF_ADDR);
+            self.memory.write_io(IF_ADDR, if_val | (1 << TIMER_INTERRUPT_BIT));
+        }
+    }
+
+    #[inline(always)]
+    fn should_try_queue_pending_peripherals(&self) -> bool {
+        if !self.queued_peripheral_pipeline || self.pending_peripheral_cycles.is_empty() {
+            return false;
+        }
+
+        if self.queued_peripheral_applied_seq != self.queued_peripheral_submitted_seq {
+            return true;
+        }
+
+        let max_pending = self
+            .pending_peripheral_cycles
+            .ppu
+            .max(self.pending_peripheral_cycles.timer)
+            .max(self.pending_peripheral_cycles.apu);
+
+        self.ime != ImeState::Enabled
+            && max_pending >= QUEUED_PERIPHERAL_SUBMIT_THRESHOLD
+    }
+
+    #[cfg_attr(target_arch = "arm", link_section = ".data")]
+    fn try_submit_pending_peripherals(&mut self, force: bool) -> bool {
+        if !self.queued_peripheral_pipeline || self.pending_peripheral_cycles.is_empty() {
+            return false;
+        }
+        if !force && !self.should_try_queue_pending_peripherals() {
+            return false;
+        }
+
+        let pending = self.pending_peripheral_cycles;
+        if self.peripherals.try_queue_advance(
+            pending.ppu,
+            pending.timer,
+            pending.apu,
+            PeripheralRegs {
+                lcdc: self.cache.lcdc,
+                stat: self.cache.stat,
+                scy: self.cache.scy,
+                scx: self.cache.scx,
+                lyc: self.cache.lyc,
+                bgp: self.cache.bgp,
+                obp0: self.cache.obp0,
+                obp1: self.cache.obp1,
+                wy: self.cache.wy,
+                wx: self.cache.wx,
+                tima: self.cache.tima,
+                tma: self.cache.tma,
+                tac: self.cache.tac,
+                ly: self.cache.ly,
+                vram: self.memory.vram(),
+                oam: self.memory.oam(),
+            },
+        ) {
+            self.pending_peripheral_cycles = PendingPeripheralCycles::default();
+            self.queued_peripheral_submitted_seq =
+                self.queued_peripheral_submitted_seq.wrapping_add(1);
+            true
+        } else {
+            false
+        }
+    }
+
+    #[cfg_attr(target_arch = "arm", link_section = ".data")]
+    fn try_sync_queued_shadow_state(&mut self, min_completed_seq: u32) -> bool {
+        if !self.queued_peripheral_pipeline
+            || self.queued_peripheral_applied_seq >= self.queued_peripheral_submitted_seq
         {
-            self.perf.record_apu(cyccnt().wrapping_sub(t0));
+            return false;
+        }
+
+        let Some(shadow) = self.peripherals.try_take_queued_shadow_state(min_completed_seq) else {
+            return false;
+        };
+        self.queued_peripheral_applied_seq = shadow
+            .completed_seq
+            .min(self.queued_peripheral_submitted_seq);
+        self.apply_queued_shadow_state(shadow);
+        true
+    }
+
+    #[cfg_attr(target_arch = "arm", link_section = ".data")]
+    fn advance_peripherals_split(&mut self, ppu_cycles: u16, timer_cycles: u16, apu_cycles: u16) {
+        self.pending_peripheral_cycles
+            .add(ppu_cycles, timer_cycles, apu_cycles);
+    }
+
+    #[cfg_attr(target_arch = "arm", link_section = ".data")]
+    fn flush_pending_peripherals(&mut self) {
+        if self.queued_peripheral_applied_seq != self.queued_peripheral_submitted_seq {
+            let next_needed = self.queued_peripheral_applied_seq.wrapping_add(1);
+            let _ = self.try_sync_queued_shadow_state(next_needed);
+        }
+
+        if self.queued_peripheral_pipeline {
+            let _ = self.try_submit_pending_peripherals(true);
+            return;
+        }
+
+        if !self.pending_peripheral_cycles.is_empty() {
+            let pending = self.pending_peripheral_cycles.take();
+        #[cfg(feature = "perf")]
+            let ppu_t0 = cyccnt();
+            let output = self.peripherals.advance(
+                pending.ppu,
+                pending.timer,
+                pending.apu,
+                PeripheralRegs {
+                    lcdc: self.cache.lcdc,
+                    stat: self.cache.stat,
+                    scy: self.cache.scy,
+                    scx: self.cache.scx,
+                    lyc: self.cache.lyc,
+                    bgp: self.cache.bgp,
+                    obp0: self.cache.obp0,
+                    obp1: self.cache.obp1,
+                    wy: self.cache.wy,
+                    wx: self.cache.wx,
+                    tima: self.cache.tima,
+                    tma: self.cache.tma,
+                    tac: self.cache.tac,
+                    ly: self.cache.ly,
+                    vram: self.memory.vram(),
+                    oam: self.memory.oam(),
+                },
+            );
+            self.apply_peripheral_output(output);
+            #[cfg(feature = "perf")]
+            {
+                let dt = cyccnt().wrapping_sub(ppu_t0);
+                self.perf.record_ppu(dt);
+                self.perf.record_timer(0);
+                self.perf.record_apu(0);
+            }
         }
     }
 
     #[cfg_attr(target_arch = "arm", link_section = ".data")]
     fn finish_tick(&mut self) -> u8 {
-        self.flush_pending_apu_cycles();
         let cycles = self.pending_cycle_counter as u8;
         self.cycle_counter = self
             .cycle_counter
@@ -977,7 +1132,8 @@ impl Sm83 {
     }
 
     #[cfg_attr(target_arch = "arm", link_section = ".data")]
-    fn has_pending_interrupt(&self) -> bool {
+    fn has_pending_interrupt(&mut self) -> bool {
+        self.flush_pending_peripherals();
         let ie = self.memory.read_io(IE_ADDR);
         let if_val = self.memory.read_io(IF_ADDR);
         ie & if_val != 0
@@ -985,6 +1141,7 @@ impl Sm83 {
 
     #[cfg_attr(target_arch = "arm", link_section = ".data")]
     fn take_pending_interrupt(&mut self) -> Option<u8> {
+        self.flush_pending_peripherals();
         let ie = self.memory.read_io(IE_ADDR);
         let if_val = self.memory.read_io(IF_ADDR);
         let pending = ie & if_val;
@@ -1268,18 +1425,19 @@ impl Sm83 {
         };
         op.execute(self)?;
 
-        // Peripherals and bus events are already advanced per M-cycle
-        // inside bus_read/bus_write/tick_cycle — no bulk advance needed.
-        self.flush_pending_apu_cycles();
-
         if self.ime == ImeState::Enabled {
             if let Some(bit) = self.take_pending_interrupt() {
                 self.dispatch_interrupt(bit)?;
             }
         }
 
+        if !self.queued_peripheral_pipeline {
+            self.flush_pending_peripherals();
+        }
+
         #[cfg(feature = "trace")]
         if let Some(ref mut hook) = self.trace_hook {
+            self.flush_pending_peripherals();
             hook(TraceEvent {
                 pc: self.registers.pc,
                 registers: &self.registers,
@@ -3864,47 +4022,44 @@ mod tests {
     }
 
     #[test]
-    fn test_tick_returns_with_no_pending_apu_cycles() {
+    fn test_tick_returns_expected_cycles_without_pending_batches() {
         let mut cpu = make_test_cpu(vec![0x00]);
 
-        cpu.tick().unwrap();
-
-        assert!(cpu.pending_apu_cycles.is_empty());
+        let cycles = cpu.tick().unwrap();
+        assert_eq!(cycles, 4);
     }
 
     #[test]
-    fn test_halted_tick_returns_with_no_pending_apu_cycles() {
+    fn test_halted_tick_returns_expected_cycles_without_pending_batches() {
         let mut cpu = make_test_cpu(vec![0x76, 0x00]);
 
         cpu.tick().unwrap(); // HALT
-        cpu.tick().unwrap(); // halted early return
+        let cycles = cpu.tick().unwrap(); // halted early return
 
-        assert!(cpu.pending_apu_cycles.is_empty());
+        assert_eq!(cycles, 4);
     }
 
     #[test]
-    fn test_interrupt_dispatch_returns_with_no_pending_apu_cycles() {
+    fn test_interrupt_dispatch_returns_expected_cycles_without_pending_batches() {
         let mut cpu = make_test_cpu(vec![0xFB, 0x00, 0x00, 0x00]);
         cpu.memory.write_io(IE_ADDR, 0x01);
         cpu.memory.write_io(IF_ADDR, 0x01);
 
         cpu.tick().unwrap(); // EI
-        cpu.tick().unwrap(); // NOP + interrupt dispatch
+        let cycles = cpu.tick().unwrap(); // NOP + interrupt dispatch
 
-        assert!(cpu.pending_apu_cycles.is_empty());
+        assert_eq!(cycles, 24);
     }
 
     #[test]
-    fn test_tick_cycle_to_t3_flushes_prior_apu_batch() {
+    fn test_tick_cycle_to_t3_keeps_cycle_counter_monotonic() {
         let mut cpu = make_test_cpu(vec![0x00]);
 
         cpu.tick_cycle();
-        assert_eq!(cpu.pending_apu_cycles.cycles, 4);
         assert_eq!(cpu.cycle_counter(), 4);
 
         cpu.tick_cycle_to_t3();
 
-        assert_eq!(cpu.pending_apu_cycles.cycles, 3);
         assert_eq!(cpu.cycle_counter(), 8);
     }
 }

--- a/core/tests/common/mod.rs
+++ b/core/tests/common/mod.rs
@@ -215,6 +215,7 @@ pub fn run_rom_frames(path: &str, frames: u32) -> Vec<u8> {
         let cycles = cpu.tick().unwrap() as u64;
         dots_elapsed += cycles;
     }
+    cpu.sync_peripherals();
 
     cpu.framebuffer().to_vec()
 }

--- a/core/tests/dkl2_lcdc_trace.rs
+++ b/core/tests/dkl2_lcdc_trace.rs
@@ -46,9 +46,10 @@ fn run_frame(cpu: &mut Sm83) {
     while cpu.cycle_counter().wrapping_sub(start) < CYCLES_PER_FRAME as u64 {
         let _ = cpu.tick();
     }
+    cpu.sync_peripherals();
 }
 
-fn dump_oam_summary(cpu: &Sm83) -> usize {
+fn dump_oam_summary(cpu: &mut Sm83) -> usize {
     let mut visible = 0;
     for i in 0..40 {
         let base = 0xFE00 + (i * 4) as u16;
@@ -547,7 +548,7 @@ fn trace_dkl2_level_lcdc() {
     let stat = cpu.read_memory(STAT_ADDR).unwrap_or(0);
     let lyc = cpu.read_memory(LYC_ADDR).unwrap_or(0);
     eprintln!("LCDC=0x{:02X} OBJ={} BGP=0x{:02X} STAT=0x{:02X} LYC={}", lcdc, (lcdc>>1)&1, bgp, stat, lyc);
-    let n = dump_oam_summary(&cpu);
+    let n = dump_oam_summary(&mut cpu);
     eprintln!("Active sprites: {}", n);
 
     // Mid-frame LCDC trace for final 3 frames

--- a/core/tests/save_state.rs
+++ b/core/tests/save_state.rs
@@ -100,7 +100,7 @@ fn test_save_state_pc_preserved() {
 #[test]
 fn test_save_state_wram_preserved() {
     let rom = make_rom(0x00, 0, 0);
-    let cpu = make_emulator(rom.clone());
+    let mut cpu = make_emulator(rom.clone());
 
     // Write known pattern into WRAM via the save-state blob.
     // WRAM occupies bytes [164..164+0x2000] in the blob.

--- a/docs/multithreaded-core-plan.md
+++ b/docs/multithreaded-core-plan.md
@@ -1,0 +1,455 @@
+# Multithreaded Core Plan
+
+## Goal
+
+Add a 2-thread runtime architecture that works on:
+
+- `platform/pico2w` by using both RP2350 cores
+- `platform/web` by moving emulation work off the UI thread
+
+while preserving the existing cycle-accurate `rustyboy-core` emulation model.
+
+## Recommendation
+
+Do **not** split the SM83, PPU, APU, DMA, timer, or bus across threads.
+
+Instead:
+
+- keep one thread as the **emulation owner**
+- use the second thread/core as a **runtime worker**
+- communicate only with coarse-grained messages and leased buffers
+
+This keeps the hard timing logic single-owner and makes the second thread useful
+without turning every peripheral boundary into a synchronization problem.
+
+## Why The Core Should Stay Single-Owner
+
+Today `Sm83` owns:
+
+- CPU registers and instruction execution
+- bus and memory
+- timer
+- PPU
+- APU
+- DMA state
+- serial state
+- joypad state
+
+and advances them together inside each instruction/M-cycle.
+
+Important coupling points already in the code:
+
+- `Sm83::tick_impl()` drives the whole machine instruction-by-instruction.
+- `Sm83::advance_ppu()` passes live VRAM/OAM slices into the PPU and snapshots the
+  finished frame on VBlank.
+- `Sm83::tick_apu()` depends on the timer's internal counter.
+- `Sm83::tick_cycle_to_t3()` exists specifically to preserve wave-RAM timing at
+  T3 within a single M-cycle.
+- `Sm83::flush_apu_before_bus_events()` shows that some MMIO writes must be
+  synchronized with pending APU work before the write is applied.
+
+That means the hot path is not "CPU + a few optional peripherals". It is one
+timing domain.
+
+## Splits That Do Not Make Sense
+
+### CPU thread + PPU thread
+
+Not recommended.
+
+Reasons:
+
+- the PPU reads live VRAM and OAM constantly
+- STAT, LY, VBlank, and LCD timing feed directly back into interrupts
+- the current implementation snapshots the front buffer at VBlank from inside
+  the same owner that advances the CPU and interrupt state
+
+Moving the PPU out-of-thread would require either:
+
+- per-cycle/per-M-cycle messages, which would be very expensive, or
+- speculative snapshots of VRAM/OAM/register state, which risks timing bugs
+
+### CPU thread + APU thread
+
+Not recommended.
+
+Reasons:
+
+- APU timing depends on the timer internal counter
+- wave RAM reads/writes have T-cycle-sensitive behavior
+- MMIO writes already force local flushes before state changes are applied
+
+This is too timing-sensitive to be a good first multicore split.
+
+### Shared `Arc<Mutex<Sm83>>` across threads
+
+Not recommended.
+
+This spreads locks through the whole runtime and makes contention and timing
+behavior part of the emulator architecture. The `RustedROM` repo is a useful
+caution here: it uses a dedicated CPU thread, but the model is centered around
+`Arc<Mutex<...>>` shared state rather than single ownership plus messages.
+
+## Splits That Do Make Sense
+
+### 1. Emulation thread + presentation/audio worker
+
+Recommended first step.
+
+The emulation thread:
+
+- owns `Sm83`
+- applies input commands
+- runs one frame worth of cycles
+- snapshots or leases frame/audio output
+- sends output messages to the worker
+
+The worker:
+
+- converts framebuffer formats if needed
+- packages audio for the platform sink
+- performs blocking or pacing-sensitive output work
+- returns reusable buffers to the emulation thread
+
+This turns the second thread into a producer/consumer pipeline instead of a
+second owner of Game Boy timing.
+
+### 2. Emulation thread + UI/main thread on web
+
+Recommended web shape.
+
+Even without true Rust/Wasm threads, the browser can still use two execution
+contexts:
+
+- a worker for emulation
+- the main thread for canvas, DOM, and UI
+
+This is the cleanest way to get emulation off the browser main thread.
+
+### 3. Emulation core + conversion/output core on Pico
+
+Recommended Pico shape.
+
+The Pico worker core should own the work that is expensive but timing-coarse:
+
+- framebuffer scaling/color conversion
+- audio sample packing for DMA buffers
+- possibly save/persistence packaging later
+
+Display DMA and audio DMA are already overlapped with emulation on core 0. The
+best use of core 1 is the CPU work around those outputs, not splitting the
+actual Game Boy timing model.
+
+## Proposed Architecture
+
+## Layer 1: Keep `rustyboy-core` single-threaded
+
+`rustyboy-core` should remain the deterministic machine implementation.
+
+Add only small runtime-facing APIs if needed, for example:
+
+- `run_frame()`
+- `take_frame_snapshot_into(...)`
+- `drain_audio_into(...)`
+- `apply_input_delta(...)`
+
+The core should not learn about threads, mutexes, workers, or platform mailboxes.
+
+## Layer 2: Add a runtime boundary
+
+Introduce a new runtime module or crate that defines the message protocol.
+
+Suggested types:
+
+```rust
+pub enum CoreCommand {
+    SetButton { button: Button, pressed: bool },
+    Pause,
+    Resume,
+    Reset,
+    LoadState(Vec<u8>),
+    SaveState,
+    Shutdown,
+}
+
+pub enum CoreEvent {
+    FrameReady(FramePacket),
+    AudioReady(AudioPacket),
+    SaveStateReady(Vec<u8>),
+    Stopped,
+}
+
+pub struct FramePacket {
+    pub frame_id: u64,
+    pub format: FrameFormat,
+    pub data: FrameBuffer,
+}
+
+pub struct AudioPacket {
+    pub frame_id: u64,
+    pub samples: AudioBuffer,
+}
+```
+
+The important part is that the runtime boundary is **message-based**, not
+`&mut Sm83`-based.
+
+## Layer 3: Use reusable buffers
+
+Avoid allocating a new `Vec` every frame.
+
+Use a small pool:
+
+- 2 frame buffers
+- 2 audio buffers
+
+Flow:
+
+1. worker returns an empty buffer token
+2. emulation fills it
+3. emulation sends it to the worker
+4. worker consumes it and returns the buffer token
+
+This is effectively a mailbox plus a double-buffer pool.
+
+## Threading Abstraction
+
+The abstraction should wrap:
+
+- spawning a long-lived worker
+- sending commands/events
+- exchanging reusable buffers
+
+It should **not** try to abstract every detail of `std::thread` and Pico
+multicore semantics into a fake universal thread API.
+
+Prefer a higher-level trait such as:
+
+```rust
+pub trait RuntimeBackend {
+    type CommandSender;
+    type CommandReceiver;
+    type EventSender;
+    type EventReceiver;
+
+    fn spawn_emu_worker(
+        entry: impl FnOnce(Self::CommandReceiver, Self::EventSender) + Send + 'static,
+    );
+}
+```
+
+For buffer exchange, use a separate trait or concrete SPSC queue wrapper rather
+than embedding buffer management into the spawn trait.
+
+## Platform Backends
+
+### Pico backend
+
+Use:
+
+- `embassy_rp::multicore::spawn_core1`
+- fixed static core-1 stack
+- `embassy_sync::channel`
+- `SpinlockRawMutex` or the embassy multicore-safe mutex/channel primitives
+
+Recommended ownership:
+
+- core 0: emulation owner
+- core 1: frame/audio worker
+
+Why core 0 should keep emulation:
+
+- current Embassy initialization and most hardware setup already live there
+- display/audio DMA startup is already integrated there
+- the emulation loop is the most timing-sensitive owner
+
+### Web backend
+
+There are two viable options.
+
+#### Option A: Dedicated Web Worker
+
+Recommended first.
+
+Shape:
+
+- main thread owns UI, DOM, canvas, menu, input
+- worker owns the emulator instance
+- messages pass input, frame buffers, audio batches, save-state requests
+
+Pros:
+
+- works with the current browser architecture model
+- does not require turning the Rust wasm build into true threaded wasm first
+- keeps UI responsive immediately
+
+Cons:
+
+- this is a browser worker abstraction, not `std::thread`
+- some glue will be JS-side rather than pure Rust
+
+#### Option B: True Rust/Wasm threads
+
+Possible, but more expensive.
+
+Constraints:
+
+- current target is `wasm32-unknown-unknown`
+- on that target, `std::thread::spawn` panics by default
+- real threaded wasm needs atomics-enabled builds and rebuilt std
+- browser hosting must be cross-origin isolated
+
+This repo already sends:
+
+- `Cross-Origin-Embedder-Policy: require-corp`
+- `Cross-Origin-Opener-Policy: same-origin`
+
+so hosting is much closer to ready than most projects, but the build pipeline
+would still need to change.
+
+If we choose this route later, we should likely model the web backend after a
+worker bootstrap approach similar to `wasm-bindgen-rayon`.
+
+## Suggested Data Flow
+
+### Commands into the emulation owner
+
+- button pressed/released
+- pause/resume
+- save/load state
+- shutdown
+
+These are low-frequency and small.
+
+### Events out of the emulation owner
+
+- frame ready
+- audio ready
+- optional telemetry/perf data
+- save-state response
+
+These are coarse-grained and bounded.
+
+### Important rule
+
+Never send per-cycle, per-scanline, or per-register mutation messages across
+threads in the normal emulation path.
+
+That would move the timing wall from the CPU to the mailbox.
+
+## Phased Implementation Plan
+
+## Phase 0: Runtime API cleanup
+
+Before threads:
+
+- add a `run_frame()` helper around the current `while cycle_counter < frame_budget`
+  loops
+- add buffer-filling APIs that write into caller-provided frame/audio buffers
+- define the command/event enums in one place
+
+Goal:
+
+- make the current single-threaded runners use the future threaded boundary,
+  just without spawning yet
+
+## Phase 1: Pico worker core
+
+Implement the 2-core Pico path first.
+
+Reason:
+
+- the hardware model is clear
+- the backend primitives already exist in Embassy
+- the repo already has a strong output pipeline on Pico
+
+Split:
+
+- core 0 runs `Sm83`
+- core 1 performs framebuffer scaling and audio sample packing
+
+Minimal first payload:
+
+- send completed 160x144 frame snapshots to core 1
+- core 1 writes the 240x216 RGB565 buffer
+- optionally move `samples_to_i2s` style packing to core 1 as well
+
+## Phase 2: Web worker runtime
+
+Move emulation off the browser main thread.
+
+Recommended first web shape:
+
+- JS main thread
+- worker-hosted wasm emulator
+
+Keep the runtime message protocol aligned with Pico as much as possible even if
+the transport differs.
+
+## Phase 3: Shared buffer pool
+
+Replace copying `Vec` traffic with reusable frame/audio buffer leases.
+
+This is where the abstraction pays off:
+
+- same producer/consumer model
+- same packet types
+- only transport/backend differs
+
+## Phase 4: Optional true threaded wasm
+
+Only do this if we explicitly want:
+
+- Rust-managed worker threads in the browser
+- shared-memory atomics
+- fewer JS-side runtime responsibilities
+
+This should be treated as a separate project, not a prerequisite for Phase 2.
+
+## Concrete Near-Term Refactors
+
+1. Add `Sm83::run_frame(cycles_per_frame)` or a small runner wrapper in `core`.
+2. Add `framebuffer_into(dst: &mut [u8; FRAMEBUFFER_SIZE])` and
+   `drain_audio_into(dst: &mut Vec<f32>)` style APIs or equivalent packet-filling helpers.
+3. Create a shared `runtime` module with `CoreCommand`, `CoreEvent`, `FramePacket`,
+   and `AudioPacket`.
+4. Build a no-op single-threaded backend first so both current platforms can
+   compile against the same runtime boundary.
+5. Then add the Pico multicore backend.
+6. Then move the web platform to a worker-based runtime.
+
+## Decision Summary
+
+Recommended:
+
+- single-owner `Sm83`
+- threaded runtime around the core
+- second thread handles coarse output work
+- message passing plus reusable buffers
+- Pico multicore first
+- web worker second
+
+Not recommended:
+
+- CPU/PPU split
+- CPU/APU split
+- shared `Arc<Mutex<Sm83>>`
+- per-cycle inter-thread synchronization
+
+## Research Notes
+
+Current repo observations:
+
+- Pico already overlaps display DMA and audio DMA with emulation, which shows the
+  runtime is already moving toward pipeline parallelism.
+- The web client currently runs emulation on the main browser thread.
+- The web server already sets COOP/COEP/CORP headers, which is a prerequisite
+  for shared-memory browser features if we later pursue true threaded wasm.
+
+External inspiration:
+
+- `CFdefense/RustedROM` demonstrates a dedicated CPU thread model, but it also
+  shows how quickly `Arc<Mutex<...>>` can become the central architecture.
+- Rust's `wasm32-unknown-unknown` target still does not provide working
+  `std::thread::spawn` out of the box, so a web threading plan must be explicit
+  about whether it means Web Workers or true atomics-enabled threaded wasm.

--- a/docs/ppu-apu-core1-plan.md
+++ b/docs/ppu-apu-core1-plan.md
@@ -1,0 +1,502 @@
+# PPU/APU Core 1 Split Plan
+
+## Goal
+
+Build a 2-core architecture where:
+
+- core 0 owns CPU execution, cartridge, timer, serial, joypad, and interrupt dispatch
+- core 1 owns as much of PPU and APU work as we can move without breaking timing
+
+This is the aggressive path after deciding that offloading only display scaling
+and output packaging is not enough.
+
+## Performance Ceiling
+
+Using the current Pico numbers from [performance-roadmap.md](./performance-roadmap.md):
+
+- total: `734M–737M cycles / 60f`
+- ppu: `225M–226M cycles / 60f`
+- apu: `85M–87M cycles / 60f`
+
+If we could move the full current PPU+APU cost off core 0 with perfect overlap:
+
+- core 0 would keep about `424M cycles / 60f`
+- core 1 would take about `311M cycles / 60f`
+- at `250 MHz`, the ideal ceiling becomes about `35.4 fps`
+
+That is the best-case ceiling for this direction before sync overhead.
+
+## The Main Constraint
+
+The current code does not have a "PPU module" and an "APU module" that can
+simply be moved to another core. It has one CPU owner that:
+
+- advances PPU directly
+- advances timer directly
+- queues and flushes APU cycles directly
+- routes MMIO writes directly
+- handles T3-sensitive APU wave accesses directly
+- snapshots LY/STAT/NR52 back into the IO register shadow directly
+
+Relevant current seams:
+
+- `Sm83::bus_write()` special-cases APU register and wave RAM writes at T3
+- `Sm83::tick_cycle_to_t3()` exists specifically for time-sensitive APU access
+- `Sm83::handle_bus_event()` applies LCD/APU MMIO writes directly
+- `Sm83::advance_ppu()` passes live VRAM/OAM slices to the PPU and raises VBlank/STAT
+- `Sm83::tick_apu()` calls `apu.tick(cycles, timer.internal_counter())`
+
+So the first step is not "spawn core 1". The first step is to create a
+timestamped peripheral boundary.
+
+## The Split We Actually Need
+
+To make a core-1 peripheral architecture viable, split both PPU and APU into:
+
+- a **control plane**
+- a **data plane**
+
+The control plane handles timing-sensitive CPU-visible semantics.
+The data plane handles the heavy work that burns cycles.
+
+## PPU Split
+
+### PPU control plane
+
+This is the part that stays tightly coupled to the CPU at first:
+
+- `dot`, `ly`, `mode`, `window_line_counter`
+- STAT line generation and edge detection
+- VBlank and STAT interrupt generation
+- LCDC/STAT/SCX/SCY/LYC/WX/WY palette register shadowing
+- frame boundary / front-buffer swap policy
+
+This logic is tightly coupled because the CPU can read LY/STAT at arbitrary
+times and because interrupts feed directly back into execution.
+
+### PPU data plane
+
+This is the part we should move first:
+
+- background scanline render
+- window scanline render
+- sprite scanline render
+- backing frame buffer storage
+- optional line-to-platform format conversion later
+
+In the current implementation this corresponds mainly to:
+
+- `render_bg_scanline`
+- `render_window_scanline`
+- `render_sprite_scanline`
+- `draw_sprite`
+
+### PPU job model
+
+Core 0 should stop calling the renderer directly.
+
+Instead, at the end of pixel transfer for a line, it emits a render job:
+
+```rust
+pub struct RenderScanlineJob {
+    pub ly: u8,
+    pub window_line: u8,
+    pub lcdc: u8,
+    pub scx: u8,
+    pub scy: u8,
+    pub wx: u8,
+    pub wy: u8,
+    pub bgp: u8,
+    pub obp0: u8,
+    pub obp1: u8,
+    pub vram_version: u32,
+    pub oam_version: u32,
+}
+```
+
+Core 1 keeps mirrored VRAM/OAM and renders that scanline into its own frame
+buffer.
+
+### Why this is the first PPU move
+
+It preserves:
+
+- local LY/STAT timing
+- local interrupt timing
+- local CPU-visible register reads
+
+while still moving the most obvious compute-heavy raster work out of the CPU
+hot path.
+
+### Optional later move: full PPU ownership on core 1
+
+Once the mirrored-memory and register-shadow machinery is stable, we can move
+the PPU timing shell too:
+
+- mode transitions
+- LY advancement
+- STAT generation
+- VBlank/STAT interrupt output
+
+At that point core 1 becomes the authoritative PPU owner and core 0 consumes:
+
+- `ly`
+- `stat`
+- `if_set_bits`
+- `frame_ready`
+
+But this should be a second stage, not the first one.
+
+## APU Split
+
+The APU is different from the PPU. It is more natural to push almost the whole
+engine to core 1, because the heavy work and the authoritative state are more
+tightly fused.
+
+### APU control shim on core 0
+
+Core 0 keeps a small shim responsible for:
+
+- intercepting MMIO reads/writes in CPU time order
+- tagging writes with exact T-cycle timestamps
+- synchronizing wave RAM accesses at T3
+- holding the CPU-visible readback shadow for NRxx and wave RAM
+- merging returned `NR52` / readback updates into the local IO shadow
+
+### APU engine on core 1
+
+Core 1 should own:
+
+- powered state
+- frame sequencer step
+- 2 MHz wave phase
+- channel 1/2/3/4 internals
+- wave RAM authoritative contents
+- sample accumulator
+- mixer state
+- sample output buffer
+
+That is essentially the current `ApuPeripheral` state.
+
+### Why the APU is harder than it looks
+
+The current core relies on:
+
+- `apu.tick(cycles, div_counter_after)`
+- `flush_apu_before_bus_events()`
+- T3-sensitive `read_wave_ram` / `write_wave_ram`
+
+So a remote APU must see:
+
+- exactly when writes happened
+- exactly what the timer internal counter was after each batch
+- exactly when the CPU touched wave RAM
+
+### APU command model
+
+Normal path:
+
+```rust
+pub struct ApuAdvanceBatch {
+    pub end_cycle: u64,
+    pub cycles: u16,
+    pub div_counter_after: u16,
+}
+
+pub enum ApuEvent {
+    RegWrite { at_cycle: u64, addr: u16, value: u8 },
+    WaveWrite { at_cycle: u64, offset: u8, value: u8 },
+}
+```
+
+Blocking path for rare but timing-sensitive reads:
+
+```rust
+pub enum ApuRpc {
+    ReadRegAt { at_cycle: u64, addr: u16 },
+    ReadWaveAt { at_cycle: u64, offset: u8 },
+    SaveState,
+    LoadState(...),
+    Reset,
+}
+```
+
+The common path is asynchronous. The weird timing cases are synchronous.
+
+## Shared Cross-Core Infrastructure
+
+## 1. Replace `BusEvent` with a timestamped peripheral event
+
+Today `BusEvent` only has:
+
+- `address`
+- `value`
+
+That is enough for the current same-core routing model, but not for a remote
+peripheral core.
+
+We need something like:
+
+```rust
+pub struct PeripheralEvent {
+    pub at_cycle: u64,
+    pub kind: PeripheralEventKind,
+}
+
+pub enum PeripheralEventKind {
+    IoWrite { addr: u16, value: u8 },
+    VramWrite { offset: u16, value: u8 },
+    OamWrite { offset: u16, value: u8 },
+    WaveWrite { offset: u8, value: u8 },
+    LyReset,
+    DmaStart { page: u8 },
+}
+```
+
+This is the most important prerequisite in the whole plan.
+
+## 2. Mirror VRAM and OAM to core 1
+
+The current PPU reads live `&[u8]` slices from `GameBoyMemory`.
+
+That cannot work across cores.
+
+Core 1 needs its own:
+
+- `vram_mirror: [u8; 0x2000]`
+- `oam_mirror: [u8; 0xA0]`
+
+Core 0 updates them by emitting timestamped writes for:
+
+- CPU writes to `0x8000..=0x9FFF`
+- CPU writes to `0xFE00..=0xFE9F`
+- OAM DMA byte copies
+- save/load/reset
+
+## 3. Keep CPU-visible register shadows on core 0
+
+Core 0 still needs fast local reads for:
+
+- `LY`
+- `STAT`
+- `NR52`
+- wave RAM readback
+
+So core 1 must publish a returned shadow:
+
+```rust
+pub struct PeripheralShadow {
+    pub ly: u8,
+    pub stat: u8,
+    pub nr52: u8,
+    pub if_set_bits: u8,
+}
+```
+
+Core 0 merges these into local IO/IF state at sync points.
+
+## 4. Add explicit sync points
+
+We do not want to fence every M-cycle if we can avoid it.
+
+We do need to fence at points where CPU-visible correctness depends on
+up-to-date peripheral state:
+
+- before reading `LY` / `STAT`
+- before reading APU registers or wave RAM
+- before `has_pending_interrupt()` / `take_pending_interrupt()`
+- during HALT wake checks
+- before save/load/reset
+
+Normal rendering/audio production should remain asynchronous between those points.
+
+## Two Viable Execution Models
+
+## Model A: Full peripheral-core ownership
+
+Core 1 owns the authoritative PPU and APU.
+
+Core 0 sends:
+
+- timed writes
+- cycle advance batches
+- synchronous read RPCs when needed
+
+Core 1 returns:
+
+- updated shadows
+- IF bits to OR into `IF`
+- frame and audio buffers
+
+### Pros
+
+- maximum theoretical offload
+- clean ownership once stable
+
+### Cons
+
+- highest correctness risk
+- highest synchronization complexity
+- requires more CPU/peripheral handshake on reads and interrupts
+
+## Model B: Control-plane/data-plane split
+
+Core 0 keeps PPU timing and interrupt shell.
+Core 1 renders scanlines and runs the APU synthesis engine.
+
+### Pros
+
+- lower sync cost
+- preserves local interrupt timing
+- smaller first step
+
+### Cons
+
+- lower ceiling than full remote ownership
+- leaves some PPU cost on core 0
+
+## Recommendation
+
+If the goal is "bigger than a modest gain" but still shippable, use:
+
+- **Model B for PPU first**
+- **near-Model A for APU**
+
+That is:
+
+- keep PPU control local at first, move scanline rendering out
+- move the APU engine out behind a local bus shim
+
+This gives us a real path to larger gains without forcing the hardest possible
+PPU correctness problem on day one.
+
+## Core 0 / Core 1 Responsibility Split
+
+## Core 0
+
+- `Sm83` execution
+- `GameBoyMemory`
+- cartridge / MBC / RTC
+- timer
+- serial
+- joypad
+- IF/IE ownership
+- PPU control plane initially
+- APU bus shim / readback shadow
+- timed event emission
+
+## Core 1
+
+- PPU raster plane
+- APU engine
+- mirrored VRAM/OAM
+- frame buffer ownership
+- audio sample buffer ownership
+- optional output conversion later
+
+## Migration Plan
+
+## Phase 0: Timestamp everything in single-core mode
+
+Before touching multicore:
+
+1. Replace `BusEvent` with `PeripheralEvent { at_cycle, kind }`.
+2. Emit timed events for VRAM and OAM writes, not just IO writes.
+3. Route those events back into the current same-core peripherals so behavior
+   does not change yet.
+
+This is the prerequisite for every later phase.
+
+## Phase 1: Split PPU into timing shell and renderer
+
+Refactor `ppu.rs` into:
+
+- `PpuTiming`
+- `PpuRenderer`
+- `PpuFrameBuffer`
+
+`PpuTiming` should stop directly owning all raster logic.
+
+The first target is:
+
+- core 0 computes when a line must be rendered
+- core 1 renders that line from mirrored VRAM/OAM
+
+## Phase 2: Introduce APU engine boundary
+
+Refactor `apu.rs` into:
+
+- `ApuBusShim`
+- `ApuEngine`
+- `ApuMixer`
+
+`ApuEngine` gets:
+
+- timed writes
+- `div_counter_after`
+- batch advance requests
+
+and returns:
+
+- `nr52`
+- optional readback shadow updates
+- audio sample buffers
+
+## Phase 3: Add multicore transport on Pico
+
+Use:
+
+- `embassy_rp::multicore::spawn_core1`
+- fixed static stack
+- one SPSC queue core0 -> core1 for event batches
+- one SPSC queue core1 -> core0 for shadows / IRQ effects / ready buffers
+- one tiny synchronous mailbox for blocking MMIO reads and save-state fencing
+
+## Phase 4: Move PPU raster + APU engine to core 1
+
+At this point core 1 should own:
+
+- scanline render
+- audio advance/mix
+- frame/audio buffer completion
+
+Measure again before moving any more shell logic.
+
+## Phase 5: Decide whether full PPU ownership is worth it
+
+Only after profiling the split system should we decide whether to also move:
+
+- LY/dot/mode bookkeeping
+- STAT generation
+- VBlank/STAT interrupt output
+
+If the control-plane shell is still a major wall after raster offload, then
+moving full PPU ownership becomes worth the added complexity.
+
+## Required Refactors Before Any Multicore Work
+
+1. Add timestamps to peripheral-side events.
+2. Add explicit VRAM/OAM mirror events.
+3. Separate PPU timing from scanline rendering.
+4. Separate APU bus semantics from synthesis/mixing.
+5. Add a first-class peripheral shadow struct instead of using only the IO array.
+6. Add pause/flush/resume hooks for save state and reset.
+7. Extend save-state support to cover full APU internal state.
+
+That last point matters because the current save-state path serializes CPU,
+timer, PPU, and memory, but not the full APU internal engine state.
+
+## What I Would Build First
+
+If we want to pursue this direction now, I would implement in this order:
+
+1. `PeripheralEvent` with timestamps.
+2. PPU timing/render split in single-core mode.
+3. APU shim/engine split in single-core mode.
+4. Pico core-1 transport.
+5. Move APU engine to core 1.
+6. Move PPU raster plane to core 1.
+7. Re-profile before considering full PPU ownership migration.
+
+That keeps the architecture moving toward the high-upside design without making
+the hardest cross-core correctness jump all at once.

--- a/platform/pico2w/build.rs
+++ b/platform/pico2w/build.rs
@@ -1,6 +1,9 @@
 fn main() {
     // Ensure the linker can find memory.x in the crate root.
-    println!("cargo:rustc-link-search={}", std::env::var("CARGO_MANIFEST_DIR").unwrap());
+    println!(
+        "cargo:rustc-link-search={}",
+        std::env::var("CARGO_MANIFEST_DIR").unwrap()
+    );
 
     // Re-run this build script if memory.x changes.
     println!("cargo:rerun-if-changed=memory.x");

--- a/platform/pico2w/src/core1.rs
+++ b/platform/pico2w/src/core1.rs
@@ -1,0 +1,822 @@
+#![cfg(target_arch = "arm")]
+
+extern crate alloc;
+
+use alloc::{boxed::Box, vec::Vec};
+use core::cell::UnsafeCell;
+use core::hint::spin_loop;
+use core::mem::MaybeUninit;
+use core::sync::atomic::{AtomicU32, Ordering};
+
+use embassy_rp::multicore::{spawn_core1, Stack};
+use embassy_rp::peripherals::CORE1;
+use embassy_rp::Peri;
+use rustyboy_core::cpu::peripheral::island::{
+    LocalPeripheralBackend, PeripheralAdvanceOutput, PeripheralBackend, PeripheralRegs,
+    PeripheralShadowState,
+};
+use rustyboy_core::cpu::peripheral::ppu::FRAMEBUFFER_SIZE;
+use rustyboy_core::cpu::save_state::{PpuState, TimerState};
+
+const AUDIO_BUFFER_CAPACITY: usize = 4096;
+const VRAM_SIZE: usize = 0x2000;
+const OAM_SIZE: usize = 0xA0;
+const ADVANCE_QUEUE_CAPACITY: usize = 64;
+
+static mut CORE1_STACK: Stack<16_384> = Stack::new();
+static mut CORE1_WORKER: MaybeUninit<Core1Worker> = MaybeUninit::uninit();
+
+#[repr(u8)]
+#[derive(Clone, Copy)]
+enum RequestKind {
+    Idle = 0,
+    Advance = 1,
+    ResetDiv = 2,
+    ResetLy = 3,
+    ReadApuRegister = 4,
+    WriteApuRegister = 5,
+    ReadWaveRam = 6,
+    WriteWaveRam = 7,
+    DrainSamples = 8,
+    TimerState = 9,
+    PpuState = 10,
+    LoadState = 11,
+    #[cfg(feature = "perf")]
+    TakePpuPerf = 12,
+    #[cfg(feature = "perf")]
+    TakeApuPerf = 13,
+}
+
+#[derive(Clone, Copy, Default)]
+struct SharedRegs {
+    lcdc: u8,
+    stat: u8,
+    scy: u8,
+    scx: u8,
+    lyc: u8,
+    bgp: u8,
+    obp0: u8,
+    obp1: u8,
+    wy: u8,
+    wx: u8,
+    tima: u8,
+    tma: u8,
+    tac: u8,
+    ly: u8,
+}
+
+impl SharedRegs {
+    fn from_peripheral_regs(regs: &PeripheralRegs<'_>) -> Self {
+        Self {
+            lcdc: regs.lcdc,
+            stat: regs.stat,
+            scy: regs.scy,
+            scx: regs.scx,
+            lyc: regs.lyc,
+            bgp: regs.bgp,
+            obp0: regs.obp0,
+            obp1: regs.obp1,
+            wy: regs.wy,
+            wx: regs.wx,
+            tima: regs.tima,
+            tma: regs.tma,
+            tac: regs.tac,
+            ly: regs.ly,
+        }
+    }
+}
+
+#[derive(Clone, Copy, Default)]
+struct SharedAdvanceOutput {
+    ly: u8,
+    stat: u8,
+    tima: u8,
+    div: u8,
+    nr52: u8,
+    flags: u8,
+}
+
+impl SharedAdvanceOutput {
+    const VBLANK_INTERRUPT: u8 = 1 << 0;
+    const STAT_INTERRUPT: u8 = 1 << 1;
+    const TIMER_INTERRUPT: u8 = 1 << 2;
+
+    const fn idle() -> Self {
+        Self {
+            ly: 0,
+            stat: 0,
+            tima: 0,
+            div: 0,
+            nr52: 0,
+            flags: 0,
+        }
+    }
+
+    fn from_output(output: PeripheralAdvanceOutput) -> Self {
+        let mut flags = 0;
+        if output.vblank_interrupt {
+            flags |= Self::VBLANK_INTERRUPT;
+        }
+        if output.stat_interrupt {
+            flags |= Self::STAT_INTERRUPT;
+        }
+        if output.timer_interrupt {
+            flags |= Self::TIMER_INTERRUPT;
+        }
+        Self {
+            ly: output.ly,
+            stat: output.stat,
+            tima: output.tima,
+            div: output.div,
+            nr52: output.nr52,
+            flags,
+        }
+    }
+
+    fn into_output(self) -> PeripheralAdvanceOutput {
+        PeripheralAdvanceOutput {
+            ly: self.ly,
+            stat: self.stat,
+            vblank_interrupt: self.flags & Self::VBLANK_INTERRUPT != 0,
+            stat_interrupt: self.flags & Self::STAT_INTERRUPT != 0,
+            tima: self.tima,
+            div: self.div,
+            timer_interrupt: self.flags & Self::TIMER_INTERRUPT != 0,
+            nr52: self.nr52,
+        }
+    }
+}
+
+#[derive(Clone, Copy, Default)]
+struct SharedShadowState {
+    ly: u8,
+    stat: u8,
+    tima: u8,
+    div: u8,
+    nr52: u8,
+    vblank_count: u32,
+    stat_interrupt_count: u32,
+    timer_interrupt_count: u32,
+}
+
+impl SharedShadowState {
+    const fn idle() -> Self {
+        Self {
+            ly: 0,
+            stat: 0,
+            tima: 0,
+            div: 0,
+            nr52: 0,
+            vblank_count: 0,
+            stat_interrupt_count: 0,
+            timer_interrupt_count: 0,
+        }
+    }
+
+    fn into_shadow_state(self, completed_seq: u32) -> PeripheralShadowState {
+        PeripheralShadowState {
+            completed_seq,
+            ly: self.ly,
+            stat: self.stat,
+            tima: self.tima,
+            div: self.div,
+            nr52: self.nr52,
+            vblank_count: self.vblank_count,
+            stat_interrupt_count: self.stat_interrupt_count,
+            timer_interrupt_count: self.timer_interrupt_count,
+        }
+    }
+}
+
+#[derive(Clone, Copy)]
+struct AdvanceRequest {
+    ppu_cycles: u16,
+    timer_cycles: u16,
+    apu_cycles: u16,
+    regs: SharedRegs,
+}
+
+impl AdvanceRequest {
+    const fn idle() -> Self {
+        Self {
+            ppu_cycles: 0,
+            timer_cycles: 0,
+            apu_cycles: 0,
+            regs: SharedRegs {
+                lcdc: 0,
+                stat: 0,
+                scy: 0,
+                scx: 0,
+                lyc: 0,
+                bgp: 0,
+                obp0: 0,
+                obp1: 0,
+                wy: 0,
+                wx: 0,
+                tima: 0,
+                tma: 0,
+                tac: 0,
+                ly: 0,
+            },
+        }
+    }
+}
+
+#[derive(Clone, Copy)]
+struct MailboxRequest {
+    kind: RequestKind,
+    addr: u16,
+    value: u8,
+    ppu_cycles: u16,
+    timer_cycles: u16,
+    apu_cycles: u16,
+    regs: SharedRegs,
+    timer_state: TimerState,
+    ppu_state: PpuState,
+}
+
+impl MailboxRequest {
+    const fn idle() -> Self {
+        Self {
+            kind: RequestKind::Idle,
+            addr: 0,
+            value: 0,
+            ppu_cycles: 0,
+            timer_cycles: 0,
+            apu_cycles: 0,
+            regs: SharedRegs {
+                lcdc: 0,
+                stat: 0,
+                scy: 0,
+                scx: 0,
+                lyc: 0,
+                bgp: 0,
+                obp0: 0,
+                obp1: 0,
+                wy: 0,
+                wx: 0,
+                tima: 0,
+                tma: 0,
+                tac: 0,
+                ly: 0,
+            },
+            timer_state: TimerState {
+                internal_counter: 0,
+            },
+            ppu_state: PpuState {
+                dot: 0,
+                ly: 0,
+                mode: rustyboy_core::cpu::peripheral::ppu::PpuMode::OamScan,
+                window_line_counter: 0,
+            },
+        }
+    }
+}
+
+#[derive(Clone, Copy)]
+struct MailboxResponse {
+    step: SharedAdvanceOutput,
+    value: u8,
+    audio_len: usize,
+    timer_state: TimerState,
+    ppu_state: PpuState,
+    #[cfg(feature = "perf")]
+    ppu_perf: rustyboy_core::cpu::peripheral::ppu::PpuPerfProfile,
+    #[cfg(feature = "perf")]
+    apu_perf: rustyboy_core::cpu::peripheral::apu::ApuPerfProfile,
+}
+
+impl MailboxResponse {
+    const fn idle() -> Self {
+        Self {
+            step: SharedAdvanceOutput::idle(),
+            value: 0,
+            audio_len: 0,
+            timer_state: TimerState {
+                internal_counter: 0,
+            },
+            ppu_state: PpuState {
+                dot: 0,
+                ly: 0,
+                mode: rustyboy_core::cpu::peripheral::ppu::PpuMode::OamScan,
+                window_line_counter: 0,
+            },
+            #[cfg(feature = "perf")]
+            ppu_perf: rustyboy_core::cpu::peripheral::ppu::PpuPerfProfile {
+                render_bg: 0,
+                render_window: 0,
+                render_sprites: 0,
+                build_stat: 0,
+            },
+            #[cfg(feature = "perf")]
+            apu_perf: rustyboy_core::cpu::peripheral::apu::ApuPerfProfile {
+                frame_seq: 0,
+                pulse: 0,
+                wave: 0,
+                noise: 0,
+                mix: 0,
+            },
+        }
+    }
+}
+
+struct Mailbox {
+    request_seq: AtomicU32,
+    response_seq: AtomicU32,
+    request: UnsafeCell<MailboxRequest>,
+    response: UnsafeCell<MailboxResponse>,
+    sync_vram: UnsafeCell<[u8; VRAM_SIZE]>,
+    sync_oam: UnsafeCell<[u8; OAM_SIZE]>,
+    frame: UnsafeCell<[u8; FRAMEBUFFER_SIZE]>,
+    audio: UnsafeCell<[f32; AUDIO_BUFFER_CAPACITY]>,
+}
+
+unsafe impl Sync for Mailbox {}
+
+impl Mailbox {
+    const fn new() -> Self {
+        Self {
+            request_seq: AtomicU32::new(0),
+            response_seq: AtomicU32::new(0),
+            request: UnsafeCell::new(MailboxRequest::idle()),
+            response: UnsafeCell::new(MailboxResponse::idle()),
+            sync_vram: UnsafeCell::new([0; VRAM_SIZE]),
+            sync_oam: UnsafeCell::new([0; OAM_SIZE]),
+            frame: UnsafeCell::new([0; FRAMEBUFFER_SIZE]),
+            audio: UnsafeCell::new([0.0; AUDIO_BUFFER_CAPACITY]),
+        }
+    }
+}
+
+static MAILBOX: Mailbox = Mailbox::new();
+
+struct AdvanceQueue {
+    submit_seq: AtomicU32,
+    complete_seq: AtomicU32,
+    requests: [UnsafeCell<AdvanceRequest>; ADVANCE_QUEUE_CAPACITY],
+    outputs: [UnsafeCell<SharedShadowState>; ADVANCE_QUEUE_CAPACITY],
+}
+
+unsafe impl Sync for AdvanceQueue {}
+
+impl AdvanceQueue {
+    const fn new() -> Self {
+        Self {
+            submit_seq: AtomicU32::new(0),
+            complete_seq: AtomicU32::new(0),
+            requests: [const { UnsafeCell::new(AdvanceRequest::idle()) }; ADVANCE_QUEUE_CAPACITY],
+            outputs: [const { UnsafeCell::new(SharedShadowState::idle()) }; ADVANCE_QUEUE_CAPACITY],
+        }
+    }
+}
+
+static ADVANCE_QUEUE: AdvanceQueue = AdvanceQueue::new();
+
+struct Core1Worker {
+    backend: LocalPeripheralBackend,
+    vblank_count: u32,
+    stat_interrupt_count: u32,
+    timer_interrupt_count: u32,
+}
+
+impl Core1Worker {
+    unsafe fn init_in_place(dst: *mut Self) {
+        LocalPeripheralBackend::init_in_place(core::ptr::addr_of_mut!((*dst).backend));
+        core::ptr::addr_of_mut!((*dst).vblank_count).write(0);
+        core::ptr::addr_of_mut!((*dst).stat_interrupt_count).write(0);
+        core::ptr::addr_of_mut!((*dst).timer_interrupt_count).write(0);
+    }
+
+    fn advance_backend(&mut self, request: AdvanceRequest) -> PeripheralAdvanceOutput {
+        let output = self.backend.advance(
+            request.ppu_cycles,
+            request.timer_cycles,
+            request.apu_cycles,
+            PeripheralRegs {
+                lcdc: request.regs.lcdc,
+                stat: request.regs.stat,
+                scy: request.regs.scy,
+                scx: request.regs.scx,
+                lyc: request.regs.lyc,
+                bgp: request.regs.bgp,
+                obp0: request.regs.obp0,
+                obp1: request.regs.obp1,
+                wy: request.regs.wy,
+                wx: request.regs.wx,
+                tima: request.regs.tima,
+                tma: request.regs.tma,
+                tac: request.regs.tac,
+                ly: request.regs.ly,
+                vram: unsafe { &*MAILBOX.sync_vram.get() },
+                oam: unsafe { &*MAILBOX.sync_oam.get() },
+            },
+        );
+        if output.vblank_interrupt {
+            self.backend
+                .snapshot_framebuffer_into(unsafe { &mut *MAILBOX.frame.get() });
+        }
+        output
+    }
+
+    fn handle_advance(&mut self, request: AdvanceRequest) -> SharedAdvanceOutput {
+        SharedAdvanceOutput::from_output(self.advance_backend(request))
+    }
+
+    fn publish_advance_shadow(&mut self, request: AdvanceRequest) -> SharedShadowState {
+        let output = self.advance_backend(request);
+        if output.vblank_interrupt {
+            self.vblank_count = self.vblank_count.wrapping_add(1);
+        }
+        if output.stat_interrupt {
+            self.stat_interrupt_count = self.stat_interrupt_count.wrapping_add(1);
+        }
+        if output.timer_interrupt {
+            self.timer_interrupt_count = self.timer_interrupt_count.wrapping_add(1);
+        }
+        SharedShadowState {
+            ly: output.ly,
+            stat: output.stat,
+            tima: output.tima,
+            div: output.div,
+            nr52: output.nr52,
+            vblank_count: self.vblank_count,
+            stat_interrupt_count: self.stat_interrupt_count,
+            timer_interrupt_count: self.timer_interrupt_count,
+        }
+    }
+
+    fn handle(&mut self, request: MailboxRequest) -> MailboxResponse {
+        let mut response = MailboxResponse::idle();
+        match request.kind {
+            RequestKind::Idle => {}
+            RequestKind::Advance => {
+                response.step = self.handle_advance(AdvanceRequest {
+                    ppu_cycles: request.ppu_cycles,
+                    timer_cycles: request.timer_cycles,
+                    apu_cycles: request.apu_cycles,
+                    regs: request.regs,
+                });
+            }
+            RequestKind::ResetDiv => self.backend.reset_div(),
+            RequestKind::ResetLy => self.backend.reset_ly(),
+            RequestKind::ReadApuRegister => {
+                response.value = self.backend.read_apu_register(request.addr);
+            }
+            RequestKind::WriteApuRegister => {
+                self.backend.write_apu_register(request.addr, request.value);
+                response.value = self.backend.read_apu_register(request.addr);
+            }
+            RequestKind::ReadWaveRam => {
+                response.value = self.backend.read_wave_ram(request.value);
+            }
+            RequestKind::WriteWaveRam => {
+                self.backend
+                    .write_wave_ram(request.value, request.addr as u8);
+                response.value = self.backend.read_wave_ram(request.value);
+            }
+            RequestKind::DrainSamples => {
+                let samples = self.backend.drain_samples();
+                let len = samples.len().min(AUDIO_BUFFER_CAPACITY);
+                (unsafe { &mut *MAILBOX.audio.get() })[..len].copy_from_slice(&samples[..len]);
+                response.audio_len = len;
+            }
+            RequestKind::TimerState => {
+                response.timer_state = self.backend.timer_state();
+            }
+            RequestKind::PpuState => {
+                response.ppu_state = self.backend.ppu_state();
+            }
+            RequestKind::LoadState => {
+                self.backend.load_state(
+                    request.timer_state,
+                    request.ppu_state,
+                    unsafe { &*MAILBOX.sync_vram.get() },
+                    unsafe { &*MAILBOX.sync_oam.get() },
+                );
+            }
+            #[cfg(feature = "perf")]
+            RequestKind::TakePpuPerf => {
+                response.ppu_perf = self.backend.take_ppu_perf_profile();
+            }
+            #[cfg(feature = "perf")]
+            RequestKind::TakeApuPerf => {
+                response.apu_perf = self.backend.take_apu_perf_profile();
+            }
+        }
+        response
+    }
+}
+
+pub struct Core1PeripheralBackend {
+    submitted_advance_seq: u32,
+}
+
+impl Core1PeripheralBackend {
+    fn new() -> Self {
+        Self {
+            submitted_advance_seq: 0,
+        }
+    }
+
+    fn transact_shared(request: MailboxRequest) -> MailboxResponse {
+        let ticket = MAILBOX.request_seq.load(Ordering::Relaxed).wrapping_add(1);
+        unsafe {
+            *MAILBOX.request.get() = request;
+        }
+        MAILBOX.request_seq.store(ticket, Ordering::Release);
+        while MAILBOX.response_seq.load(Ordering::Acquire) != ticket {
+            spin_loop();
+        }
+        unsafe { *MAILBOX.response.get() }
+    }
+
+    fn transact(&mut self, request: MailboxRequest) -> MailboxResponse {
+        Self::transact_shared(request)
+    }
+
+    fn copy_sync_memory(vram: &[u8], oam: &[u8]) {
+        unsafe {
+            (&mut *MAILBOX.sync_vram.get()).copy_from_slice(vram);
+            (&mut *MAILBOX.sync_oam.get()).copy_from_slice(oam);
+        }
+    }
+
+    fn try_queue_advance_request(&mut self, request: AdvanceRequest) -> bool {
+        let next_seq = self.submitted_advance_seq.wrapping_add(1);
+        let completed = ADVANCE_QUEUE.complete_seq.load(Ordering::Acquire);
+        if next_seq.wrapping_sub(completed) > ADVANCE_QUEUE_CAPACITY as u32 {
+            return false;
+        }
+
+        let index = (next_seq.wrapping_sub(1) as usize) % ADVANCE_QUEUE_CAPACITY;
+        unsafe {
+            *ADVANCE_QUEUE.requests[index].get() = request;
+        }
+        ADVANCE_QUEUE.submit_seq.store(next_seq, Ordering::Release);
+        self.submitted_advance_seq = next_seq;
+        true
+    }
+
+    fn try_take_queued_shadow_state(&mut self, min_completed_seq: u32) -> Option<PeripheralShadowState> {
+        loop {
+            let completed = ADVANCE_QUEUE.complete_seq.load(Ordering::Acquire);
+            if completed < min_completed_seq {
+                return None;
+            }
+
+            let index = (completed.wrapping_sub(1) as usize) % ADVANCE_QUEUE_CAPACITY;
+            let shadow = unsafe { *ADVANCE_QUEUE.outputs[index].get() };
+            let confirm = ADVANCE_QUEUE.complete_seq.load(Ordering::Acquire);
+            if confirm == completed {
+                return Some(shadow.into_shadow_state(completed));
+            }
+        }
+    }
+
+    fn wait_queued_shadow_state(&mut self, min_completed_seq: u32) -> PeripheralShadowState {
+        loop {
+            if let Some(shadow) = self.try_take_queued_shadow_state(min_completed_seq) {
+                return shadow;
+            }
+            spin_loop();
+        }
+    }
+}
+
+impl PeripheralBackend for Core1PeripheralBackend {
+    fn advance(
+        &mut self,
+        ppu_cycles: u16,
+        timer_cycles: u16,
+        apu_cycles: u16,
+        regs: PeripheralRegs<'_>,
+    ) -> PeripheralAdvanceOutput {
+        let response = self.transact(MailboxRequest {
+            kind: RequestKind::Advance,
+            addr: 0,
+            value: 0,
+            ppu_cycles,
+            timer_cycles,
+            apu_cycles,
+            regs: SharedRegs::from_peripheral_regs(&regs),
+            timer_state: TimerState {
+                internal_counter: 0,
+            },
+            ppu_state: PpuState {
+                dot: 0,
+                ly: 0,
+                mode: rustyboy_core::cpu::peripheral::ppu::PpuMode::OamScan,
+                window_line_counter: 0,
+            },
+        });
+        response.step.into_output()
+    }
+
+    fn supports_queued_advance(&self) -> bool {
+        true
+    }
+
+    fn try_queue_advance(
+        &mut self,
+        ppu_cycles: u16,
+        timer_cycles: u16,
+        apu_cycles: u16,
+        regs: PeripheralRegs<'_>,
+    ) -> bool {
+        self.try_queue_advance_request(AdvanceRequest {
+            ppu_cycles,
+            timer_cycles,
+            apu_cycles,
+            regs: SharedRegs::from_peripheral_regs(&regs),
+        })
+    }
+
+    fn try_take_queued_shadow_state(
+        &mut self,
+        min_completed_seq: u32,
+    ) -> Option<PeripheralShadowState> {
+        Core1PeripheralBackend::try_take_queued_shadow_state(self, min_completed_seq)
+    }
+
+    fn wait_queued_shadow_state(&mut self, min_completed_seq: u32) -> PeripheralShadowState {
+        Core1PeripheralBackend::wait_queued_shadow_state(self, min_completed_seq)
+    }
+
+    fn reset_div(&mut self) {
+        let _ = self.transact(MailboxRequest {
+            kind: RequestKind::ResetDiv,
+            ..MailboxRequest::idle()
+        });
+    }
+
+    fn reset_ly(&mut self) {
+        let _ = self.transact(MailboxRequest {
+            kind: RequestKind::ResetLy,
+            ..MailboxRequest::idle()
+        });
+    }
+
+    fn read_apu_register(&mut self, address: u16) -> u8 {
+        self.transact(MailboxRequest {
+            kind: RequestKind::ReadApuRegister,
+            addr: address,
+            ..MailboxRequest::idle()
+        })
+        .value
+    }
+
+    fn write_apu_register(&mut self, address: u16, value: u8) {
+        let _ = self.transact(MailboxRequest {
+            kind: RequestKind::WriteApuRegister,
+            addr: address,
+            value,
+            ..MailboxRequest::idle()
+        });
+    }
+
+    fn read_wave_ram(&mut self, offset: u8) -> u8 {
+        self.transact(MailboxRequest {
+            kind: RequestKind::ReadWaveRam,
+            value: offset,
+            ..MailboxRequest::idle()
+        })
+        .value
+    }
+
+    fn write_wave_ram(&mut self, offset: u8, value: u8) {
+        let _ = self.transact(MailboxRequest {
+            kind: RequestKind::WriteWaveRam,
+            addr: value as u16,
+            value: offset,
+            ..MailboxRequest::idle()
+        });
+    }
+
+    fn on_vram_write(&mut self, offset: u16, value: u8) {
+        unsafe {
+            (*MAILBOX.sync_vram.get())[offset as usize] = value;
+        }
+    }
+
+    fn on_oam_write(&mut self, offset: u16, value: u8) {
+        unsafe {
+            (*MAILBOX.sync_oam.get())[offset as usize] = value;
+        }
+    }
+
+    fn sync_memory(&mut self, vram: &[u8], oam: &[u8]) {
+        Self::copy_sync_memory(vram, oam);
+    }
+
+    fn snapshot_framebuffer_into(&mut self, dst: &mut [u8; FRAMEBUFFER_SIZE]) {
+        dst.copy_from_slice(unsafe { &*MAILBOX.frame.get() });
+    }
+
+    fn drain_samples(&mut self) -> Vec<f32> {
+        let response = self.transact(MailboxRequest {
+            kind: RequestKind::DrainSamples,
+            ..MailboxRequest::idle()
+        });
+        unsafe { (&*MAILBOX.audio.get())[..response.audio_len].to_vec() }
+    }
+
+    fn clear_samples(&mut self) {
+        let _ = self.transact(MailboxRequest {
+            kind: RequestKind::DrainSamples,
+            ..MailboxRequest::idle()
+        });
+    }
+
+    fn timer_state(&self) -> TimerState {
+        Self::transact_shared(MailboxRequest {
+            kind: RequestKind::TimerState,
+            ..MailboxRequest::idle()
+        })
+        .timer_state
+    }
+
+    fn ppu_state(&self) -> PpuState {
+        Self::transact_shared(MailboxRequest {
+            kind: RequestKind::PpuState,
+            ..MailboxRequest::idle()
+        })
+        .ppu_state
+    }
+
+    fn load_state(&mut self, timer: TimerState, ppu: PpuState, vram: &[u8], oam: &[u8]) {
+        Self::copy_sync_memory(vram, oam);
+        let _ = self.transact(MailboxRequest {
+            kind: RequestKind::LoadState,
+            timer_state: timer,
+            ppu_state: ppu,
+            ..MailboxRequest::idle()
+        });
+    }
+
+    #[cfg(feature = "perf")]
+    fn take_ppu_perf_profile(&mut self) -> rustyboy_core::cpu::peripheral::ppu::PpuPerfProfile {
+        self.transact(MailboxRequest {
+            kind: RequestKind::TakePpuPerf,
+            ..MailboxRequest::idle()
+        })
+        .ppu_perf
+    }
+
+    #[cfg(feature = "perf")]
+    fn take_apu_perf_profile(&mut self) -> rustyboy_core::cpu::peripheral::apu::ApuPerfProfile {
+        self.transact(MailboxRequest {
+            kind: RequestKind::TakeApuPerf,
+            ..MailboxRequest::idle()
+        })
+        .apu_perf
+    }
+}
+
+fn core1_main() -> ! {
+    let worker = core::ptr::addr_of_mut!(CORE1_WORKER).cast::<Core1Worker>();
+    unsafe {
+        Core1Worker::init_in_place(worker);
+    }
+    let mut last_ticket = 0u32;
+    let mut completed_advance_seq = 0u32;
+    loop {
+        let submitted_advance_seq = ADVANCE_QUEUE.submit_seq.load(Ordering::Acquire);
+        if completed_advance_seq != submitted_advance_seq {
+            let next_seq = completed_advance_seq.wrapping_add(1);
+            let index = (next_seq.wrapping_sub(1) as usize) % ADVANCE_QUEUE_CAPACITY;
+            let request = unsafe { *ADVANCE_QUEUE.requests[index].get() };
+            let shadow = unsafe { (&mut *worker).publish_advance_shadow(request) };
+            unsafe {
+                *ADVANCE_QUEUE.outputs[index].get() = shadow;
+            }
+            completed_advance_seq = next_seq;
+            ADVANCE_QUEUE
+                .complete_seq
+                .store(completed_advance_seq, Ordering::Release);
+            continue;
+        }
+
+        let ticket = MAILBOX.request_seq.load(Ordering::Acquire);
+        if ticket == last_ticket {
+            spin_loop();
+            continue;
+        }
+        let request = unsafe { *MAILBOX.request.get() };
+        let response = unsafe { (&mut *worker).handle(request) };
+        unsafe {
+            *MAILBOX.response.get() = response;
+        }
+        MAILBOX.response_seq.store(ticket, Ordering::Release);
+        last_ticket = ticket;
+    }
+}
+
+pub fn spawn_peripheral_core(core1: Peri<'static, CORE1>) -> Box<dyn PeripheralBackend> {
+    spawn_core1(
+        core1,
+        unsafe { &mut *core::ptr::addr_of_mut!(CORE1_STACK) },
+        move || core1_main(),
+    );
+
+    Box::new(Core1PeripheralBackend::new())
+}

--- a/platform/pico2w/src/display/fb.rs
+++ b/platform/pico2w/src/display/fb.rs
@@ -40,21 +40,25 @@ impl FbDisplay {
         let mut encoder = png::Encoder::new(w, self.width, self.height);
         encoder.set_color(png::ColorType::Rgb);
         encoder.set_depth(png::BitDepth::Eight);
-        let mut writer = encoder.write_header().map_err(|e| {
-            std::io::Error::new(std::io::ErrorKind::Other, e.to_string())
-        })?;
+        let mut writer = encoder
+            .write_header()
+            .map_err(|e| std::io::Error::new(std::io::ErrorKind::Other, e.to_string()))?;
 
-        let data: Vec<u8> = self.pixels.iter().flat_map(|p| {
-            // Expand Rgb565 → 8-bit RGB
-            let r = (p.r() << 3) | (p.r() >> 2);
-            let g = (p.g() << 2) | (p.g() >> 4);
-            let b = (p.b() << 3) | (p.b() >> 2);
-            [r, g, b]
-        }).collect();
+        let data: Vec<u8> = self
+            .pixels
+            .iter()
+            .flat_map(|p| {
+                // Expand Rgb565 → 8-bit RGB
+                let r = (p.r() << 3) | (p.r() >> 2);
+                let g = (p.g() << 2) | (p.g() >> 4);
+                let b = (p.b() << 3) | (p.b() >> 2);
+                [r, g, b]
+            })
+            .collect();
 
-        writer.write_image_data(&data).map_err(|e| {
-            std::io::Error::new(std::io::ErrorKind::Other, e.to_string())
-        })
+        writer
+            .write_image_data(&data)
+            .map_err(|e| std::io::Error::new(std::io::ErrorKind::Other, e.to_string()))
     }
 }
 

--- a/platform/pico2w/src/display/hw.rs
+++ b/platform/pico2w/src/display/hw.rs
@@ -8,8 +8,8 @@ use defmt::{info, warn};
 use embassy_rp::gpio::{Level, Output};
 use embassy_rp::peripherals::{DMA_CH1, PIN_10, PIN_11, PIN_12, PIN_13, PIN_8, PIN_9, SPI1};
 use embassy_rp::spi::{Async, Blocking, Config as SpiConfig, Spi};
-use embassy_rp::{dma, interrupt};
 use embassy_rp::Peri;
+use embassy_rp::{dma, interrupt};
 
 use display_interface_spi::SPIInterface;
 use embedded_hal_bus::spi::ExclusiveDevice;
@@ -130,9 +130,9 @@ impl<'d> GameDisplay<'d> {
         spi1: Peri<'d, SPI1>,
         dma: Peri<'d, DMA_CH1>,
         irqs: impl interrupt::typelevel::Binding<
-            interrupt::typelevel::DMA_IRQ_0,
-            dma::InterruptHandler<DMA_CH1>,
-        > + 'd,
+                interrupt::typelevel::DMA_IRQ_0,
+                dma::InterruptHandler<DMA_CH1>,
+            > + 'd,
     ) -> Self {
         // The DMA_IRQ_0 ISR now calls BOTH InterruptHandler<DMA_CH0> and
         // InterruptHandler<DMA_CH1> unconditionally (combined bind_interrupts!).
@@ -143,7 +143,9 @@ impl<'d> GameDisplay<'d> {
         if ahb_err {
             warn!("DMA CH1 ahb_error set before init — aborting to clear");
             // Write bit 1 to CHAN_ABORT to trigger a CH1 abort.
-            rp_pac::DMA.chan_abort().write_value(rp_pac::dma::regs::ChanAbort(1u32 << 1));
+            rp_pac::DMA
+                .chan_abort()
+                .write_value(rp_pac::dma::regs::ChanAbort(1u32 << 1));
             while rp_pac::DMA.chan_abort().read().chan_abort() & (1u16 << 1) != 0 {}
         }
         // Clear any pending CH1 interrupt flag in INTS0 (W1C: write 1 to clear).
@@ -159,7 +161,13 @@ impl<'d> GameDisplay<'d> {
         let bl = Output::new(bl_pin, Level::High);
 
         info!("display: async SPI re-initialised for game loop");
-        Self { spi, cs, dc, _rst: rst, _bl: bl }
+        Self {
+            spi,
+            cs,
+            dc,
+            _rst: rst,
+            _bl: bl,
+        }
     }
 
     /// Paint the static letterbox bars (top C3, bottom black) once before the
@@ -171,13 +179,16 @@ impl<'d> GameDisplay<'d> {
         // Top bar: rows 0..51, colour C3
         self.set_window(0, 0, DISPLAY_X_END, TOP_BAR_Y_END).await;
         self.write_command(0x2C, &[]).await;
-        self.fill_rect_raw(LETTERBOX_ROWS * DISPLAY_ROW_PIXELS, &C3_BE).await;
+        self.fill_rect_raw(LETTERBOX_ROWS * DISPLAY_ROW_PIXELS, &C3_BE)
+            .await;
         info!("display: top bar done");
 
         // Bottom bar: rows 268..319, colour black
-        self.set_window(0, BOTTOM_BAR_Y_START, DISPLAY_X_END, DISPLAY_Y_END).await;
+        self.set_window(0, BOTTOM_BAR_Y_START, DISPLAY_X_END, DISPLAY_Y_END)
+            .await;
         self.write_command(0x2C, &[]).await;
-        self.fill_rect_raw(LETTERBOX_ROWS * DISPLAY_ROW_PIXELS, &BLACK_BE).await;
+        self.fill_rect_raw(LETTERBOX_ROWS * DISPLAY_ROW_PIXELS, &BLACK_BE)
+            .await;
         info!("display: letterbox bars done");
     }
 
@@ -187,7 +198,8 @@ impl<'d> GameDisplay<'d> {
     /// [`super::scale_to_rgb565`]. Returns a future; `.await` it after doing
     /// other work to overlap the ~13 ms transfer with emulation.
     pub async fn send_frame_raw(&mut self, buf: &[u16; 51840]) {
-        self.set_window(0, GAME_Y_START, DISPLAY_X_END, GAME_Y_END).await;
+        self.set_window(0, GAME_Y_START, DISPLAY_X_END, GAME_Y_END)
+            .await;
         self.write_command(0x2C, &[]).await;
 
         self.dc.set_high();
@@ -223,7 +235,7 @@ impl<'d> GameDisplay<'d> {
         let mut row = [0u8; ROW_BYTES];
         let mut i = 0;
         while i < ROW_BYTES {
-            row[i]     = pixel_be[0];
+            row[i] = pixel_be[0];
             row[i + 1] = pixel_be[1];
             i += 2;
         }

--- a/platform/pico2w/src/display/mod.rs
+++ b/platform/pico2w/src/display/mod.rs
@@ -9,10 +9,10 @@
 //! Rgb565>` so the rendering logic can be exercised on the host with a
 //! framebuffer stub — see [`fb`].
 
-#[cfg(target_arch = "arm")]
-pub mod hw;
 #[cfg(any(not(target_arch = "arm"), feature = "std"))]
 pub mod fb;
+#[cfg(target_arch = "arm")]
+pub mod hw;
 
 use embedded_graphics::draw_target::DrawTarget;
 use embedded_graphics::geometry::{Dimensions, Point, Size};
@@ -127,17 +127,18 @@ impl<D: DrawTarget<Color = Rgb565> + Dimensions> Display<D> {
         );
         // buf stores big-endian u16s; swap back to native-endian before handing
         // to mipidsi, which handles its own byte ordering.
-        let _ = self.inner.fill_contiguous(&rect, buf.iter().map(|&v| Rgb565::from(RawU16::new(v.swap_bytes()))));
+        let _ = self.inner.fill_contiguous(
+            &rect,
+            buf.iter()
+                .map(|&v| Rgb565::from(RawU16::new(v.swap_bytes()))),
+        );
     }
 
     fn fill_bar(&mut self, y: i32, height: i32, color: Rgb565) {
         if height <= 0 {
             return;
         }
-        let rect = Rectangle::new(
-            Point::new(0, y),
-            Size::new(SCREEN_W as u32, height as u32),
-        );
+        let rect = Rectangle::new(Point::new(0, y), Size::new(SCREEN_W as u32, height as u32));
         let _ = self.inner.fill_contiguous(&rect, core::iter::repeat(color));
     }
 
@@ -235,7 +236,11 @@ impl<D: DrawTarget<Color = Rgb565> + Dimensions> Display<D> {
                     let gx = slot_x / 2;
                     let gy = ry / 2;
                     let row = font::GLYPHS[SEQUENCE[slot]][gy as usize];
-                    if (row >> (7 - gx)) & 1 == 1 { fg } else { bg }
+                    if (row >> (7 - gx)) & 1 == 1 {
+                        fg
+                    } else {
+                        bg
+                    }
                 } else {
                     bg
                 }
@@ -264,7 +269,11 @@ impl<D: DrawTarget<Color = Rgb565> + Dimensions> Display<D> {
         let colors = (y0..y1).flat_map(move |py2| {
             let row = bitmap[(py2 - py) as usize];
             (x0..x1).map(move |px2| {
-                if (row >> (7 - (px2 - px))) & 1 == 1 { fg } else { bg }
+                if (row >> (7 - (px2 - px))) & 1 == 1 {
+                    fg
+                } else {
+                    bg
+                }
             })
         });
         let _ = self.inner.fill_contiguous(&rect, colors);
@@ -331,8 +340,8 @@ mod font {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
     use super::fb::FbDisplay;
+    use super::*;
     use embedded_graphics::prelude::IntoStorage;
 
     fn make_display() -> Display<FbDisplay> {
@@ -360,7 +369,11 @@ mod tests {
         assert_eq!(fb_ref[0], C3, "top bar pixel should be C3");
         // Bottom bar: first pixel after scaled region
         let bot_start = ((Y_OFFSET + SCALED_H) * SCREEN_W) as usize;
-        assert_eq!(fb_ref[bot_start], Rgb565::BLACK, "bottom bar pixel should be black");
+        assert_eq!(
+            fb_ref[bot_start],
+            Rgb565::BLACK,
+            "bottom bar pixel should be black"
+        );
         // A pixel inside the scaled region should be C0
         let mid = (Y_OFFSET * SCREEN_W) as usize;
         assert_eq!(fb_ref[mid], C0, "game region pixel should be C0");
@@ -380,7 +393,10 @@ mod tests {
             pixels.iter().map(|p| p.into_storage()).collect();
         // All four DMG colours should appear
         for c in [C0, C1, C2, C3] {
-            assert!(colors_present.contains(&c.into_storage()), "missing palette entry");
+            assert!(
+                colors_present.contains(&c.into_storage()),
+                "missing palette entry"
+            );
         }
     }
 
@@ -390,11 +406,7 @@ mod tests {
         disp.splash_step(0);
         // Every pixel should be C1 (background) or C3 (logo above screen)
         for &px in disp.inner.as_ref() {
-            assert!(
-                px == C1 || px == C3,
-                "unexpected pixel {:?} on frame 0",
-                px
-            );
+            assert!(px == C1 || px == C3, "unexpected pixel {:?} on frame 0", px);
         }
     }
 
@@ -416,7 +428,11 @@ mod tests {
         let fb_ref = disp.inner.as_ref();
         assert_eq!(fb_ref[0], C3, "top bar should be C3");
         let bot_start = ((Y_OFFSET + SCALED_H) * SCREEN_W) as usize;
-        assert_eq!(fb_ref[bot_start], Rgb565::BLACK, "bottom bar should be black");
+        assert_eq!(
+            fb_ref[bot_start],
+            Rgb565::BLACK,
+            "bottom bar should be black"
+        );
     }
 
     #[test]

--- a/platform/pico2w/src/flash_rom.rs
+++ b/platform/pico2w/src/flash_rom.rs
@@ -37,10 +37,7 @@ pub enum FlashRomStageError<E: Debug> {
     Reader(E),
     Flash(FlashError),
     InvalidRomSizeCode(u8),
-    TooLarge {
-        bytes: usize,
-        capacity: usize,
-    },
+    TooLarge { bytes: usize, capacity: usize },
 }
 
 pub struct FlashRomReader<'d> {
@@ -57,7 +54,11 @@ impl<'d> FlashRomReader<'d> {
 impl RomReader for FlashRomReader<'_> {
     type Error = FlashRomReadError;
 
-    fn read_bank(&mut self, bank: usize, buf: &mut [u8; ROM_BANK_BYTES]) -> Result<(), Self::Error> {
+    fn read_bank(
+        &mut self,
+        bank: usize,
+        buf: &mut [u8; ROM_BANK_BYTES],
+    ) -> Result<(), Self::Error> {
         if bank >= self.info.bank_count {
             buf.fill(0xFF);
             return Err(FlashRomReadError::OutOfBounds);

--- a/platform/pico2w/src/input.rs
+++ b/platform/pico2w/src/input.rs
@@ -9,7 +9,7 @@
 #[cfg(target_arch = "arm")]
 use embassy_rp::gpio::{Input, Pull};
 #[cfg(target_arch = "arm")]
-use embassy_rp::peripherals::{PIN_0, PIN_1, PIN_2, PIN_3, PIN_21, PIN_22, PIN_26, PIN_27};
+use embassy_rp::peripherals::{PIN_0, PIN_1, PIN_2, PIN_21, PIN_22, PIN_26, PIN_27, PIN_3};
 #[cfg(target_arch = "arm")]
 use embassy_rp::Peri;
 #[cfg(target_arch = "arm")]
@@ -44,17 +44,21 @@ impl ButtonState {
     /// `other` (current), yielding `(Button, pressed)` pairs.
     pub fn diff(self, other: ButtonState) -> impl Iterator<Item = (Button, bool)> {
         let pairs: [(bool, bool, Button); 8] = [
-            (self.up,     other.up,     Button::Up),
-            (self.down,   other.down,   Button::Down),
-            (self.left,   other.left,   Button::Left),
-            (self.right,  other.right,  Button::Right),
-            (self.a,      other.a,      Button::A),
-            (self.b,      other.b,      Button::B),
-            (self.start,  other.start,  Button::Start),
+            (self.up, other.up, Button::Up),
+            (self.down, other.down, Button::Down),
+            (self.left, other.left, Button::Left),
+            (self.right, other.right, Button::Right),
+            (self.a, other.a, Button::A),
+            (self.b, other.b, Button::B),
+            (self.start, other.start, Button::Start),
             (self.select, other.select, Button::Select),
         ];
         pairs.into_iter().filter_map(|(prev, next, btn)| {
-            if prev != next { Some((btn, next)) } else { None }
+            if prev != next {
+                Some((btn, next))
+            } else {
+                None
+            }
         })
     }
 }
@@ -65,25 +69,25 @@ impl ButtonState {
 
 /// Encode `ButtonState` as a bitmask (bit 0 = up … bit 7 = select).
 fn state_to_bits(s: ButtonState) -> u8 {
-      (s.up     as u8)
-    | (s.down   as u8) << 1
-    | (s.left   as u8) << 2
-    | (s.right  as u8) << 3
-    | (s.a      as u8) << 4
-    | (s.b      as u8) << 5
-    | (s.start  as u8) << 6
-    | (s.select as u8) << 7
+    (s.up as u8)
+        | (s.down as u8) << 1
+        | (s.left as u8) << 2
+        | (s.right as u8) << 3
+        | (s.a as u8) << 4
+        | (s.b as u8) << 5
+        | (s.start as u8) << 6
+        | (s.select as u8) << 7
 }
 
 fn bits_to_state(b: u8) -> ButtonState {
     ButtonState {
-        up:     b & (1 << 0) != 0,
-        down:   b & (1 << 1) != 0,
-        left:   b & (1 << 2) != 0,
-        right:  b & (1 << 3) != 0,
-        a:      b & (1 << 4) != 0,
-        b:      b & (1 << 5) != 0,
-        start:  b & (1 << 6) != 0,
+        up: b & (1 << 0) != 0,
+        down: b & (1 << 1) != 0,
+        left: b & (1 << 2) != 0,
+        right: b & (1 << 3) != 0,
+        a: b & (1 << 4) != 0,
+        b: b & (1 << 5) != 0,
+        start: b & (1 << 6) != 0,
         select: b & (1 << 7) != 0,
     }
 }
@@ -97,20 +101,20 @@ fn bits_to_state(b: u8) -> ButtonState {
 /// Separated from GPIO reads so it can be driven with a synthetic clock in
 /// unit tests via [`InputState::update`].
 pub struct InputState {
-    raw:          ButtonState,
-    debounced:    ButtonState,
+    raw: ButtonState,
+    debounced: ButtonState,
     // When each button's raw state last changed (ms timestamp; None = stable)
-    raw_changed:  [Option<u64>; 8],
+    raw_changed: [Option<u64>; 8],
     // Menu combo tracking
-    combo_since:  Option<u64>,
-    combo_fired:  bool,
+    combo_since: Option<u64>,
+    combo_fired: bool,
 }
 
 impl Default for InputState {
     fn default() -> Self {
         Self {
-            raw:         ButtonState::default(),
-            debounced:   ButtonState::default(),
+            raw: ButtonState::default(),
+            debounced: ButtonState::default(),
             raw_changed: [None; 8],
             combo_since: None,
             combo_fired: false,
@@ -142,7 +146,11 @@ impl InputState {
                 self.raw_changed[i as usize] = Some(now_ms);
             } else if let Some(changed_at) = self.raw_changed[i as usize] {
                 if now_ms.saturating_sub(changed_at) >= DEBOUNCE_MS {
-                    if new_bit { deb_bits |= mask; } else { deb_bits &= !mask; }
+                    if new_bit {
+                        deb_bits |= mask;
+                    } else {
+                        deb_bits &= !mask;
+                    }
                     self.raw_changed[i as usize] = None;
                 }
             }
@@ -161,9 +169,7 @@ impl InputState {
                     false
                 }
                 Some(since) => {
-                    if !self.combo_fired
-                        && now_ms.saturating_sub(since) >= MENU_HOLD_MS
-                    {
+                    if !self.combo_fired && now_ms.saturating_sub(since) >= MENU_HOLD_MS {
                         self.combo_fired = true;
                         true
                     } else {
@@ -185,39 +191,39 @@ impl InputState {
 
 #[cfg(target_arch = "arm")]
 pub struct InputHandler<'d> {
-    up:     Input<'d>,
-    down:   Input<'d>,
-    left:   Input<'d>,
-    right:  Input<'d>,
-    a:      Input<'d>,
-    b:      Input<'d>,
-    start:  Input<'d>,
+    up: Input<'d>,
+    down: Input<'d>,
+    left: Input<'d>,
+    right: Input<'d>,
+    a: Input<'d>,
+    b: Input<'d>,
+    start: Input<'d>,
     select: Input<'d>,
-    state:  InputState,
+    state: InputState,
 }
 
 #[cfg(target_arch = "arm")]
 impl<'d> InputHandler<'d> {
     pub fn new(
-        up_pin:     Peri<'d, PIN_21>,
-        down_pin:   Peri<'d, PIN_22>,
-        left_pin:   Peri<'d, PIN_26>,
-        right_pin:  Peri<'d, PIN_27>,
-        a_pin:      Peri<'d, PIN_0>,
-        b_pin:      Peri<'d, PIN_1>,
-        start_pin:  Peri<'d, PIN_2>,
+        up_pin: Peri<'d, PIN_21>,
+        down_pin: Peri<'d, PIN_22>,
+        left_pin: Peri<'d, PIN_26>,
+        right_pin: Peri<'d, PIN_27>,
+        a_pin: Peri<'d, PIN_0>,
+        b_pin: Peri<'d, PIN_1>,
+        start_pin: Peri<'d, PIN_2>,
         select_pin: Peri<'d, PIN_3>,
     ) -> Self {
         Self {
-            up:     Input::new(up_pin,     Pull::Up),
-            down:   Input::new(down_pin,   Pull::Up),
-            left:   Input::new(left_pin,   Pull::Up),
-            right:  Input::new(right_pin,  Pull::Up),
-            a:      Input::new(a_pin,      Pull::Up),
-            b:      Input::new(b_pin,      Pull::Up),
-            start:  Input::new(start_pin,  Pull::Up),
+            up: Input::new(up_pin, Pull::Up),
+            down: Input::new(down_pin, Pull::Up),
+            left: Input::new(left_pin, Pull::Up),
+            right: Input::new(right_pin, Pull::Up),
+            a: Input::new(a_pin, Pull::Up),
+            b: Input::new(b_pin, Pull::Up),
+            start: Input::new(start_pin, Pull::Up),
             select: Input::new(select_pin, Pull::Up),
-            state:  InputState::default(),
+            state: InputState::default(),
         }
     }
 
@@ -232,13 +238,13 @@ impl<'d> InputHandler<'d> {
 
     fn read_raw(&self) -> ButtonState {
         ButtonState {
-            up:     self.up.is_low(),
-            down:   self.down.is_low(),
-            left:   self.left.is_low(),
-            right:  self.right.is_low(),
-            a:      self.a.is_low(),
-            b:      self.b.is_low(),
-            start:  self.start.is_low(),
+            up: self.up.is_low(),
+            down: self.down.is_low(),
+            left: self.left.is_low(),
+            right: self.right.is_low(),
+            a: self.a.is_low(),
+            b: self.b.is_low(),
+            start: self.start.is_low(),
             select: self.select.is_low(),
         }
     }
@@ -256,21 +262,30 @@ mod tests {
 
     #[test]
     fn diff_no_change() {
-        let s = ButtonState { up: true, ..Default::default() };
+        let s = ButtonState {
+            up: true,
+            ..Default::default()
+        };
         assert_eq!(s.diff(s).count(), 0);
     }
 
     #[test]
     fn diff_single_press() {
         let prev = ButtonState::default();
-        let curr = ButtonState { a: true, ..Default::default() };
+        let curr = ButtonState {
+            a: true,
+            ..Default::default()
+        };
         let changes: Vec<_> = prev.diff(curr).collect();
         assert_eq!(changes, vec![(Button::A, true)]);
     }
 
     #[test]
     fn diff_single_release() {
-        let prev = ButtonState { b: true, ..Default::default() };
+        let prev = ButtonState {
+            b: true,
+            ..Default::default()
+        };
         let curr = ButtonState::default();
         let changes: Vec<_> = prev.diff(curr).collect();
         assert_eq!(changes, vec![(Button::B, false)]);
@@ -278,8 +293,16 @@ mod tests {
 
     #[test]
     fn diff_simultaneous_changes() {
-        let prev = ButtonState { up: true, down: false, ..Default::default() };
-        let curr = ButtonState { up: false, down: true, ..Default::default() };
+        let prev = ButtonState {
+            up: true,
+            down: false,
+            ..Default::default()
+        };
+        let curr = ButtonState {
+            up: false,
+            down: true,
+            ..Default::default()
+        };
         let changes: Vec<_> = prev.diff(curr).collect();
         assert_eq!(changes.len(), 2);
         assert!(changes.contains(&(Button::Up, false)));
@@ -297,8 +320,14 @@ mod tests {
     #[test]
     fn bits_round_trip_all_ones() {
         let s = ButtonState {
-            up: true, down: true, left: true, right: true,
-            a: true, b: true, start: true, select: true,
+            up: true,
+            down: true,
+            left: true,
+            right: true,
+            a: true,
+            b: true,
+            start: true,
+            select: true,
         };
         assert_eq!(state_to_bits(s), 0xFF);
         assert_eq!(bits_to_state(state_to_bits(s)), s);
@@ -306,7 +335,12 @@ mod tests {
 
     #[test]
     fn bits_round_trip_arbitrary() {
-        let s = ButtonState { up: true, a: true, select: true, ..Default::default() };
+        let s = ButtonState {
+            up: true,
+            a: true,
+            select: true,
+            ..Default::default()
+        };
         assert_eq!(bits_to_state(state_to_bits(s)), s);
     }
 
@@ -315,7 +349,10 @@ mod tests {
     #[test]
     fn debounce_rejects_before_window() {
         let mut state = InputState::default();
-        let pressed = ButtonState { a: true, ..Default::default() };
+        let pressed = ButtonState {
+            a: true,
+            ..Default::default()
+        };
 
         // Raw changes at t=0, stable at t=5 — not yet past 10 ms window
         state.update(pressed, 0);
@@ -326,7 +363,10 @@ mod tests {
     #[test]
     fn debounce_accepts_after_window() {
         let mut state = InputState::default();
-        let pressed = ButtonState { a: true, ..Default::default() };
+        let pressed = ButtonState {
+            a: true,
+            ..Default::default()
+        };
 
         state.update(pressed, 0);
         let (deb, _) = state.update(pressed, 10);
@@ -336,10 +376,16 @@ mod tests {
     #[test]
     fn debounce_resets_on_bounce() {
         let mut state = InputState::default();
-        let pressed  = ButtonState { a: true,  ..Default::default() };
-        let released = ButtonState { a: false, ..Default::default() };
+        let pressed = ButtonState {
+            a: true,
+            ..Default::default()
+        };
+        let released = ButtonState {
+            a: false,
+            ..Default::default()
+        };
 
-        state.update(pressed, 0);  // raw goes high
+        state.update(pressed, 0); // raw goes high
         state.update(released, 5); // bounces low before window — resets timer
         let (deb, _) = state.update(pressed, 12); // stable again but window not elapsed from t=5
         assert!(!deb.a, "bounce before window should reset debounce");
@@ -350,7 +396,11 @@ mod tests {
     #[test]
     fn combo_fires_after_hold() {
         let mut state = InputState::default();
-        let both = ButtonState { start: true, select: true, ..Default::default() };
+        let both = ButtonState {
+            start: true,
+            select: true,
+            ..Default::default()
+        };
 
         // Debounce both buttons first
         state.update(both, 0);
@@ -368,7 +418,11 @@ mod tests {
     #[test]
     fn combo_fires_only_once() {
         let mut state = InputState::default();
-        let both = ButtonState { start: true, select: true, ..Default::default() };
+        let both = ButtonState {
+            start: true,
+            select: true,
+            ..Default::default()
+        };
 
         state.update(both, 0);
         state.update(both, 10);
@@ -381,7 +435,11 @@ mod tests {
     #[test]
     fn combo_resets_after_release() {
         let mut state = InputState::default();
-        let both     = ButtonState { start: true, select: true, ..Default::default() };
+        let both = ButtonState {
+            start: true,
+            select: true,
+            ..Default::default()
+        };
         let released = ButtonState::default();
 
         state.update(both, 0);

--- a/platform/pico2w/src/lib.rs
+++ b/platform/pico2w/src/lib.rs
@@ -4,6 +4,8 @@ extern crate alloc;
 
 #[cfg(target_arch = "arm")]
 pub mod audio;
+#[cfg(target_arch = "arm")]
+pub mod core1;
 pub mod display;
 #[cfg(target_arch = "arm")]
 pub mod flash_rom;

--- a/platform/pico2w/src/main.rs
+++ b/platform/pico2w/src/main.rs
@@ -9,8 +9,12 @@ use core::task::{Context, Poll, RawWaker, RawWakerVTable, Waker};
 use cortex_m_rt::ExceptionFrame;
 #[cortex_m_rt::exception]
 unsafe fn HardFault(ef: &ExceptionFrame) -> ! {
-    defmt::error!("HardFault: PC=0x{:08x} LR=0x{:08x} PSR=0x{:08x}",
-        ef.pc(), ef.lr(), ef.xpsr());
+    defmt::error!(
+        "HardFault: PC=0x{:08x} LR=0x{:08x} PSR=0x{:08x}",
+        ef.pc(),
+        ef.lr(),
+        ef.xpsr()
+    );
     loop {}
 }
 
@@ -25,7 +29,9 @@ static HEAP: Heap = Heap::empty();
 use defmt::{error, info, warn};
 use embassy_executor::Spawner;
 use embassy_rp::gpio::{Level, Output};
-use embassy_rp::peripherals::{DMA_CH0, DMA_CH1, PIN_10, PIN_11, PIN_12, PIN_13, PIN_8, PIN_9, PIO0, SPI1};
+use embassy_rp::peripherals::{
+    DMA_CH0, DMA_CH1, PIN_10, PIN_11, PIN_12, PIN_13, PIN_8, PIN_9, PIO0, SPI1,
+};
 use embassy_rp::pio::{InterruptHandler as PioIrqHandler, Pio};
 use embassy_rp::pio_programs::i2s::{PioI2sOut, PioI2sOutProgram};
 use embassy_rp::spi::{self, Spi};
@@ -38,16 +44,16 @@ use {defmt_rtt as _, panic_probe as _};
 
 use rustyboy_core::cpu::cpu::Cpu;
 use rustyboy_core::cpu::instructions::opcodes::OpCodeDecoder;
+use rustyboy_core::cpu::peripheral::island::PeripheralBackend;
 use rustyboy_core::cpu::peripheral::joypad::Button;
 use rustyboy_core::cpu::registers::{Flags, Registers};
 use rustyboy_core::cpu::sm83::Sm83;
 use rustyboy_core::memory::GameBoyMemory;
 use rustyboy_pico2w::audio::{AudioBuffers, SAMPLE_RATE};
+use rustyboy_pico2w::core1::spawn_peripheral_core;
 use rustyboy_pico2w::display::hw::{GameDisplay, HwDisplay};
 use rustyboy_pico2w::display::scale_to_rgb565;
-use rustyboy_pico2w::flash_rom::{
-    new_onboard_flash, probe_staged_rom, stage_rom_from_reader,
-};
+use rustyboy_pico2w::flash_rom::{new_onboard_flash, probe_staged_rom, stage_rom_from_reader};
 use rustyboy_pico2w::input::{ButtonState, InputHandler};
 use rustyboy_pico2w::sd::{DummyClock, SdRomReader};
 use rustyboy_pico2w::stack_probe;
@@ -58,8 +64,7 @@ const TARGET_SYS_HZ: u32 = 266_000_000;
 #[cfg(not(feature = "oc-266"))]
 const TARGET_SYS_HZ: u32 = 250_000_000;
 
-const TARGET_CORE_VOLTAGE: embassy_rp::clocks::CoreVoltage =
-    embassy_rp::clocks::CoreVoltage::V1_20;
+const TARGET_CORE_VOLTAGE: embassy_rp::clocks::CoreVoltage = embassy_rp::clocks::CoreVoltage::V1_20;
 
 const FIRMWARE_VERSION: &str = env!("CARGO_PKG_VERSION");
 const CYCLES_PER_FRAME: u64 = 70_224;
@@ -207,8 +212,10 @@ async fn main(_spawner: Spawner) {
     let memory = GameBoyMemory::with_cartridge(alloc::boxed::Box::new(cart));
     info!("building OpCodeDecoder");
     let decoder = alloc::boxed::Box::new(OpCodeDecoder::new());
+    info!("spawning peripheral core");
+    let peripherals: alloc::boxed::Box<dyn PeripheralBackend> = spawn_peripheral_core(p.CORE1);
     info!("building Sm83 CPU");
-    let mut cpu = Sm83::new(alloc::boxed::Box::new(memory), decoder)
+    let mut cpu = Sm83::new_with_peripherals(alloc::boxed::Box::new(memory), decoder, peripherals)
         .with_registers(Registers {
             a: 0x01,
             f: Flags::from_bits_truncate(0xB0),
@@ -251,10 +258,14 @@ async fn main(_spawner: Spawner) {
     // SAFETY: hw_disp was dropped above, SPI1 and all display pins are free.
     let mut game_disp = unsafe {
         GameDisplay::new_after_splash(
-            PIN_10::steal(), PIN_11::steal(),
-            PIN_9::steal(),  PIN_8::steal(),
-            PIN_12::steal(), PIN_13::steal(),
-            SPI1::steal(),   p.DMA_CH1,
+            PIN_10::steal(),
+            PIN_11::steal(),
+            PIN_9::steal(),
+            PIN_8::steal(),
+            PIN_12::steal(),
+            PIN_13::steal(),
+            SPI1::steal(),
+            p.DMA_CH1,
             Irqs,
         )
     };
@@ -298,6 +309,7 @@ async fn main(_spawner: Spawner) {
         while cpu.cycle_counter().wrapping_sub(frame_start) < CYCLES_PER_FRAME {
             let _ = cpu.tick();
         }
+        cpu.sync_peripherals();
 
         // Propagate button changes to the CPU.
         let (state, menu) = input.poll();

--- a/platform/pico2w/src/sd.rs
+++ b/platform/pico2w/src/sd.rs
@@ -23,9 +23,9 @@ where
     <D as BlockDevice>::Error: core::fmt::Debug,
     T: TimeSource,
 {
-    mgr:    VolumeManager<D, T>,
+    mgr: VolumeManager<D, T>,
     volume: RawVolume,
-    file:   RawFile,
+    file: RawFile,
 }
 
 #[derive(Debug)]
@@ -50,7 +50,7 @@ where
     /// open it for sequential bank reads.
     pub fn new(mgr: VolumeManager<D, T>) -> Result<Self, SdError<D::Error>> {
         let volume = mgr.open_raw_volume(VolumeIdx(0))?;
-        let root   = mgr.open_root_dir(volume)?;
+        let root = mgr.open_root_dir(volume)?;
 
         if let Some(file) = find_rom_in_dir(&mgr, root)? {
             let _ = mgr.close_dir(root);
@@ -91,7 +91,9 @@ where
         let mut total = 0;
         while total < 0x4000 {
             let n = self.mgr.read(self.file, &mut buf[total..])?;
-            if n == 0 { break; }
+            if n == 0 {
+                break;
+            }
             total += n;
         }
         Ok(())

--- a/platform/pico2w/src/stack_probe.rs
+++ b/platform/pico2w/src/stack_probe.rs
@@ -26,7 +26,12 @@ mod imp {
 
     #[inline]
     fn bounds() -> (usize, usize) {
-        unsafe { (&__sheap as *const u8 as usize, &_stack_start as *const u8 as usize) }
+        unsafe {
+            (
+                &__sheap as *const u8 as usize,
+                &_stack_start as *const u8 as usize,
+            )
+        }
     }
 
     fn active_thread_sp() -> usize {
@@ -70,10 +75,7 @@ mod imp {
         if current_margin <= COLLISION_GUARD_BYTES {
             panic!(
                 "stack collision risk {}: sp=0x{:08x} bottom=0x{:08x} margin={}B",
-                label,
-                state.current_sp,
-                state.bottom,
-                current_margin,
+                label, state.current_sp, state.bottom, current_margin,
             );
         }
 
@@ -82,10 +84,7 @@ mod imp {
         {
             warn!(
                 "stack low headroom {}: sp=0x{:08x} bottom=0x{:08x} margin={}B",
-                label,
-                state.current_sp,
-                state.bottom,
-                current_margin,
+                label, state.current_sp, state.bottom, current_margin,
             );
         }
     }

--- a/platform/pico2w/src/xip_cartridge.rs
+++ b/platform/pico2w/src/xip_cartridge.rs
@@ -1,8 +1,8 @@
 use alloc::vec::Vec;
 
-use rustyboy_core::memory::cartridge::{Cartridge, CartridgeRomWindows};
 #[cfg(feature = "perf")]
 use rustyboy_core::memory::cartridge::CartridgePerfProfile;
+use rustyboy_core::memory::cartridge::{Cartridge, CartridgeRomWindows};
 
 #[cfg(feature = "perf")]
 use rustyboy_core::cpu::perf::cyccnt;

--- a/platform/web/client/src/lib.rs
+++ b/platform/web/client/src/lib.rs
@@ -59,6 +59,7 @@ impl EmulatorHandle {
         while self.cpu.cycle_counter().wrapping_sub(start) < CYCLES_PER_FRAME as u64 {
             let _ = self.cpu.tick();
         }
+        self.cpu.sync_peripherals();
     }
 
     /// Returns the framebuffer as an RGBA8 Vec for use in JS as Uint8ClampedArray.
@@ -81,13 +82,13 @@ impl EmulatorHandle {
     /// Returns a debug string with key PPU/interrupt state for on-screen display.
     /// Only available when compiled with the `debug-overlay` feature.
     #[cfg(feature = "debug-overlay")]
-    pub fn debug_state(&self) -> String {
-        let read = |a: u16| self.cpu.read_memory(a).unwrap_or(0);
-        let lcdc = read(0xFF40);
-        let stat = read(0xFF41);
-        let ly   = read(0xFF44);
-        let lyc  = read(0xFF45);
-        let scx  = read(0xFF43);
+    pub fn debug_state(&mut self) -> String {
+        let read = |cpu: &mut Sm83, a: u16| cpu.read_memory(a).unwrap_or(0);
+        let lcdc = read(&mut self.cpu, 0xFF40);
+        let stat = read(&mut self.cpu, 0xFF41);
+        let ly   = read(&mut self.cpu, 0xFF44);
+        let lyc  = read(&mut self.cpu, 0xFF45);
+        let scx  = read(&mut self.cpu, 0xFF43);
         let scy  = read(0xFF42);
         let if_  = read(0xFF0F);
         let ie   = read(0xFFFF);
@@ -110,7 +111,7 @@ impl EmulatorHandle {
     }
 
     /// Serialize the full emulator state to a byte blob (save state).
-    pub fn save_state(&self) -> Vec<u8> {
+    pub fn save_state(&mut self) -> Vec<u8> {
         self.cpu.save_state()
     }
 


### PR DESCRIPTION
## Summary
- add a shared peripheral-island backend and Pico core1 worker for timer, PPU, and APU execution
- switch the Pico multicore path to queued shadow-state updates with a speculative no-wait hot path on core0
- wire the runtime through the existing core and web entry points, and include the architecture notes for the multithreaded split

## Validation
- cargo check --features perf
- cargo test -p rustyboy-core --target x86_64-unknown-linux-gnu --test blargg_dmg_sound
- flashed Pico hardware and measured the current release build at roughly 24-25 FPS

## Caveats
- this branch intentionally prioritizes throughput over exact timing on the queued Pico path
- LY/STAT/TIMA/DIV/IF, framebuffer, and audio state can be stale relative to the CPU because the hot path no longer waits for peripheral catch-up

## Results

Overall sustained 20-22fps, barely an improvement over the single core model. CPU sync is real. Decided to shelve this.