### PR TITLE
pico2w: fix APU batch-sampling buzz; add gated audio feature

### DIFF
--- a/core/src/cpu/peripheral/apu.rs
+++ b/core/src/cpu/peripheral/apu.rs
@@ -61,6 +61,17 @@ const CPU_FREQ: u32 = 4_194_304;
 /// Using fixed-point: accumulator counts in units of SAMPLE_RATE.
 const SAMPLE_PERIOD_NUM: u32 = CPU_FREQ;
 const SAMPLE_PERIOD_DEN: u32 = SAMPLE_RATE;
+/// Maximum T-cycles per tick() sub-step. Must be ≤ the shortest duty-cycle
+/// step period of any audible frequency so that tick_channels() always runs at
+/// least once between consecutive sample emissions.
+///
+/// Step period for frequency f = CPU_FREQ / (f * 8).
+/// At 16 384 Hz: step = 4 194 304 / (16384 * 8) = 32 T-cycles — so 32 is the
+/// largest value that stays correct up to ~16 kHz, which covers all music
+/// notes and typical sound effects.  Smaller values improve accuracy further
+/// but increase Core 1 iteration count: 4 → ~16 400 iters/batch (~5.8 ms),
+/// 32 → ~2 050 iters/batch (~1.4 ms).
+const TICK_GRAN: u16 = 32;
 /// About 804 stereo pairs are produced per Game Boy frame at 48 kHz.
 /// Reserve some headroom so the hot audio path doesn't regrow this buffer.
 const SAMPLE_BUFFER_CAPACITY_HINT: usize = 2048;
@@ -782,9 +793,29 @@ impl ApuPeripheral {
             };
         }
 
-        self.tick_frame_sequencer(cycles, div_counter);
-        self.tick_channels(cycles);
-        self.produce_samples(cycles);
+        if cycles <= TICK_GRAN {
+            self.tick_frame_sequencer(cycles, div_counter);
+            self.tick_channels(cycles);
+            self.produce_samples(cycles);
+        } else {
+            // Subdivide into ≤TICK_GRAN chunks so tick_channels() runs at
+            // per-instruction granularity. Larger chunks let the channel advance
+            // multiple duty-cycle steps before the sample is read, which shifts
+            // high-frequency tones off pitch and causes the 60 Hz buzz fixed in
+            // the first pass.
+            let div_start = div_counter.wrapping_sub(cycles);
+            let mut remaining = cycles;
+            let mut elapsed = 0u16;
+            while remaining > 0 {
+                let chunk = remaining.min(TICK_GRAN);
+                elapsed = elapsed.wrapping_add(chunk);
+                let div = div_start.wrapping_add(elapsed);
+                self.tick_frame_sequencer(chunk, div);
+                self.tick_channels(chunk);
+                self.produce_samples(chunk);
+                remaining -= chunk;
+            }
+        }
 
         ApuOutput {
             nr52: self.build_nr52(),

--- a/platform/pico2w/Cargo.toml
+++ b/platform/pico2w/Cargo.toml
@@ -21,6 +21,8 @@ oc-300 = []
 fps = []
 # Enable stack sentinel / collision detection instrumentation.
 stack-probe = []
+# Enable audio output. Off by default; pass --features audio to enable.
+audio = []
 
 # ---------------------------------------------------------------------------
 # Cross-platform dependencies (compile on any target, including host tests)

--- a/platform/pico2w/src/audio.rs
+++ b/platform/pico2w/src/audio.rs
@@ -2,6 +2,14 @@
 
 const AUDIO_BUF_SIZE: usize = 1024;
 
+/// Hardware output volume scale: divide samples by this before packing into I2S.
+/// With the `audio` feature: 8 (~18 dB attenuation).
+/// Without the `audio` feature: i16::MAX (effective silence).
+#[cfg(feature = "audio")]
+const VOLUME_DIV: i16 = 8;
+#[cfg(not(feature = "audio"))]
+const VOLUME_DIV: i16 = i16::MAX;
+
 // Double-buffer for I2S DMA: two back-to-back static arrays in .bss.
 static mut AUDIO_BUF_A: [u32; AUDIO_BUF_SIZE] = [0u32; AUDIO_BUF_SIZE];
 static mut AUDIO_BUF_B: [u32; AUDIO_BUF_SIZE] = [0u32; AUDIO_BUF_SIZE];
@@ -71,8 +79,8 @@ impl AudioBuffers {
 fn samples_to_i2s(samples: &[f32], buf: &mut [u32]) -> usize {
     let pairs = (samples.len() / 2).min(buf.len());
     for i in 0..pairs {
-        let l = (samples[i * 2] * 32767.0) as i16;
-        let r = (samples[i * 2 + 1] * 32767.0) as i16;
+        let l = (samples[i * 2] * 32767.0) as i16 / VOLUME_DIV;
+        let r = (samples[i * 2 + 1] * 32767.0) as i16 / VOLUME_DIV;
         buf[i] = ((l as u16 as u32) << 16) | (r as u16 as u32);
     }
     pairs
@@ -81,8 +89,8 @@ fn samples_to_i2s(samples: &[f32], buf: &mut [u32]) -> usize {
 fn samples_i16_to_i2s(samples: &[i16], buf: &mut [u32]) -> usize {
     let pairs = (samples.len() / 2).min(buf.len());
     for i in 0..pairs {
-        let l = samples[i * 2];
-        let r = samples[i * 2 + 1];
+        let l = samples[i * 2] / VOLUME_DIV;
+        let r = samples[i * 2 + 1] / VOLUME_DIV;
         buf[i] = ((l as u16 as u32) << 16) | (r as u16 as u32);
     }
     pairs


### PR DESCRIPTION
## Summary

- **APU batch-sampling fix**: `ApuPeripheral::tick()` now subdivides large T-cycle batches into ≤32-cycle chunks (`TICK_GRAN=32`). Previously a full-frame batch (up to 65535 T-cycles) called `tick_channels()` once then emitted ~750 identical samples — producing a 60 Hz rectangular buzz on audio output. `TICK_GRAN=32` keeps all audible frequencies (up to ~16 kHz) properly sampled while limiting Core 1 to ~2050 iterations per batch (~1.4 ms vs ~5.8 ms for TICK_GRAN=4 which caused a watchdog crash).
- **Gated audio feature**: New `audio` Cargo feature (off by default). Without it `VOLUME_DIV = i16::MAX` (silence); `--features audio` enables audio at VOLUME_DIV=8 (~18 dB attenuation). Allows development builds to default to silent without touching hardware mute logic.

## Test plan

- [ ] `cargo build --release` compiles clean (silent default)
- [ ] `cargo build --release --features audio` compiles clean (audio enabled)
- [ ] Flash with `--features audio`: audio plays without buzz, high-frequency tones are in pitch, volume is comfortable
- [ ] Flash without `--features audio`: no audio output

🤖 Generated with [Claude Code](https://claude.com/claude-code)