### PR TITLE
core: place SM83 hot path in SRAM to free XIP cache for ROM data

### DIFF
--- a/core/src/cpu/instructions/adc/opcode.rs
+++ b/core/src/cpu/instructions/adc/opcode.rs
@@ -10,6 +10,7 @@ pub struct Adc {
 }
 
 impl OpCode for Adc {
+#[cfg_attr(target_arch = "arm", link_section = ".data")]
     fn execute(
         &self,
         instruction: &mut dyn Instructions,

--- a/core/src/cpu/instructions/add/opcode.rs
+++ b/core/src/cpu/instructions/add/opcode.rs
@@ -10,6 +10,7 @@ pub struct Add8 {
 }
 
 impl OpCode for Add8 {
+#[cfg_attr(target_arch = "arm", link_section = ".data")]
     fn execute(&self, cpu: &mut dyn Instructions, memory: &mut GameBoyMemory) -> Result<u8, Error> {
         cpu.add8(&self, memory)
     }
@@ -22,6 +23,7 @@ pub struct Add16 {
 }
 
 impl OpCode for Add16 {
+#[cfg_attr(target_arch = "arm", link_section = ".data")]
     fn execute(
         &self,
         cpu: &mut dyn Instructions,
@@ -38,6 +40,7 @@ pub struct AddSP16 {
 }
 
 impl OpCode for AddSP16 {
+#[cfg_attr(target_arch = "arm", link_section = ".data")]
     fn execute(&self, cpu: &mut dyn Instructions, memory: &mut GameBoyMemory) -> Result<u8, Error> {
         cpu.add_sp16(&self, memory)
     }

--- a/core/src/cpu/instructions/call/opcode.rs
+++ b/core/src/cpu/instructions/call/opcode.rs
@@ -17,6 +17,7 @@ pub struct Call {
 }
 
 impl OpCode for Call {
+#[cfg_attr(target_arch = "arm", link_section = ".data")]
     fn execute(&self, cpu: &mut dyn Instructions, memory: &mut GameBoyMemory) -> Result<u8, Error> {
         cpu.call(self, memory)
     }

--- a/core/src/cpu/instructions/cb/opcode.rs
+++ b/core/src/cpu/instructions/cb/opcode.rs
@@ -33,6 +33,7 @@ pub struct CbInstruction {
 }
 
 impl OpCode for CbInstruction {
+#[cfg_attr(target_arch = "arm", link_section = ".data")]
     fn execute(&self, cpu: &mut dyn Instructions, memory: &mut GameBoyMemory) -> Result<u8, Error> {
         cpu.cb(self, memory)
     }

--- a/core/src/cpu/instructions/cp/opcode.rs
+++ b/core/src/cpu/instructions/cp/opcode.rs
@@ -11,6 +11,7 @@ pub struct Cp8 {
 }
 
 impl OpCode for Cp8 {
+#[cfg_attr(target_arch = "arm", link_section = ".data")]
     fn execute(&self, cpu: &mut dyn Instructions, memory: &mut GameBoyMemory) -> Result<u8, Error> {
         cpu.cp8(&self, memory)
     }

--- a/core/src/cpu/instructions/inc_dec/opcode.rs
+++ b/core/src/cpu/instructions/inc_dec/opcode.rs
@@ -11,6 +11,7 @@ pub struct Inc8 {
 }
 
 impl OpCode for Inc8 {
+#[cfg_attr(target_arch = "arm", link_section = ".data")]
     fn execute(&self, cpu: &mut dyn Instructions, memory: &mut GameBoyMemory) -> Result<u8, Error> {
         cpu.inc8(self, memory)
     }
@@ -24,6 +25,7 @@ pub struct Dec8 {
 }
 
 impl OpCode for Dec8 {
+#[cfg_attr(target_arch = "arm", link_section = ".data")]
     fn execute(&self, cpu: &mut dyn Instructions, memory: &mut GameBoyMemory) -> Result<u8, Error> {
         cpu.dec8(self, memory)
     }
@@ -36,6 +38,7 @@ pub struct Inc16 {
 }
 
 impl OpCode for Inc16 {
+#[cfg_attr(target_arch = "arm", link_section = ".data")]
     fn execute(
         &self,
         cpu: &mut dyn Instructions,
@@ -52,6 +55,7 @@ pub struct Dec16 {
 }
 
 impl OpCode for Dec16 {
+#[cfg_attr(target_arch = "arm", link_section = ".data")]
     fn execute(
         &self,
         cpu: &mut dyn Instructions,

--- a/core/src/cpu/instructions/jump/opcode.rs
+++ b/core/src/cpu/instructions/jump/opcode.rs
@@ -31,6 +31,7 @@ pub struct Jump {
 }
 
 impl OpCode for Jump {
+#[cfg_attr(target_arch = "arm", link_section = ".data")]
     fn execute(&self, cpu: &mut dyn Instructions, memory: &mut GameBoyMemory) -> Result<u8, Error> {
         cpu.jump(&self, memory)
     }

--- a/core/src/cpu/instructions/ld/opcode.rs
+++ b/core/src/cpu/instructions/ld/opcode.rs
@@ -11,6 +11,7 @@ pub struct Ld8 {
 }
 
 impl OpCode for Ld8 {
+#[cfg_attr(target_arch = "arm", link_section = ".data")]
     fn execute(&self, cpu: &mut dyn Instructions, memory: &mut GameBoyMemory) -> Result<u8, Error> {
         cpu.ld8(&self, memory)
     }

--- a/core/src/cpu/instructions/ld16/opcode.rs
+++ b/core/src/cpu/instructions/ld16/opcode.rs
@@ -30,6 +30,7 @@ pub struct Ld16 {
 }
 
 impl OpCode for Ld16 {
+#[cfg_attr(target_arch = "arm", link_section = ".data")]
     fn execute(&self, cpu: &mut dyn Instructions, memory: &mut GameBoyMemory) -> Result<u8, Error> {
         cpu.ld16(&self, memory)
     }

--- a/core/src/cpu/instructions/logic/opcode.rs
+++ b/core/src/cpu/instructions/logic/opcode.rs
@@ -11,6 +11,7 @@ pub struct And8 {
 }
 
 impl OpCode for And8 {
+#[cfg_attr(target_arch = "arm", link_section = ".data")]
     fn execute(&self, cpu: &mut dyn Instructions, memory: &mut GameBoyMemory) -> Result<u8, Error> {
         cpu.and8(&self, memory)
     }
@@ -24,6 +25,7 @@ pub struct Or8 {
 }
 
 impl OpCode for Or8 {
+#[cfg_attr(target_arch = "arm", link_section = ".data")]
     fn execute(&self, cpu: &mut dyn Instructions, memory: &mut GameBoyMemory) -> Result<u8, Error> {
         cpu.or8(&self, memory)
     }
@@ -37,6 +39,7 @@ pub struct Xor8 {
 }
 
 impl OpCode for Xor8 {
+#[cfg_attr(target_arch = "arm", link_section = ".data")]
     fn execute(&self, cpu: &mut dyn Instructions, memory: &mut GameBoyMemory) -> Result<u8, Error> {
         cpu.xor8(&self, memory)
     }

--- a/core/src/cpu/instructions/misc/opcode.rs
+++ b/core/src/cpu/instructions/misc/opcode.rs
@@ -21,6 +21,7 @@ pub struct Misc {
 }
 
 impl OpCode for Misc {
+#[cfg_attr(target_arch = "arm", link_section = ".data")]
     fn execute(
         &self,
         cpu: &mut dyn Instructions,

--- a/core/src/cpu/instructions/ret/opcode.rs
+++ b/core/src/cpu/instructions/ret/opcode.rs
@@ -19,6 +19,7 @@ pub struct Ret {
 }
 
 impl OpCode for Ret {
+#[cfg_attr(target_arch = "arm", link_section = ".data")]
     fn execute(&self, cpu: &mut dyn Instructions, memory: &mut GameBoyMemory) -> Result<u8, Error> {
         cpu.ret(self, memory)
     }

--- a/core/src/cpu/instructions/rotate/opcode.rs
+++ b/core/src/cpu/instructions/rotate/opcode.rs
@@ -16,6 +16,7 @@ pub struct Rotate {
 }
 
 impl OpCode for Rotate {
+#[cfg_attr(target_arch = "arm", link_section = ".data")]
     fn execute(
         &self,
         cpu: &mut dyn Instructions,

--- a/core/src/cpu/instructions/rst/opcode.rs
+++ b/core/src/cpu/instructions/rst/opcode.rs
@@ -8,6 +8,7 @@ pub struct Rst {
 }
 
 impl OpCode for Rst {
+#[cfg_attr(target_arch = "arm", link_section = ".data")]
     fn execute(&self, cpu: &mut dyn Instructions, memory: &mut GameBoyMemory) -> Result<u8, Error> {
         cpu.rst(self, memory)
     }

--- a/core/src/cpu/instructions/sbc/opcode.rs
+++ b/core/src/cpu/instructions/sbc/opcode.rs
@@ -10,6 +10,7 @@ pub struct Sbc8 {
 }
 
 impl OpCode for Sbc8 {
+#[cfg_attr(target_arch = "arm", link_section = ".data")]
     fn execute(&self, cpu: &mut dyn Instructions, memory: &mut GameBoyMemory) -> Result<u8, Error> {
         cpu.sbc8(&self, memory)
     }

--- a/core/src/cpu/instructions/stack/opcode.rs
+++ b/core/src/cpu/instructions/stack/opcode.rs
@@ -9,6 +9,7 @@ pub struct Push16 {
 }
 
 impl OpCode for Push16 {
+#[cfg_attr(target_arch = "arm", link_section = ".data")]
     fn execute(&self, cpu: &mut dyn Instructions, memory: &mut GameBoyMemory) -> Result<u8, Error> {
         cpu.push16(self, memory)
     }
@@ -20,6 +21,7 @@ pub struct Pop16 {
 }
 
 impl OpCode for Pop16 {
+#[cfg_attr(target_arch = "arm", link_section = ".data")]
     fn execute(&self, cpu: &mut dyn Instructions, memory: &mut GameBoyMemory) -> Result<u8, Error> {
         cpu.pop16(self, memory)
     }

--- a/core/src/cpu/instructions/sub/opcode.rs
+++ b/core/src/cpu/instructions/sub/opcode.rs
@@ -10,6 +10,7 @@ pub struct Sub8 {
 }
 
 impl OpCode for Sub8 {
+#[cfg_attr(target_arch = "arm", link_section = ".data")]
     fn execute(&self, cpu: &mut dyn Instructions, memory: &mut GameBoyMemory) -> Result<u8, Error> {
         cpu.sub8(&self, memory)
     }

--- a/core/src/cpu/sm83.rs
+++ b/core/src/cpu/sm83.rs
@@ -135,6 +135,7 @@ impl Sm83 {
     // ── Register encoding helpers ─────────────────────────────────────────────
 
     /// r16 pairs for stack instructions: 0=BC 1=DE 2=HL 3=AF.
+    #[cfg_attr(target_arch = "arm", link_section = ".data")]
     fn r16stk_get(&self, r: u8) -> u16 {
         match r {
             0 => self.registers.bc(),
@@ -148,6 +149,7 @@ impl Sm83 {
         }
     }
 
+    #[cfg_attr(target_arch = "arm", link_section = ".data")]
     fn r16stk_set(&mut self, r: u8, v: u16) {
         match r {
             0 => self.registers.set_bc(v),
@@ -264,6 +266,7 @@ impl Sm83 {
 
     // ── Register enum helpers ─────────────────────────────────────────────────
 
+    #[cfg_attr(target_arch = "arm", link_section = ".data")]
     fn get_r8_enum(&self, r: Register8) -> u8 {
         match r {
             Register8::A => self.registers.a,
@@ -276,6 +279,7 @@ impl Sm83 {
         }
     }
 
+    #[cfg_attr(target_arch = "arm", link_section = ".data")]
     fn set_r8_enum(&mut self, r: Register8, val: u8) {
         match r {
             Register8::A => self.registers.a = val,
@@ -288,6 +292,7 @@ impl Sm83 {
         }
     }
 
+    #[cfg_attr(target_arch = "arm", link_section = ".data")]
     fn get_r16_enum(&self, r: Register16) -> u16 {
         match r {
             Register16::AF => {
@@ -302,6 +307,7 @@ impl Sm83 {
         }
     }
 
+    #[cfg_attr(target_arch = "arm", link_section = ".data")]
     fn set_r16_enum(&mut self, r: Register16, val: u16) {
         match r {
             Register16::AF => {
@@ -315,6 +321,7 @@ impl Sm83 {
         }
     }
 
+    #[cfg_attr(target_arch = "arm", link_section = ".data")]
     fn get_operand8(&mut self, op: &Operand, memory: &mut GameBoyMemory) -> u8 {
         match op {
             Operand::Register8(r) => self.get_r8_enum(*r),
@@ -338,6 +345,7 @@ impl Sm83 {
         }
     }
 
+    #[cfg_attr(target_arch = "arm", link_section = ".data")]
     fn set_operand8(&mut self, op: &Operand, val: u8, memory: &mut GameBoyMemory) {
         match op {
             Operand::Register8(r) => self.set_r8_enum(*r, val),
@@ -367,6 +375,7 @@ impl Sm83 {
         }
     }
 
+    #[cfg_attr(target_arch = "arm", link_section = ".data")]
     fn check_condition(&self, cond: &Condition) -> bool {
         match cond {
             Condition::NZ => !self.registers.f.contains(Flags::Z),
@@ -376,6 +385,7 @@ impl Sm83 {
         }
     }
 
+    #[cfg_attr(target_arch = "arm", link_section = ".data")]
     fn pop16_inner(&mut self, memory: &mut GameBoyMemory) -> u16 {
         let lo = memory.read_fast(self.registers.sp);
         let hi = memory.read_fast(self.registers.sp.wrapping_add(1));
@@ -383,6 +393,7 @@ impl Sm83 {
         u16::from_le_bytes([lo, hi])
     }
 
+    #[cfg_attr(target_arch = "arm", link_section = ".data")]
     fn push16_inner(&mut self, val: u16, memory: &mut GameBoyMemory) {
         self.registers.sp = self.registers.sp.wrapping_sub(2);
         self.bus_write(memory, self.registers.sp.wrapping_add(1), (val >> 8) as u8);
@@ -510,6 +521,7 @@ impl Sm83 {
 // ── Instructions implementation ───────────────────────────────────────────────
 
 impl Instructions for Sm83 {
+    #[cfg_attr(target_arch = "arm", link_section = ".data")]
     fn add8(&mut self, op: &Add8, memory: &mut GameBoyMemory) -> Result<u8, InstructionError> {
         let val = self.get_operand8(&op.operand, memory);
         let (r, f) = add_u8(self.registers.a, val);
@@ -518,6 +530,7 @@ impl Instructions for Sm83 {
         Ok(op.cycles)
     }
 
+    #[cfg_attr(target_arch = "arm", link_section = ".data")]
     fn add16(&mut self, op: &Add16) -> Result<u8, InstructionError> {
         let rr = match op.operand {
             Operand::Register16(r) => self.get_r16_enum(r),
@@ -539,6 +552,7 @@ impl Instructions for Sm83 {
         Ok(op.cycles)
     }
 
+    #[cfg_attr(target_arch = "arm", link_section = ".data")]
     fn add_sp16(
         &mut self,
         op: &AddSP16,
@@ -551,6 +565,7 @@ impl Instructions for Sm83 {
         Ok(op.cycles)
     }
 
+    #[cfg_attr(target_arch = "arm", link_section = ".data")]
     fn adc(&mut self, op: &Adc, memory: &mut GameBoyMemory) -> Result<u8, InstructionError> {
         let val = self.get_operand8(&op.operand, memory);
         let cy = self.registers.f.contains(Flags::C) as u8;
@@ -560,6 +575,7 @@ impl Instructions for Sm83 {
         Ok(op.cycles)
     }
 
+    #[cfg_attr(target_arch = "arm", link_section = ".data")]
     fn sub8(&mut self, op: &Sub8, memory: &mut GameBoyMemory) -> Result<u8, InstructionError> {
         let val = self.get_operand8(&op.operand, memory);
         let (r, f) = sub_u8(self.registers.a, val);
@@ -568,6 +584,7 @@ impl Instructions for Sm83 {
         Ok(op.cycles)
     }
 
+    #[cfg_attr(target_arch = "arm", link_section = ".data")]
     fn sbc8(&mut self, op: &Sbc8, memory: &mut GameBoyMemory) -> Result<u8, InstructionError> {
         let val = self.get_operand8(&op.operand, memory);
         let cy = self.registers.f.contains(Flags::C) as u8;
@@ -577,12 +594,14 @@ impl Instructions for Sm83 {
         Ok(op.cycles)
     }
 
+    #[cfg_attr(target_arch = "arm", link_section = ".data")]
     fn cp8(&mut self, op: &Cp8, memory: &mut GameBoyMemory) -> Result<u8, InstructionError> {
         let val = self.get_operand8(&op.operand, memory);
         self.registers.f = cp_u8(self.registers.a, val);
         Ok(op.cycles)
     }
 
+    #[cfg_attr(target_arch = "arm", link_section = ".data")]
     fn ld8(&mut self, op: &Ld8, memory: &mut GameBoyMemory) -> Result<u8, InstructionError> {
         if op.src == Operand::Imm8 {
             let val = self.fetch_byte(memory);
@@ -606,6 +625,7 @@ impl Instructions for Sm83 {
         Ok(op.cycles)
     }
 
+    #[cfg_attr(target_arch = "arm", link_section = ".data")]
     fn ld16(&mut self, op: &Ld16, memory: &mut GameBoyMemory) -> Result<u8, InstructionError> {
         match &op.op {
             Ld16Op::RrImm16 { dest } => {
@@ -698,6 +718,7 @@ impl Instructions for Sm83 {
         Ok(op.cycles)
     }
 
+    #[cfg_attr(target_arch = "arm", link_section = ".data")]
     fn inc8(&mut self, op: &Inc8, memory: &mut GameBoyMemory) -> Result<u8, InstructionError> {
         match &op.operand {
             Operand::Register8(r) => {
@@ -721,6 +742,7 @@ impl Instructions for Sm83 {
         Ok(op.cycles)
     }
 
+    #[cfg_attr(target_arch = "arm", link_section = ".data")]
     fn dec8(&mut self, op: &Dec8, memory: &mut GameBoyMemory) -> Result<u8, InstructionError> {
         match &op.operand {
             Operand::Register8(r) => {
@@ -744,18 +766,21 @@ impl Instructions for Sm83 {
         Ok(op.cycles)
     }
 
+    #[cfg_attr(target_arch = "arm", link_section = ".data")]
     fn inc16(&mut self, op: &Inc16) -> Result<u8, InstructionError> {
         let v = self.get_r16_enum(op.operand);
         self.set_r16_enum(op.operand, v.wrapping_add(1));
         Ok(op.cycles)
     }
 
+    #[cfg_attr(target_arch = "arm", link_section = ".data")]
     fn dec16(&mut self, op: &Dec16) -> Result<u8, InstructionError> {
         let v = self.get_r16_enum(op.operand);
         self.set_r16_enum(op.operand, v.wrapping_sub(1));
         Ok(op.cycles)
     }
 
+    #[cfg_attr(target_arch = "arm", link_section = ".data")]
     fn rotate_accumulator(&mut self, op: &Rotate) -> Result<u8, InstructionError> {
         let a = self.registers.a;
         let carry = self.registers.f.contains(Flags::C);
@@ -784,6 +809,7 @@ impl Instructions for Sm83 {
         Ok(op.cycles)
     }
 
+    #[cfg_attr(target_arch = "arm", link_section = ".data")]
     fn and8(&mut self, op: &And8, memory: &mut GameBoyMemory) -> Result<u8, InstructionError> {
         let val = self.get_operand8(&op.operand, memory);
         let (r, f) = and_u8(self.registers.a, val);
@@ -792,6 +818,7 @@ impl Instructions for Sm83 {
         Ok(op.cycles)
     }
 
+    #[cfg_attr(target_arch = "arm", link_section = ".data")]
     fn or8(&mut self, op: &Or8, memory: &mut GameBoyMemory) -> Result<u8, InstructionError> {
         let val = self.get_operand8(&op.operand, memory);
         let (r, f) = or_u8(self.registers.a, val);
@@ -800,6 +827,7 @@ impl Instructions for Sm83 {
         Ok(op.cycles)
     }
 
+    #[cfg_attr(target_arch = "arm", link_section = ".data")]
     fn xor8(&mut self, op: &Xor8, memory: &mut GameBoyMemory) -> Result<u8, InstructionError> {
         let val = self.get_operand8(&op.operand, memory);
         let (r, f) = xor_u8(self.registers.a, val);
@@ -808,6 +836,7 @@ impl Instructions for Sm83 {
         Ok(op.cycles)
     }
 
+    #[cfg_attr(target_arch = "arm", link_section = ".data")]
     fn jump(&mut self, op: &Jump, memory: &mut GameBoyMemory) -> Result<u8, InstructionError> {
         match &op.op {
             JumpOp::Jp => {
@@ -843,6 +872,7 @@ impl Instructions for Sm83 {
         Ok(op.cycles)
     }
 
+    #[cfg_attr(target_arch = "arm", link_section = ".data")]
     fn misc(&mut self, op: &Misc) -> Result<u8, InstructionError> {
         match op.op {
             MiscOp::Nop => {}
@@ -881,6 +911,7 @@ impl Instructions for Sm83 {
         Ok(op.cycles)
     }
 
+    #[cfg_attr(target_arch = "arm", link_section = ".data")]
     fn push16(&mut self, op: &Push16, memory: &mut GameBoyMemory) -> Result<u8, InstructionError> {
         let idx = match op.operand {
             Register16::BC => 0,
@@ -894,6 +925,7 @@ impl Instructions for Sm83 {
         Ok(op.cycles)
     }
 
+    #[cfg_attr(target_arch = "arm", link_section = ".data")]
     fn pop16(&mut self, op: &Pop16, memory: &mut GameBoyMemory) -> Result<u8, InstructionError> {
         let val = self.pop16_inner(memory);
         let idx = match op.operand {
@@ -907,6 +939,7 @@ impl Instructions for Sm83 {
         Ok(op.cycles)
     }
 
+    #[cfg_attr(target_arch = "arm", link_section = ".data")]
     fn call(&mut self, op: &Call, memory: &mut GameBoyMemory) -> Result<u8, InstructionError> {
         let lo = self.fetch_byte(memory);
         let hi = self.fetch_byte(memory);
@@ -925,6 +958,7 @@ impl Instructions for Sm83 {
         }
     }
 
+    #[cfg_attr(target_arch = "arm", link_section = ".data")]
     fn ret(&mut self, op: &Ret, memory: &mut GameBoyMemory) -> Result<u8, InstructionError> {
         match &op.op {
             RetOp::Ret => {
@@ -948,6 +982,7 @@ impl Instructions for Sm83 {
         Ok(op.cycles)
     }
 
+    #[cfg_attr(target_arch = "arm", link_section = ".data")]
     fn rst(&mut self, op: &Rst, memory: &mut GameBoyMemory) -> Result<u8, InstructionError> {
         let ret = self.registers.pc;
         self.push16_inner(ret, memory);
@@ -955,6 +990,7 @@ impl Instructions for Sm83 {
         Ok(op.cycles)
     }
 
+    #[cfg_attr(target_arch = "arm", link_section = ".data")]
     fn cb(
         &mut self,
         op: &CbInstruction,

--- a/platform/pico2w/src/main.rs
+++ b/platform/pico2w/src/main.rs
@@ -338,11 +338,7 @@ async fn main(_spawner: Spawner) {
 
                 #[cfg(feature = "fps")]
                 {
-                    let profile = gameboy
-                        .as_mut()
-                        .expect("Running without GameBoy")
-                        .take_transport_profile();
-                    tracker.tick(profile);
+                    tracker.tick();
                 }
             }
 

--- a/platform/pico2w/src/main.rs
+++ b/platform/pico2w/src/main.rs
@@ -337,7 +337,13 @@ async fn main(_spawner: Spawner) {
                     .await;
 
                 #[cfg(feature = "fps")]
-                tracker.tick();
+                {
+                    let profile = gameboy
+                        .as_mut()
+                        .expect("Running without GameBoy")
+                        .take_transport_profile();
+                    tracker.tick(profile);
+                }
             }
 
             AppState::InGameMenu(menu_state) => {

--- a/platform/pico2w/src/main.rs
+++ b/platform/pico2w/src/main.rs
@@ -337,9 +337,7 @@ async fn main(_spawner: Spawner) {
                     .await;
 
                 #[cfg(feature = "fps")]
-                {
-                    tracker.tick();
-                }
+                tracker.tick();
             }
 
             AppState::InGameMenu(menu_state) => {

--- a/platform/pico2w/src/multicore.rs
+++ b/platform/pico2w/src/multicore.rs
@@ -452,10 +452,10 @@ struct Core1Transport {
     audio_rx: &'static MpMcQueue<i16, AUDIO_QUEUE_CAPACITY>,
     shared: &'static SharedWorkerState,
     lcd_timing: LcdTiming,
-    timing_io: [u8; 0x80],
-    pending_timing_cycles: u16,
-    timing_if_bits: u8,
-    timing_frame_ready: bool,
+    lcd_timing_io: [u8; 0x80],
+    pending_lcd_timing_cycles: u16,
+    lcd_timing_if_bits: u8,
+    lcd_timing_frame_ready: bool,
     pending_apu: Option<PendingApuAdvance>,
     pending_ppu: Option<PendingPpuAdvance>,
     next_ticket: u32,
@@ -490,10 +490,10 @@ impl Core1Transport {
             audio_rx,
             shared,
             lcd_timing: LcdTiming::new(),
-            timing_io: [0; 0x80],
-            pending_timing_cycles: 0,
-            timing_if_bits: 0,
-            timing_frame_ready: false,
+            lcd_timing_io: [0; 0x80],
+            pending_lcd_timing_cycles: 0,
+            lcd_timing_if_bits: 0,
+            lcd_timing_frame_ready: false,
             pending_apu: None,
             pending_ppu: None,
             next_ticket: 1,
@@ -522,77 +522,77 @@ impl Core1Transport {
 
     #[cfg_attr(target_arch = "arm", link_section = ".data")]
     #[inline(always)]
-    fn advance_timing_ppu(&mut self, cycles: u16) {
-        let mut cycles = self.pending_timing_cycles as u32 + cycles as u32;
+    fn advance_lcd_timing(&mut self, cycles: u16) {
+        let mut cycles = self.pending_lcd_timing_cycles as u32 + cycles as u32;
         if cycles < LCD_TIMING_BATCH_CYCLES as u32 {
-            self.pending_timing_cycles = cycles as u16;
+            self.pending_lcd_timing_cycles = cycles as u16;
             return;
         }
         while cycles >= LCD_TIMING_BATCH_CYCLES as u32 {
-            self.tick_timing_ppu(LCD_TIMING_BATCH_CYCLES);
+            self.tick_lcd_timing(LCD_TIMING_BATCH_CYCLES);
             cycles -= LCD_TIMING_BATCH_CYCLES as u32;
         }
-        self.pending_timing_cycles = cycles as u16;
+        self.pending_lcd_timing_cycles = cycles as u16;
     }
 
     #[cfg_attr(target_arch = "arm", link_section = ".data")]
     #[inline(always)]
-    fn flush_pending_timing_ppu(&mut self) {
-        let pending = self.pending_timing_cycles;
+    fn flush_pending_lcd_timing(&mut self) {
+        let pending = self.pending_lcd_timing_cycles;
         if pending == 0 {
             return;
         }
-        self.pending_timing_cycles = 0;
-        self.tick_timing_ppu(pending);
+        self.pending_lcd_timing_cycles = 0;
+        self.tick_lcd_timing(pending);
     }
 
     #[cfg_attr(target_arch = "arm", link_section = ".data")]
     #[inline(always)]
-    fn tick_timing_ppu(&mut self, cycles: u16) {
-        let output = self.lcd_timing.tick(cycles, &mut self.timing_io);
+    fn tick_lcd_timing(&mut self, cycles: u16) {
+        let output = self.lcd_timing.tick(cycles, &mut self.lcd_timing_io);
         if output.vblank_interrupt {
-            self.timing_if_bits |= 1 << VBLANK_INTERRUPT_BIT;
-            self.timing_frame_ready = true;
+            self.lcd_timing_if_bits |= 1 << VBLANK_INTERRUPT_BIT;
+            self.lcd_timing_frame_ready = true;
         }
         if output.stat_interrupt {
-            self.timing_if_bits |= 1 << STAT_INTERRUPT_BIT;
+            self.lcd_timing_if_bits |= 1 << STAT_INTERRUPT_BIT;
         }
     }
 
     #[cfg_attr(target_arch = "arm", link_section = ".data")]
     #[inline(always)]
-    fn write_timing_ppu_register(&mut self, addr: u16, value: u8) {
+    fn write_lcd_timing_register(&mut self, addr: u16, value: u8) {
         if !(IO_REG_BASE..=IO_REG_END).contains(&addr) {
             return;
         }
-        self.flush_pending_timing_ppu();
+        self.flush_pending_lcd_timing();
         if addr == LY_ADDR {
             self.lcd_timing.reset_ly();
-            self.timing_io[(LY_ADDR - IO_REG_BASE) as usize] = 0;
+            self.lcd_timing_io[(LY_ADDR - IO_REG_BASE) as usize] = 0;
             return;
         }
-        self.timing_io[(addr - IO_REG_BASE) as usize] = value;
+        self.lcd_timing_io[(addr - IO_REG_BASE) as usize] = value;
     }
 
-    fn sync_timing_ppu_state(&mut self, io: &[u8]) {
+    fn sync_lcd_timing_state(&mut self, io: &[u8]) {
         self.lcd_timing = LcdTiming::new();
-        self.timing_io.copy_from_slice(&io[..0x80]);
-        self.lcd_timing.sync_prev_stat_line(&self.timing_io);
-        self.timing_io[(LY_ADDR - IO_REG_BASE) as usize] = self.lcd_timing.ly();
-        self.pending_timing_cycles = 0;
-        self.timing_if_bits = 0;
-        self.timing_frame_ready = false;
+        self.lcd_timing_io.copy_from_slice(&io[..0x80]);
+        self.lcd_timing.sync_prev_stat_line(&self.lcd_timing_io);
+        self.lcd_timing_io[(LY_ADDR - IO_REG_BASE) as usize] = self.lcd_timing.ly();
+        self.pending_lcd_timing_cycles = 0;
+        self.lcd_timing_if_bits = 0;
+        self.lcd_timing_frame_ready = false;
     }
 
-    fn load_timing_ppu_state(&mut self, state: PpuState, io: &[u8]) {
+    fn load_lcd_timing_state(&mut self, state: PpuState, io: &[u8]) {
         self.lcd_timing.load_state(state);
-        self.timing_io.copy_from_slice(&io[..0x80]);
-        self.lcd_timing.sync_prev_stat_line(&self.timing_io);
-        self.timing_io[(LY_ADDR - IO_REG_BASE) as usize] = state.ly;
-        self.timing_io[(STAT_ADDR - IO_REG_BASE) as usize] = state.stat;
-        self.pending_timing_cycles = 0;
-        self.timing_if_bits = 0;
-        self.timing_frame_ready = false;
+        self.lcd_timing_io.copy_from_slice(&io[..0x80]);
+        self.lcd_timing.sync_prev_stat_line(&self.lcd_timing_io);
+        self.lcd_timing_io[(LY_ADDR - IO_REG_BASE) as usize] = state.ly;
+        self.lcd_timing_io[(STAT_ADDR - IO_REG_BASE) as usize] = state.stat;
+        self.pending_lcd_timing_cycles = 0;
+        self.lcd_timing_if_bits = 0;
+        self.lcd_timing_frame_ready = false;
     }
 
     #[cfg_attr(target_arch = "arm", link_section = ".data")]
@@ -715,7 +715,7 @@ impl WorkerTransport for Core1Transport {
                 div_counter,
             } => self.queue_pending_apu(cycles, div_counter),
             WorkerCommand::AdvancePpu { cycles } => {
-                self.advance_timing_ppu(cycles);
+                self.advance_lcd_timing(cycles);
                 self.queue_pending_ppu(cycles);
             }
             WorkerCommand::WriteApuRegister { .. } | WorkerCommand::WriteWaveRam { .. } => {
@@ -723,7 +723,7 @@ impl WorkerTransport for Core1Transport {
                 self.enqueue_blocking(Core1Command::Worker(command));
             }
             WorkerCommand::WritePpuRegister { addr, value } => {
-                self.write_timing_ppu_register(addr, value);
+                self.write_lcd_timing_register(addr, value);
                 self.flush_pending_ppu();
                 self.enqueue_blocking(Core1Command::Worker(WorkerCommand::WritePpuRegister {
                     addr,
@@ -759,7 +759,7 @@ impl WorkerTransport for Core1Transport {
     #[cfg_attr(target_arch = "arm", link_section = ".data")]
     #[inline(always)]
     fn write_ppu_register(&mut self, addr: u16, value: u8) {
-        self.write_timing_ppu_register(addr, value);
+        self.write_lcd_timing_register(addr, value);
         self.flush_pending_ppu();
         self.enqueue_blocking(Core1Command::Worker(WorkerCommand::WritePpuRegister {
             addr,
@@ -775,7 +775,7 @@ impl WorkerTransport for Core1Transport {
         }
         self.flush_pending_ppu();
         for &(addr, value) in regs {
-            self.write_timing_ppu_register(addr, value);
+            self.write_lcd_timing_register(addr, value);
             self.enqueue_blocking(Core1Command::Worker(WorkerCommand::WritePpuRegister {
                 addr,
                 value,
@@ -829,7 +829,7 @@ impl WorkerTransport for Core1Transport {
 
     fn sync_ppu_state(&mut self, io: &[u8], vram: &[u8], oam: &[u8]) {
         self.flush_pending_ppu();
-        self.sync_timing_ppu_state(io);
+        self.sync_lcd_timing_state(io);
         critical_section::with(|cs| {
             let mut snapshots = self.shared.sync_snapshot.borrow(cs).borrow_mut();
             snapshots.io.copy_from_slice(&io[..0x80]);
@@ -846,7 +846,7 @@ impl WorkerTransport for Core1Transport {
 
     fn load_ppu_state(&mut self, state: PpuState, io: &[u8], vram: &[u8], oam: &[u8]) {
         self.flush_pending_ppu();
-        self.load_timing_ppu_state(state, io);
+        self.load_lcd_timing_state(state, io);
         critical_section::with(|cs| {
             let mut snapshots = self.shared.sync_snapshot.borrow(cs).borrow_mut();
             snapshots.io.copy_from_slice(&io[..0x80]);
@@ -862,7 +862,7 @@ impl WorkerTransport for Core1Transport {
     }
 
     fn snapshot_ppu_state(&self, _io: &[u8]) -> PpuState {
-        self.lcd_timing.to_save_state(&self.timing_io)
+        self.lcd_timing.to_save_state(&self.lcd_timing_io)
     }
 
     fn poll_output(&mut self, out: &mut [u8; FRAMEBUFFER_SIZE]) -> WorkerOutput {
@@ -873,16 +873,16 @@ impl WorkerTransport for Core1Transport {
             self.last_frame_seq = frame_seq;
         }
         let _worker_if_bits = self.shared.pending_if_bits.swap(0, Ordering::AcqRel);
-        let if_bits = self.timing_if_bits;
-        self.timing_if_bits = 0;
-        let timing_frame_ready = self.timing_frame_ready;
-        self.timing_frame_ready = false;
+        let if_bits = self.lcd_timing_if_bits;
+        self.lcd_timing_if_bits = 0;
+        let lcd_timing_frame_ready = self.lcd_timing_frame_ready;
+        self.lcd_timing_frame_ready = false;
         WorkerOutput {
             apu_nr52: self.shared.apu_nr52.load(Ordering::Acquire),
-            ppu_ly: self.timing_io[(LY_ADDR - IO_REG_BASE) as usize],
-            ppu_stat: self.timing_io[(STAT_ADDR - IO_REG_BASE) as usize],
+            ppu_ly: self.lcd_timing_io[(LY_ADDR - IO_REG_BASE) as usize],
+            ppu_stat: self.lcd_timing_io[(STAT_ADDR - IO_REG_BASE) as usize],
             if_bits,
-            frame_ready: frame_ready || timing_frame_ready,
+            frame_ready: frame_ready || lcd_timing_frame_ready,
         }
     }
 }

--- a/platform/pico2w/src/multicore.rs
+++ b/platform/pico2w/src/multicore.rs
@@ -15,7 +15,7 @@ use embassy_rp::Peri;
 use heapless::mpmc::MpMcQueue;
 use rustyboy_core::cpu::cpu::CpuError;
 use rustyboy_core::cpu::peripheral::joypad::Button;
-use rustyboy_core::cpu::peripheral::ppu::FRAMEBUFFER_SIZE;
+use rustyboy_core::cpu::peripheral::ppu::{PpuMode, FRAMEBUFFER_SIZE};
 use rustyboy_core::cpu::registers::{Flags, Registers};
 use rustyboy_core::cpu::save_state::{PpuState, SaveState};
 use rustyboy_core::gameboy::GameBoy;
@@ -29,10 +29,32 @@ use crate::stack_probe;
 const CORE1_STACK_SIZE: usize = 8192;
 const COMMAND_QUEUE_CAPACITY: usize = 512;
 const AUDIO_QUEUE_CAPACITY: usize = 2048;
-const PPU_ADVANCE_BATCH_CYCLES: u16 = 912;
+const PPU_ADVANCE_BATCH_CYCLES: u16 = 456;
+const TIMING_PPU_BATCH_CYCLES: u16 = 80;
 const SCALED_FRAME_SLOT_COUNT: usize = 3;
 const IO_REG_BASE: u16 = 0xFF00;
 const IO_REG_END: u16 = 0xFF7F;
+const STAT_ADDR: u16 = 0xFF41;
+const LY_ADDR: u16 = 0xFF44;
+const VBLANK_INTERRUPT_BIT: u8 = 0;
+const STAT_INTERRUPT_BIT: u8 = 1;
+const LCDC_IO: usize = 0x40;
+const STAT_IO: usize = 0x41;
+const SCY_IO: usize = 0x42;
+const SCX_IO: usize = 0x43;
+const LY_IO: usize = 0x44;
+const LYC_IO: usize = 0x45;
+const BGP_IO: usize = 0x47;
+const OBP0_IO: usize = 0x48;
+const OBP1_IO: usize = 0x49;
+const WY_IO: usize = 0x4A;
+const WX_IO: usize = 0x4B;
+const DOTS_PER_SCANLINE: u16 = 456;
+const OAM_SCAN_DOTS: u16 = 80;
+const PIXEL_TRANSFER_DOTS: u16 = 172;
+const VISIBLE_SCANLINES: u8 = 144;
+const TOTAL_SCANLINES: u8 = 154;
+const SCREEN_HEIGHT: u8 = 144;
 
 static SHARED_WORKER_STATE: SharedWorkerState = SharedWorkerState::new();
 static COMMAND_QUEUE: MpMcQueue<Core1Command, COMMAND_QUEUE_CAPACITY> = MpMcQueue::new();
@@ -139,7 +161,6 @@ struct SharedWorkerState {
     ppu_stat: AtomicU8,
     pending_if_bits: AtomicU8,
     ppu_render_version: AtomicU32,
-    ppu_state: Mutex<RefCell<PpuState>>,
 }
 
 impl SharedWorkerState {
@@ -166,22 +187,6 @@ impl SharedWorkerState {
             ppu_stat: AtomicU8::new(0),
             pending_if_bits: AtomicU8::new(0),
             ppu_render_version: AtomicU32::new(0),
-            ppu_state: Mutex::new(RefCell::new(PpuState {
-                dot: 0,
-                ly: 0,
-                mode: rustyboy_core::cpu::peripheral::ppu::PpuMode::OamScan,
-                window_line_counter: 0,
-                lcdc: 0,
-                stat: 0,
-                scy: 0,
-                scx: 0,
-                lyc: 0,
-                bgp: 0,
-                obp0: 0,
-                obp1: 0,
-                wy: 0,
-                wx: 0,
-            })),
         }
     }
 
@@ -262,19 +267,186 @@ impl SharedWorkerState {
         });
         self.ppu_render_version.fetch_add(1, Ordering::AcqRel);
     }
+}
 
-    fn write_live_ppu_register(&self, addr: u16, value: u8) {
-        if !(IO_REG_BASE..=IO_REG_END).contains(&addr) {
-            return;
+#[derive(Clone, Copy)]
+struct TimingPpuOutput {
+    vblank_interrupt: bool,
+    stat_interrupt: bool,
+}
+
+/// Core 0 only needs CPU-visible LCD timing. Keeping this tiny mirror here
+/// avoids allocating a full framebuffer just to make LY/STAT synchronous.
+#[derive(Clone, Copy)]
+struct TimingPpu {
+    dot: u16,
+    ly: u8,
+    mode: PpuMode,
+    window_line_counter: u8,
+    prev_stat_line: bool,
+}
+
+impl TimingPpu {
+    const fn new() -> Self {
+        Self {
+            dot: 0,
+            ly: 0,
+            mode: PpuMode::OamScan,
+            window_line_counter: 0,
+            prev_stat_line: false,
         }
-        critical_section::with(|cs| {
-            self.live_ppu_snapshot.borrow(cs).borrow_mut().io[(addr - IO_REG_BASE) as usize] =
-                value;
-        });
     }
 
-    fn snapshot_ppu_state(&self) -> PpuState {
-        critical_section::with(|cs| *self.ppu_state.borrow(cs).borrow())
+    fn ly(&self) -> u8 {
+        self.ly
+    }
+
+    fn reset_ly(&mut self) {
+        self.ly = 0;
+    }
+
+    fn sync_prev_stat_line(&mut self, io: &[u8]) {
+        let lyc = io[LYC_IO];
+        let stat = io[STAT_IO];
+        let lyc_match = self.ly == lyc;
+        self.prev_stat_line = (lyc_match && (stat & 0x40 != 0))
+            || (self.mode == PpuMode::HBlank && (stat & 0x08 != 0))
+            || (self.mode == PpuMode::VBlank && (stat & 0x10 != 0))
+            || (self.mode == PpuMode::OamScan && (stat & 0x20 != 0));
+    }
+
+    fn load_state(&mut self, state: PpuState) {
+        self.dot = state.dot;
+        self.ly = state.ly;
+        self.mode = state.mode;
+        self.window_line_counter = state.window_line_counter;
+    }
+
+    fn to_save_state(&self, io: &[u8]) -> PpuState {
+        PpuState {
+            dot: self.dot,
+            ly: self.ly,
+            mode: self.mode,
+            window_line_counter: self.window_line_counter,
+            lcdc: io[LCDC_IO],
+            stat: io[STAT_IO],
+            scy: io[SCY_IO],
+            scx: io[SCX_IO],
+            lyc: io[LYC_IO],
+            bgp: io[BGP_IO],
+            obp0: io[OBP0_IO],
+            obp1: io[OBP1_IO],
+            wy: io[WY_IO],
+            wx: io[WX_IO],
+        }
+    }
+
+    #[cfg_attr(target_arch = "arm", link_section = ".data")]
+    fn tick(&mut self, cycles: u16, io: &mut [u8]) -> TimingPpuOutput {
+        if io[LCDC_IO] & 0x80 == 0 {
+            self.reset_lcd(io);
+            return TimingPpuOutput {
+                vblank_interrupt: false,
+                stat_interrupt: false,
+            };
+        }
+
+        let mut vblank_interrupt = false;
+        let mut remaining = cycles;
+
+        while remaining > 0 {
+            let threshold = match self.mode {
+                PpuMode::OamScan => OAM_SCAN_DOTS,
+                PpuMode::PixelTransfer => OAM_SCAN_DOTS + PIXEL_TRANSFER_DOTS,
+                PpuMode::HBlank | PpuMode::VBlank => DOTS_PER_SCANLINE,
+            };
+            let dots_to_threshold = threshold.saturating_sub(self.dot);
+
+            if dots_to_threshold > 0 && remaining < dots_to_threshold {
+                self.dot += remaining;
+                break;
+            }
+
+            self.dot += dots_to_threshold;
+            remaining -= dots_to_threshold;
+
+            match self.mode {
+                PpuMode::OamScan => {
+                    self.mode = PpuMode::PixelTransfer;
+                }
+                PpuMode::PixelTransfer => {
+                    self.mode = PpuMode::HBlank;
+                    if self.window_participates_on_current_line(io) {
+                        self.window_line_counter = self.window_line_counter.wrapping_add(1);
+                    }
+                }
+                PpuMode::HBlank => {
+                    self.dot = 0;
+                    self.ly += 1;
+                    if self.ly >= VISIBLE_SCANLINES {
+                        self.mode = PpuMode::VBlank;
+                        vblank_interrupt = true;
+                    } else {
+                        self.mode = PpuMode::OamScan;
+                    }
+                }
+                PpuMode::VBlank => {
+                    self.dot = 0;
+                    self.ly += 1;
+                    if self.ly >= TOTAL_SCANLINES {
+                        self.ly = 0;
+                        self.mode = PpuMode::OamScan;
+                        self.window_line_counter = 0;
+                    }
+                }
+            }
+        }
+
+        let stat_interrupt = self.build_stat(io);
+        io[LY_IO] = self.ly;
+
+        TimingPpuOutput {
+            vblank_interrupt,
+            stat_interrupt,
+        }
+    }
+
+    #[cfg_attr(target_arch = "arm", link_section = ".data")]
+    fn reset_lcd(&mut self, io: &mut [u8]) {
+        self.dot = 0;
+        self.ly = 0;
+        self.mode = PpuMode::HBlank;
+        self.window_line_counter = 0;
+        self.prev_stat_line = false;
+        io[LY_IO] = 0;
+        io[STAT_IO] = (io[STAT_IO] & 0x78) | (PpuMode::HBlank as u8);
+    }
+
+    #[cfg_attr(target_arch = "arm", link_section = ".data")]
+    fn build_stat(&mut self, io: &mut [u8]) -> bool {
+        let lyc = io[LYC_IO];
+        let lyc_match = self.ly == lyc;
+        let new_stat =
+            (io[STAT_IO] & 0x78) | if lyc_match { 0x04 } else { 0x00 } | (self.mode as u8);
+        io[STAT_IO] = new_stat;
+
+        let stat_line = (lyc_match && (new_stat & 0x40 != 0))
+            || (self.mode == PpuMode::HBlank && (new_stat & 0x08 != 0))
+            || (self.mode == PpuMode::VBlank && (new_stat & 0x10 != 0))
+            || (self.mode == PpuMode::OamScan && (new_stat & 0x20 != 0));
+
+        let interrupt = stat_line && !self.prev_stat_line;
+        self.prev_stat_line = stat_line;
+        interrupt
+    }
+
+    fn window_participates_on_current_line(&self, io: &[u8]) -> bool {
+        let lcdc = io[LCDC_IO];
+        lcdc & 0x20 != 0
+            && lcdc & 0x01 != 0
+            && self.ly < SCREEN_HEIGHT
+            && self.ly >= io[WY_IO]
+            && io[WX_IO] <= 166
     }
 }
 
@@ -293,6 +465,11 @@ struct Core1Transport {
     command_tx: &'static MpMcQueue<Core1Command, COMMAND_QUEUE_CAPACITY>,
     audio_rx: &'static MpMcQueue<i16, AUDIO_QUEUE_CAPACITY>,
     shared: &'static SharedWorkerState,
+    timing_ppu: TimingPpu,
+    timing_io: [u8; 0x80],
+    pending_timing_cycles: u16,
+    timing_if_bits: u8,
+    timing_frame_ready: bool,
     pending_apu: Option<PendingApuAdvance>,
     pending_ppu: Option<PendingPpuAdvance>,
     next_ticket: u32,
@@ -328,6 +505,11 @@ impl Core1Transport {
             command_tx,
             audio_rx,
             shared,
+            timing_ppu: TimingPpu::new(),
+            timing_io: [0; 0x80],
+            pending_timing_cycles: 0,
+            timing_if_bits: 0,
+            timing_frame_ready: false,
             pending_apu: None,
             pending_ppu: None,
             next_ticket: 1,
@@ -358,6 +540,81 @@ impl Core1Transport {
                 }
             }
         }
+    }
+
+    #[cfg_attr(target_arch = "arm", link_section = ".data")]
+    #[inline(always)]
+    fn advance_timing_ppu(&mut self, cycles: u16) {
+        let mut cycles = self.pending_timing_cycles as u32 + cycles as u32;
+        if cycles < TIMING_PPU_BATCH_CYCLES as u32 {
+            self.pending_timing_cycles = cycles as u16;
+            return;
+        }
+        while cycles >= TIMING_PPU_BATCH_CYCLES as u32 {
+            self.advance_timing_ppu_now(TIMING_PPU_BATCH_CYCLES);
+            cycles -= TIMING_PPU_BATCH_CYCLES as u32;
+        }
+        self.pending_timing_cycles = cycles as u16;
+    }
+
+    #[cfg_attr(target_arch = "arm", link_section = ".data")]
+    #[inline(always)]
+    fn flush_pending_timing_ppu(&mut self) {
+        let pending = self.pending_timing_cycles;
+        if pending == 0 {
+            return;
+        }
+        self.pending_timing_cycles = 0;
+        self.advance_timing_ppu_now(pending);
+    }
+
+    #[cfg_attr(target_arch = "arm", link_section = ".data")]
+    #[inline(always)]
+    fn advance_timing_ppu_now(&mut self, cycles: u16) {
+        let output = self.timing_ppu.tick(cycles, &mut self.timing_io);
+        if output.vblank_interrupt {
+            self.timing_if_bits |= 1 << VBLANK_INTERRUPT_BIT;
+            self.timing_frame_ready = true;
+        }
+        if output.stat_interrupt {
+            self.timing_if_bits |= 1 << STAT_INTERRUPT_BIT;
+        }
+    }
+
+    #[cfg_attr(target_arch = "arm", link_section = ".data")]
+    #[inline(always)]
+    fn write_timing_ppu_register(&mut self, addr: u16, value: u8) {
+        if !(IO_REG_BASE..=IO_REG_END).contains(&addr) {
+            return;
+        }
+        self.flush_pending_timing_ppu();
+        if addr == LY_ADDR {
+            self.timing_ppu.reset_ly();
+            self.timing_io[(LY_ADDR - IO_REG_BASE) as usize] = 0;
+            return;
+        }
+        self.timing_io[(addr - IO_REG_BASE) as usize] = value;
+    }
+
+    fn sync_timing_ppu_state(&mut self, io: &[u8]) {
+        self.timing_ppu = TimingPpu::new();
+        self.timing_io.copy_from_slice(&io[..0x80]);
+        self.timing_ppu.sync_prev_stat_line(&self.timing_io);
+        self.timing_io[(LY_ADDR - IO_REG_BASE) as usize] = self.timing_ppu.ly();
+        self.pending_timing_cycles = 0;
+        self.timing_if_bits = 0;
+        self.timing_frame_ready = false;
+    }
+
+    fn load_timing_ppu_state(&mut self, state: PpuState, io: &[u8]) {
+        self.timing_ppu.load_state(state);
+        self.timing_io.copy_from_slice(&io[..0x80]);
+        self.timing_ppu.sync_prev_stat_line(&self.timing_io);
+        self.timing_io[(LY_ADDR - IO_REG_BASE) as usize] = state.ly;
+        self.timing_io[(STAT_ADDR - IO_REG_BASE) as usize] = state.stat;
+        self.pending_timing_cycles = 0;
+        self.timing_if_bits = 0;
+        self.timing_frame_ready = false;
     }
 
     #[cfg_attr(target_arch = "arm", link_section = ".data")]
@@ -494,18 +751,25 @@ impl WorkerTransport for Core1Transport {
                 cycles,
                 div_counter,
             } => self.queue_pending_apu(cycles, div_counter),
-            WorkerCommand::AdvancePpu { cycles } => self.queue_pending_ppu(cycles),
+            WorkerCommand::AdvancePpu { cycles } => {
+                self.advance_timing_ppu(cycles);
+                self.queue_pending_ppu(cycles);
+            }
             WorkerCommand::WriteApuRegister { .. } | WorkerCommand::WriteWaveRam { .. } => {
                 self.flush_pending_apu();
                 self.transport_profile.apu_commands =
                     self.transport_profile.apu_commands.wrapping_add(1);
                 self.enqueue_blocking(Core1Command::Worker(command));
             }
-            WorkerCommand::WritePpuRegister { .. } => {
+            WorkerCommand::WritePpuRegister { addr, value } => {
+                self.write_timing_ppu_register(addr, value);
                 self.flush_pending_ppu();
                 self.transport_profile.ppu_register_writes =
                     self.transport_profile.ppu_register_writes.wrapping_add(1);
-                self.enqueue_blocking(Core1Command::Worker(command));
+                self.enqueue_blocking(Core1Command::Worker(WorkerCommand::WritePpuRegister {
+                    addr,
+                    value,
+                }));
             }
             _ => {
                 self.enqueue_blocking(Core1Command::Worker(command));
@@ -544,8 +808,8 @@ impl WorkerTransport for Core1Transport {
     #[cfg_attr(target_arch = "arm", link_section = ".data")]
     #[inline(always)]
     fn write_ppu_register(&mut self, addr: u16, value: u8) {
+        self.write_timing_ppu_register(addr, value);
         self.flush_pending_ppu();
-        self.shared.write_live_ppu_register(addr, value);
         self.transport_profile.ppu_register_writes =
             self.transport_profile.ppu_register_writes.wrapping_add(1);
         self.enqueue_blocking(Core1Command::Worker(WorkerCommand::WritePpuRegister {
@@ -561,19 +825,12 @@ impl WorkerTransport for Core1Transport {
             return;
         }
         self.flush_pending_ppu();
-        critical_section::with(|cs| {
-            let mut snapshot = self.shared.live_ppu_snapshot.borrow(cs).borrow_mut();
-            for &(addr, value) in regs {
-                if (IO_REG_BASE..=IO_REG_END).contains(&addr) {
-                    snapshot.io[(addr - IO_REG_BASE) as usize] = value;
-                }
-            }
-        });
         self.transport_profile.ppu_register_writes = self
             .transport_profile
             .ppu_register_writes
             .wrapping_add(regs.len() as u32);
         for &(addr, value) in regs {
+            self.write_timing_ppu_register(addr, value);
             self.enqueue_blocking(Core1Command::Worker(WorkerCommand::WritePpuRegister {
                 addr,
                 value,
@@ -627,6 +884,7 @@ impl WorkerTransport for Core1Transport {
 
     fn sync_ppu_state(&mut self, io: &[u8], vram: &[u8], oam: &[u8]) {
         self.flush_pending_ppu();
+        self.sync_timing_ppu_state(io);
         critical_section::with(|cs| {
             let mut snapshots = self.shared.sync_snapshot.borrow(cs).borrow_mut();
             snapshots.io.copy_from_slice(&io[..0x80]);
@@ -644,6 +902,7 @@ impl WorkerTransport for Core1Transport {
 
     fn load_ppu_state(&mut self, state: PpuState, io: &[u8], vram: &[u8], oam: &[u8]) {
         self.flush_pending_ppu();
+        self.load_timing_ppu_state(state, io);
         critical_section::with(|cs| {
             let mut snapshots = self.shared.sync_snapshot.borrow(cs).borrow_mut();
             snapshots.io.copy_from_slice(&io[..0x80]);
@@ -660,7 +919,7 @@ impl WorkerTransport for Core1Transport {
     }
 
     fn snapshot_ppu_state(&self, _io: &[u8]) -> PpuState {
-        self.shared.snapshot_ppu_state()
+        self.timing_ppu.to_save_state(&self.timing_io)
     }
 
     fn poll_output(&mut self, out: &mut [u8; FRAMEBUFFER_SIZE]) -> WorkerOutput {
@@ -670,12 +929,17 @@ impl WorkerTransport for Core1Transport {
         if frame_ready {
             self.last_frame_seq = frame_seq;
         }
+        let _worker_if_bits = self.shared.pending_if_bits.swap(0, Ordering::AcqRel);
+        let if_bits = self.timing_if_bits;
+        self.timing_if_bits = 0;
+        let timing_frame_ready = self.timing_frame_ready;
+        self.timing_frame_ready = false;
         WorkerOutput {
             apu_nr52: self.shared.apu_nr52.load(Ordering::Acquire),
-            ppu_ly: self.shared.ppu_ly.load(Ordering::Acquire),
-            ppu_stat: self.shared.ppu_stat.load(Ordering::Acquire),
-            if_bits: self.shared.pending_if_bits.swap(0, Ordering::AcqRel),
-            frame_ready,
+            ppu_ly: self.timing_io[(LY_ADDR - IO_REG_BASE) as usize],
+            ppu_stat: self.timing_io[(STAT_ADDR - IO_REG_BASE) as usize],
+            if_bits,
+            frame_ready: frame_ready || timing_frame_ready,
         }
     }
 }
@@ -780,9 +1044,6 @@ fn publish_worker_state(shared: &'static SharedWorkerState, worker: &mut GameBoy
         shared.publish_frame(worker);
     }
     shared.publish_worker_output(state);
-    critical_section::with(|cs| {
-        *shared.ppu_state.borrow(cs).borrow_mut() = worker.snapshot_ppu_state();
-    });
 }
 
 #[cfg_attr(target_arch = "arm", link_section = ".data")]
@@ -807,7 +1068,11 @@ fn run_core1_worker(
 
         match command {
             Core1Command::Worker(worker_command) => {
-                if matches!(worker_command, WorkerCommand::AdvancePpu { .. }) {
+                let ppu_cycles = match worker_command {
+                    WorkerCommand::AdvancePpu { cycles } => cycles as u32,
+                    _ => 0,
+                };
+                if ppu_cycles != 0 {
                     let render_version = shared.ppu_render_version.load(Ordering::Acquire);
                     if render_version != last_ppu_render_version {
                         critical_section::with(|cs| {

--- a/platform/pico2w/src/multicore.rs
+++ b/platform/pico2w/src/multicore.rs
@@ -529,7 +529,7 @@ impl Core1Transport {
             return;
         }
         while cycles >= LCD_TIMING_BATCH_CYCLES as u32 {
-            self.advance_timing_ppu_now(LCD_TIMING_BATCH_CYCLES);
+            self.tick_timing_ppu(LCD_TIMING_BATCH_CYCLES);
             cycles -= LCD_TIMING_BATCH_CYCLES as u32;
         }
         self.pending_timing_cycles = cycles as u16;
@@ -543,12 +543,12 @@ impl Core1Transport {
             return;
         }
         self.pending_timing_cycles = 0;
-        self.advance_timing_ppu_now(pending);
+        self.tick_timing_ppu(pending);
     }
 
     #[cfg_attr(target_arch = "arm", link_section = ".data")]
     #[inline(always)]
-    fn advance_timing_ppu_now(&mut self, cycles: u16) {
+    fn tick_timing_ppu(&mut self, cycles: u16) {
         let output = self.lcd_timing.tick(cycles, &mut self.timing_io);
         if output.vblank_interrupt {
             self.timing_if_bits |= 1 << VBLANK_INTERRUPT_BIT;

--- a/platform/pico2w/src/multicore.rs
+++ b/platform/pico2w/src/multicore.rs
@@ -30,7 +30,7 @@ const CORE1_STACK_SIZE: usize = 8192;
 const COMMAND_QUEUE_CAPACITY: usize = 512;
 const AUDIO_QUEUE_CAPACITY: usize = 2048;
 const PPU_ADVANCE_BATCH_CYCLES: u16 = 456;
-const TIMING_PPU_BATCH_CYCLES: u16 = 80;
+const LCD_TIMING_BATCH_CYCLES: u16 = 80;
 const SCALED_FRAME_SLOT_COUNT: usize = 3;
 const IO_REG_BASE: u16 = 0xFF00;
 const IO_REG_END: u16 = 0xFF7F;
@@ -81,19 +81,6 @@ enum Core1Command {
     Halt {
         ticket: u32,
     },
-}
-
-#[derive(Clone, Copy, Default)]
-pub struct TransportProfile {
-    pub command_enqueues: u32,
-    pub command_queue_spins: u32,
-    pub apu_commands: u32,
-    pub ppu_advance_commands: u32,
-    pub frame_publishes: u32,
-    pub ppu_vram_bytes: u32,
-    pub ppu_oam_bytes: u32,
-    pub ppu_register_writes: u32,
-    pub audio_queue_drops: u32,
 }
 
 struct PpuSnapshot {
@@ -155,7 +142,6 @@ struct SharedWorkerState {
     published_frame: AtomicU8,
     published_frame_seq: AtomicU32,
     sync_complete: AtomicU32,
-    audio_queue_drops: AtomicU32,
     apu_nr52: AtomicU8,
     ppu_ly: AtomicU8,
     ppu_stat: AtomicU8,
@@ -181,7 +167,6 @@ impl SharedWorkerState {
             published_frame: AtomicU8::new(0),
             published_frame_seq: AtomicU32::new(0),
             sync_complete: AtomicU32::new(0),
-            audio_queue_drops: AtomicU32::new(0),
             apu_nr52: AtomicU8::new(0),
             ppu_ly: AtomicU8::new(0),
             ppu_stat: AtomicU8::new(0),
@@ -270,15 +255,16 @@ impl SharedWorkerState {
 }
 
 #[derive(Clone, Copy)]
-struct TimingPpuOutput {
+struct LcdTimingOutput {
     vblank_interrupt: bool,
     stat_interrupt: bool,
 }
 
-/// Core 0 only needs CPU-visible LCD timing. Keeping this tiny mirror here
-/// avoids allocating a full framebuffer just to make LY/STAT synchronous.
+/// Core 0 only needs the LCD timing state that the CPU can observe through
+/// LY, STAT, and LCD interrupts. Keeping this tiny mirror synchronous avoids
+/// waiting on the async renderer just to answer those reads correctly.
 #[derive(Clone, Copy)]
-struct TimingPpu {
+struct LcdTiming {
     dot: u16,
     ly: u8,
     mode: PpuMode,
@@ -286,7 +272,7 @@ struct TimingPpu {
     prev_stat_line: bool,
 }
 
-impl TimingPpu {
+impl LcdTiming {
     const fn new() -> Self {
         Self {
             dot: 0,
@@ -342,10 +328,10 @@ impl TimingPpu {
     }
 
     #[cfg_attr(target_arch = "arm", link_section = ".data")]
-    fn tick(&mut self, cycles: u16, io: &mut [u8]) -> TimingPpuOutput {
+    fn tick(&mut self, cycles: u16, io: &mut [u8]) -> LcdTimingOutput {
         if io[LCDC_IO] & 0x80 == 0 {
             self.reset_lcd(io);
-            return TimingPpuOutput {
+            return LcdTimingOutput {
                 vblank_interrupt: false,
                 stat_interrupt: false,
             };
@@ -405,7 +391,7 @@ impl TimingPpu {
         let stat_interrupt = self.build_stat(io);
         io[LY_IO] = self.ly;
 
-        TimingPpuOutput {
+        LcdTimingOutput {
             vblank_interrupt,
             stat_interrupt,
         }
@@ -465,7 +451,7 @@ struct Core1Transport {
     command_tx: &'static MpMcQueue<Core1Command, COMMAND_QUEUE_CAPACITY>,
     audio_rx: &'static MpMcQueue<i16, AUDIO_QUEUE_CAPACITY>,
     shared: &'static SharedWorkerState,
-    timing_ppu: TimingPpu,
+    lcd_timing: LcdTiming,
     timing_io: [u8; 0x80],
     pending_timing_cycles: u16,
     timing_if_bits: u8,
@@ -474,9 +460,7 @@ struct Core1Transport {
     pending_ppu: Option<PendingPpuAdvance>,
     next_ticket: u32,
     last_frame_seq: u32,
-    last_profile_frame_seq: u32,
     held_frame_slot: u8,
-    transport_profile: TransportProfile,
 }
 
 impl Core1Transport {
@@ -505,7 +489,7 @@ impl Core1Transport {
             command_tx,
             audio_rx,
             shared,
-            timing_ppu: TimingPpu::new(),
+            lcd_timing: LcdTiming::new(),
             timing_io: [0; 0x80],
             pending_timing_cycles: 0,
             timing_if_bits: 0,
@@ -514,9 +498,7 @@ impl Core1Transport {
             pending_ppu: None,
             next_ticket: 1,
             last_frame_seq: 0,
-            last_profile_frame_seq: 0,
             held_frame_slot: u8::MAX,
-            transport_profile: TransportProfile::default(),
         }
     }
 
@@ -527,15 +509,11 @@ impl Core1Transport {
         loop {
             match self.command_tx.enqueue(command) {
                 Ok(()) => {
-                    self.transport_profile.command_enqueues =
-                        self.transport_profile.command_enqueues.wrapping_add(1);
                     asm::sev();
                     return;
                 }
                 Err(returned) => {
                     command = returned;
-                    self.transport_profile.command_queue_spins =
-                        self.transport_profile.command_queue_spins.wrapping_add(1);
                     core::hint::spin_loop();
                 }
             }
@@ -546,13 +524,13 @@ impl Core1Transport {
     #[inline(always)]
     fn advance_timing_ppu(&mut self, cycles: u16) {
         let mut cycles = self.pending_timing_cycles as u32 + cycles as u32;
-        if cycles < TIMING_PPU_BATCH_CYCLES as u32 {
+        if cycles < LCD_TIMING_BATCH_CYCLES as u32 {
             self.pending_timing_cycles = cycles as u16;
             return;
         }
-        while cycles >= TIMING_PPU_BATCH_CYCLES as u32 {
-            self.advance_timing_ppu_now(TIMING_PPU_BATCH_CYCLES);
-            cycles -= TIMING_PPU_BATCH_CYCLES as u32;
+        while cycles >= LCD_TIMING_BATCH_CYCLES as u32 {
+            self.advance_timing_ppu_now(LCD_TIMING_BATCH_CYCLES);
+            cycles -= LCD_TIMING_BATCH_CYCLES as u32;
         }
         self.pending_timing_cycles = cycles as u16;
     }
@@ -571,7 +549,7 @@ impl Core1Transport {
     #[cfg_attr(target_arch = "arm", link_section = ".data")]
     #[inline(always)]
     fn advance_timing_ppu_now(&mut self, cycles: u16) {
-        let output = self.timing_ppu.tick(cycles, &mut self.timing_io);
+        let output = self.lcd_timing.tick(cycles, &mut self.timing_io);
         if output.vblank_interrupt {
             self.timing_if_bits |= 1 << VBLANK_INTERRUPT_BIT;
             self.timing_frame_ready = true;
@@ -589,7 +567,7 @@ impl Core1Transport {
         }
         self.flush_pending_timing_ppu();
         if addr == LY_ADDR {
-            self.timing_ppu.reset_ly();
+            self.lcd_timing.reset_ly();
             self.timing_io[(LY_ADDR - IO_REG_BASE) as usize] = 0;
             return;
         }
@@ -597,19 +575,19 @@ impl Core1Transport {
     }
 
     fn sync_timing_ppu_state(&mut self, io: &[u8]) {
-        self.timing_ppu = TimingPpu::new();
+        self.lcd_timing = LcdTiming::new();
         self.timing_io.copy_from_slice(&io[..0x80]);
-        self.timing_ppu.sync_prev_stat_line(&self.timing_io);
-        self.timing_io[(LY_ADDR - IO_REG_BASE) as usize] = self.timing_ppu.ly();
+        self.lcd_timing.sync_prev_stat_line(&self.timing_io);
+        self.timing_io[(LY_ADDR - IO_REG_BASE) as usize] = self.lcd_timing.ly();
         self.pending_timing_cycles = 0;
         self.timing_if_bits = 0;
         self.timing_frame_ready = false;
     }
 
     fn load_timing_ppu_state(&mut self, state: PpuState, io: &[u8]) {
-        self.timing_ppu.load_state(state);
+        self.lcd_timing.load_state(state);
         self.timing_io.copy_from_slice(&io[..0x80]);
-        self.timing_ppu.sync_prev_stat_line(&self.timing_io);
+        self.lcd_timing.sync_prev_stat_line(&self.timing_io);
         self.timing_io[(LY_ADDR - IO_REG_BASE) as usize] = state.ly;
         self.timing_io[(STAT_ADDR - IO_REG_BASE) as usize] = state.stat;
         self.pending_timing_cycles = 0;
@@ -621,8 +599,6 @@ impl Core1Transport {
     #[inline(always)]
     fn flush_pending_apu(&mut self) {
         if let Some(pending) = self.pending_apu.take() {
-            self.transport_profile.apu_commands =
-                self.transport_profile.apu_commands.wrapping_add(1);
             self.enqueue_blocking(Core1Command::Worker(WorkerCommand::AdvanceApu {
                 cycles: pending.cycles,
                 div_counter: pending.div_counter,
@@ -661,8 +637,6 @@ impl Core1Transport {
     #[inline(always)]
     fn flush_pending_ppu(&mut self) {
         if let Some(pending) = self.pending_ppu.take() {
-            self.transport_profile.ppu_advance_commands =
-                self.transport_profile.ppu_advance_commands.wrapping_add(1);
             self.enqueue_blocking(Core1Command::Worker(WorkerCommand::AdvancePpu {
                 cycles: pending.cycles,
             }));
@@ -685,8 +659,6 @@ impl Core1Transport {
             }
             None => {
                 if cycles >= PPU_ADVANCE_BATCH_CYCLES {
-                    self.transport_profile.ppu_advance_commands =
-                        self.transport_profile.ppu_advance_commands.wrapping_add(1);
                     self.enqueue_blocking(Core1Command::Worker(WorkerCommand::AdvancePpu {
                         cycles,
                     }));
@@ -707,15 +679,6 @@ impl Core1Transport {
         while self.shared.sync_complete.load(Ordering::Acquire) != ticket {
             core::hint::spin_loop();
         }
-    }
-
-    fn take_transport_profile(&mut self) -> TransportProfile {
-        let mut profile = core::mem::take(&mut self.transport_profile);
-        let frame_seq = self.shared.published_frame_seq.load(Ordering::Acquire);
-        profile.frame_publishes = frame_seq.wrapping_sub(self.last_profile_frame_seq);
-        self.last_profile_frame_seq = frame_seq;
-        profile.audio_queue_drops = self.shared.audio_queue_drops.swap(0, Ordering::AcqRel);
-        profile
     }
 
     fn published_scaled_frame(&mut self) -> &'static ScaledFrame {
@@ -757,15 +720,11 @@ impl WorkerTransport for Core1Transport {
             }
             WorkerCommand::WriteApuRegister { .. } | WorkerCommand::WriteWaveRam { .. } => {
                 self.flush_pending_apu();
-                self.transport_profile.apu_commands =
-                    self.transport_profile.apu_commands.wrapping_add(1);
                 self.enqueue_blocking(Core1Command::Worker(command));
             }
             WorkerCommand::WritePpuRegister { addr, value } => {
                 self.write_timing_ppu_register(addr, value);
                 self.flush_pending_ppu();
-                self.transport_profile.ppu_register_writes =
-                    self.transport_profile.ppu_register_writes.wrapping_add(1);
                 self.enqueue_blocking(Core1Command::Worker(WorkerCommand::WritePpuRegister {
                     addr,
                     value,
@@ -785,10 +744,6 @@ impl WorkerTransport for Core1Transport {
         }
         self.flush_pending_ppu();
         self.shared.write_live_vram_range(start_offset, data);
-        self.transport_profile.ppu_vram_bytes = self
-            .transport_profile
-            .ppu_vram_bytes
-            .wrapping_add(data.len() as u32);
     }
 
     #[cfg_attr(target_arch = "arm", link_section = ".data")]
@@ -799,10 +754,6 @@ impl WorkerTransport for Core1Transport {
         }
         self.flush_pending_ppu();
         self.shared.write_live_oam_range(start_offset, data);
-        self.transport_profile.ppu_oam_bytes = self
-            .transport_profile
-            .ppu_oam_bytes
-            .wrapping_add(data.len() as u32);
     }
 
     #[cfg_attr(target_arch = "arm", link_section = ".data")]
@@ -810,8 +761,6 @@ impl WorkerTransport for Core1Transport {
     fn write_ppu_register(&mut self, addr: u16, value: u8) {
         self.write_timing_ppu_register(addr, value);
         self.flush_pending_ppu();
-        self.transport_profile.ppu_register_writes =
-            self.transport_profile.ppu_register_writes.wrapping_add(1);
         self.enqueue_blocking(Core1Command::Worker(WorkerCommand::WritePpuRegister {
             addr,
             value,
@@ -825,10 +774,6 @@ impl WorkerTransport for Core1Transport {
             return;
         }
         self.flush_pending_ppu();
-        self.transport_profile.ppu_register_writes = self
-            .transport_profile
-            .ppu_register_writes
-            .wrapping_add(regs.len() as u32);
         for &(addr, value) in regs {
             self.write_timing_ppu_register(addr, value);
             self.enqueue_blocking(Core1Command::Worker(WorkerCommand::WritePpuRegister {
@@ -897,7 +842,6 @@ impl WorkerTransport for Core1Transport {
         self.wait_for_ticket(ticket);
         self.shared.clear_published_frames();
         self.last_frame_seq = 0;
-        self.last_profile_frame_seq = 0;
     }
 
     fn load_ppu_state(&mut self, state: PpuState, io: &[u8], vram: &[u8], oam: &[u8]) {
@@ -915,11 +859,10 @@ impl WorkerTransport for Core1Transport {
         self.wait_for_ticket(ticket);
         self.shared.clear_published_frames();
         self.last_frame_seq = 0;
-        self.last_profile_frame_seq = 0;
     }
 
     fn snapshot_ppu_state(&self, _io: &[u8]) -> PpuState {
-        self.timing_ppu.to_save_state(&self.timing_io)
+        self.lcd_timing.to_save_state(&self.timing_io)
     }
 
     fn poll_output(&mut self, out: &mut [u8; FRAMEBUFFER_SIZE]) -> WorkerOutput {
@@ -1018,11 +961,6 @@ impl PicoGameBoy {
     pub fn load_state(&mut self, state: SaveState) -> Result<(), &'static str> {
         self.gb.load_state(state)
     }
-
-    pub fn take_transport_profile(&mut self) -> TransportProfile {
-        self.gb.transport_mut().take_transport_profile()
-    }
-
     /// Flush pending commands and halt core1 in a WFE loop.
     ///
     /// After this returns, core1 will never read from flash again, making it
@@ -1119,16 +1057,8 @@ fn run_core1_worker(
             }
         }
 
-        let mut dropped = 0u32;
         worker.drain_audio_samples_to(|sample| {
-            if audio_tx.enqueue(sample).is_err() {
-                dropped = dropped.wrapping_add(1);
-            }
+            let _ = audio_tx.enqueue(sample);
         });
-        if dropped != 0 {
-            shared
-                .audio_queue_drops
-                .fetch_add(dropped, Ordering::AcqRel);
-        }
     }
 }

--- a/platform/pico2w/src/perf.rs
+++ b/platform/pico2w/src/perf.rs
@@ -1,16 +1,9 @@
 use defmt::info;
 use embassy_time::Instant;
-use rustyboy_pico2w::multicore::TransportProfile;
 
 pub struct PerfTracker {
     frame_count: u32,
     window_start: Instant,
-    frame_publishes: u32,
-    queue_spins: u32,
-    command_enqueues: u32,
-    ppu_vram_bytes: u32,
-    ppu_register_writes: u32,
-    audio_queue_drops: u32,
 }
 
 impl PerfTracker {
@@ -18,23 +11,11 @@ impl PerfTracker {
         Self {
             frame_count: 0,
             window_start: Instant::now(),
-            frame_publishes: 0,
-            queue_spins: 0,
-            command_enqueues: 0,
-            ppu_vram_bytes: 0,
-            ppu_register_writes: 0,
-            audio_queue_drops: 0,
         }
     }
 
-    pub fn tick(&mut self, profile: TransportProfile) {
+    pub fn tick(&mut self) {
         self.frame_count += 1;
-        self.frame_publishes = self.frame_publishes.wrapping_add(profile.frame_publishes);
-        self.queue_spins = self.queue_spins.wrapping_add(profile.command_queue_spins);
-        self.command_enqueues = self.command_enqueues.wrapping_add(profile.command_enqueues);
-        self.ppu_vram_bytes = self.ppu_vram_bytes.wrapping_add(profile.ppu_vram_bytes);
-        self.ppu_register_writes = self.ppu_register_writes.wrapping_add(profile.ppu_register_writes);
-        self.audio_queue_drops = self.audio_queue_drops.wrapping_add(profile.audio_queue_drops);
 
         if self.frame_count < 60 {
             return;
@@ -42,24 +23,9 @@ impl PerfTracker {
 
         let elapsed_us = self.window_start.elapsed().as_micros();
         let fps = (self.frame_count as u64 * 1_000_000) / elapsed_us.max(1);
-        info!(
-            "fps={} pub={} spins={} enqs={} vram={}B ppu_regs={} audio_drops={}",
-            fps,
-            self.frame_publishes,
-            self.queue_spins,
-            self.command_enqueues,
-            self.ppu_vram_bytes,
-            self.ppu_register_writes,
-            self.audio_queue_drops,
-        );
+        info!("fps={}", fps);
 
         self.frame_count = 0;
         self.window_start = Instant::now();
-        self.frame_publishes = 0;
-        self.queue_spins = 0;
-        self.command_enqueues = 0;
-        self.ppu_vram_bytes = 0;
-        self.ppu_register_writes = 0;
-        self.audio_queue_drops = 0;
     }
 }

--- a/platform/pico2w/src/perf.rs
+++ b/platform/pico2w/src/perf.rs
@@ -1,9 +1,16 @@
 use defmt::info;
 use embassy_time::Instant;
+use rustyboy_pico2w::multicore::TransportProfile;
 
 pub struct PerfTracker {
     frame_count: u32,
     window_start: Instant,
+    frame_publishes: u32,
+    queue_spins: u32,
+    command_enqueues: u32,
+    ppu_vram_bytes: u32,
+    ppu_register_writes: u32,
+    audio_queue_drops: u32,
 }
 
 impl PerfTracker {
@@ -11,20 +18,48 @@ impl PerfTracker {
         Self {
             frame_count: 0,
             window_start: Instant::now(),
+            frame_publishes: 0,
+            queue_spins: 0,
+            command_enqueues: 0,
+            ppu_vram_bytes: 0,
+            ppu_register_writes: 0,
+            audio_queue_drops: 0,
         }
     }
 
-    pub fn tick(&mut self) {
+    pub fn tick(&mut self, profile: TransportProfile) {
         self.frame_count += 1;
+        self.frame_publishes = self.frame_publishes.wrapping_add(profile.frame_publishes);
+        self.queue_spins = self.queue_spins.wrapping_add(profile.command_queue_spins);
+        self.command_enqueues = self.command_enqueues.wrapping_add(profile.command_enqueues);
+        self.ppu_vram_bytes = self.ppu_vram_bytes.wrapping_add(profile.ppu_vram_bytes);
+        self.ppu_register_writes = self.ppu_register_writes.wrapping_add(profile.ppu_register_writes);
+        self.audio_queue_drops = self.audio_queue_drops.wrapping_add(profile.audio_queue_drops);
+
         if self.frame_count < 60 {
             return;
         }
 
         let elapsed_us = self.window_start.elapsed().as_micros();
         let fps = (self.frame_count as u64 * 1_000_000) / elapsed_us.max(1);
-        info!("fps: {}", fps);
+        info!(
+            "fps={} pub={} spins={} enqs={} vram={}B ppu_regs={} audio_drops={}",
+            fps,
+            self.frame_publishes,
+            self.queue_spins,
+            self.command_enqueues,
+            self.ppu_vram_bytes,
+            self.ppu_register_writes,
+            self.audio_queue_drops,
+        );
 
         self.frame_count = 0;
         self.window_start = Instant::now();
+        self.frame_publishes = 0;
+        self.queue_spins = 0;
+        self.command_enqueues = 0;
+        self.ppu_vram_bytes = 0;
+        self.ppu_register_writes = 0;
+        self.audio_queue_drops = 0;
     }
 }

--- a/platform/pico2w/src/xip_cartridge.rs
+++ b/platform/pico2w/src/xip_cartridge.rs
@@ -76,7 +76,7 @@ impl XipCartridge {
             current_bank_valid: rom_bank_count > 1,
             rom_bank_count,
             mbc,
-            ram: alloc::vec![0u8; ram_bytes],
+            ram: alloc::vec![0u8; effective_ram_bytes(cart_type, ram_bytes)],
         };
         cart.refresh_mappings();
         Ok(cart)
@@ -408,6 +408,15 @@ fn ram_bytes_from_code(code: u8) -> usize {
     }
 }
 
+fn effective_ram_bytes(cart_type: u8, ram_bytes: usize) -> usize {
+    match cart_type {
+        // Match the core MBC1 cartridge path used by the web frontend. Some
+        // software touches external RAM even when the header says no RAM.
+        0x01 | 0x02 | 0x03 => ram_bytes.max(0x2000),
+        _ => ram_bytes,
+    }
+}
+
 fn mbc_state_from_header(cart_type: u8, ram_bytes: usize) -> Option<MbcState> {
     let ram_bank_count = if ram_bytes == 0 {
         0
@@ -466,6 +475,14 @@ mod tests {
         cart.write(0x2000, 0x02);
         assert_eq!(cart.current_rom_bank(), 2);
         assert_eq!(cart.read_rom(0x4000), 0x02);
+    }
+
+    #[test]
+    fn mbc1_without_ram_header_matches_core_ram_fallback() {
+        let mut cart = XipCartridge::new(leak_rom(4, 0x01, 0x00)).unwrap();
+        cart.write(0x0000, 0x0A);
+        cart.write(0xA123, 0x42);
+        assert_eq!(cart.read_ram(0x0123), 0x42);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Places the SM83 hot instruction path in SRAM so RP2350 XIP cache is available for ROM reads
- Adds a tiny core-0 `LcdTiming` mirror so CPU-visible `LY`, `STAT`, and LCD interrupts stay synchronous while core 1 continues rendering asynchronously
- Keeps the Pico XIP cartridge path aligned with the core/web MBC1 RAM fallback behavior

## Cool Spot Slowdown

Cool Spot was the clearest failure case on Pico 2W:

- The emulator reported about 60fps
- Audio sounded normal
- Gameplay and animation still ran in obvious slow motion
- The title animation could start very slowly and gradually speed up after idling for a while
- Entering and leaving the in-game pause screen could change how slow it felt

The web app played the same ROM at normal pace, which pointed away from a game-specific behavior bug and toward a Pico runtime/timing issue.

## Root Cause

The SRAM hot-path work helped overall throughput, but it was not the whole story. Cool Spot appears to poll LCD timing registers and interrupts closely. On Pico, those CPU-visible values were effectively coming back from the async core-1 PPU worker.

That meant the emulated CPU could observe stale `LY`/`STAT` state and delayed VBlank/STAT interrupt edges. When the game polled for a particular LCD state, it could burn extra emulated cycles waiting for the async worker to catch up. From the outside that looked like slow motion:

- audio stayed near normal because APU progress was not blocked the same way
- the outer frame loop could still look close to 60fps
- game logic and animation advanced too slowly because the CPU was spending too much emulated time waiting on delayed LCD timing

## Why `LcdTiming` Fixes It

`LcdTiming` is a tiny timing-only LCD mirror that runs synchronously on core 0 alongside the CPU. It does not render pixels or allocate a framebuffer. It only maintains the CPU-observable LCD state:

- `LY`
- `STAT`
- VBlank interrupt edges
- STAT interrupt edges

That keeps the values the game polls in lockstep with emulated CPU progress, while core 1 still handles the heavier rendering work asynchronously. In other words:

- core 0 answers LCD timing reads immediately and consistently
- core 1 still renders frames from shared PPU state
- CPU-visible timing is no longer delayed by renderer scheduling or command latency

This fixes the Cool Spot slow-motion behavior without giving up the multicore rendering split.

## Test Plan

- [x] Verified on Pico 2W hardware with Cool Spot staged in flash; gameplay pace is back near normal instead of slow motion
- [x] `cargo check --features fps`
- [x] `cargo test-host xip_cartridge`
