### PR TITLE
Add save state and battery save persistence

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2718,6 +2718,7 @@ dependencies = [
  "bitflags 2.11.1",
  "bytemuck",
  "png",
+ "sha2",
 ]
 
 [[package]]
@@ -2764,6 +2765,7 @@ dependencies = [
  "rand",
  "reqwest",
  "rsa",
+ "rustyboy-core",
  "serde",
  "serde_json",
  "sqlx",

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -11,6 +11,7 @@ trace = []
 [dependencies]
 bitflags = "2.5.0"
 bytemuck = { version = "1", default-features = false, features = ["extern_crate_alloc"] }
+sha2 = { version = "0.10.9", default-features = false }
 
 [dev-dependencies]
 png = "0.17"

--- a/core/src/cpu/save_state.rs
+++ b/core/src/cpu/save_state.rs
@@ -1,4 +1,4 @@
-//! Typed save state representation for the RBSS v1 format.
+//! Typed save state representation for RBSS save-state blobs.
 //!
 //! On the **save path**, `Sm83::save_state()` writes directly to a `Vec<u8>` —
 //! no `SaveState` instance is created.
@@ -21,7 +21,9 @@ use crate::memory::memory::GameBoyMemory;
 // ── Format constants ──────────────────────────────────────────────────────────
 
 pub const MAGIC: &[u8; 4] = b"RBSS";
-pub const VERSION: u16 = 1;
+pub const VERSION_V1: u16 = 1;
+pub const VERSION_V2: u16 = 2;
+pub const VERSION: u16 = VERSION_V2;
 
 const MAGIC_SIZE: usize = 4;
 const VERSION_SIZE: usize = size_of::<u16>();
@@ -51,8 +53,12 @@ const WRAM_SIZE: usize = 0x2000;
 const HRAM_SIZE: usize = 0x7F;
 const VRAM_SIZE: usize = 0x2000;
 const OAM_SIZE: usize = 0xA0;
-const MBC_SIZE: usize = 4 * size_of::<u8>(); // rom_bank_lo upper_bits ram_mode ram_enabled
-const CART_RAM_LEN_SIZE: usize = size_of::<u16>();
+const MBC_SIZE_V1_LEGACY: usize = 4 * size_of::<u8>(); // rom_bank_lo upper_bits ram_mode ram_enabled
+const MBC_SIZE_V1_MBC3_RTC: usize = 18;
+const CART_RAM_LEN_SIZE_V1: usize = size_of::<u16>();
+const SECTION_HEADER_SIZE: usize = 8; // 4-byte tag + u32 length
+const SECTION_MBC: &[u8; 4] = b"MBC\0";
+const SECTION_CART_RAM: &[u8; 4] = b"CRAM";
 
 /// Minimum valid blob length: everything up through OAM, without optional MBC/cart RAM.
 pub const MIN_BLOB_SIZE: usize = HEADER_SIZE
@@ -263,7 +269,7 @@ impl MbcState {
             ram_mode: b[2] != 0,
             ram_enabled: b[3] != 0,
         };
-        (state, MBC_SIZE)
+        (state, MBC_SIZE_V1_LEGACY)
     }
 }
 
@@ -276,11 +282,13 @@ impl MbcState {
 /// `load_state` method.
 pub struct SaveState {
     blob: Vec<u8>,
+    version: u16,
 
     pub cpu: CpuState,
     pub timer: TimerState,
     pub ppu: PpuState,
     mbc: Option<MbcState>,
+    mbc_payload_range: Option<Range<usize>>,
 
     io_range: Range<usize>,
     ie_offset: usize,
@@ -292,7 +300,7 @@ pub struct SaveState {
 }
 
 impl SaveState {
-    /// Serialize emulator state into an RBSS v1 blob.
+    /// Serialize emulator state into the default RBSS format.
     ///
     /// Called by `Sm83::save_state` which constructs the typed state structs
     /// from its own fields and passes them here. This function owns the format.
@@ -302,17 +310,53 @@ impl SaveState {
         ppu: PpuState,
         memory: &GameBoyMemory,
     ) -> Vec<u8> {
-        let mut out = Vec::with_capacity(MIN_BLOB_SIZE);
+        Self::serialize_v2(cpu, timer, ppu, memory)
+    }
+
+    /// Serialize emulator state into an RBSS v1 blob.
+    pub fn serialize_v1(
+        cpu: CpuState,
+        timer: TimerState,
+        ppu: PpuState,
+        memory: &GameBoyMemory,
+    ) -> Vec<u8> {
+        let cart_ram_len = memory.external_ram().map_or(0, |r| r.len());
+        // v1 tail: MBC state (≤ 18 bytes) + u16 RAM length prefix + cart RAM
+        let capacity = MIN_BLOB_SIZE + 18 + 2 + cart_ram_len;
+        let mut out = Vec::with_capacity(capacity);
         out.extend_from_slice(MAGIC);
-        out.extend_from_slice(&VERSION.to_le_bytes());
+        out.extend_from_slice(&VERSION_V1.to_le_bytes());
         cpu.serialize(&mut out);
         timer.serialize(&mut out);
         ppu.serialize(&mut out);
-        memory.save_state(&mut out);
+        memory.save_state_v1(&mut out);
         out
     }
 
-    /// Parse and validate a raw RBSS v1 blob.
+    /// Serialize emulator state into an RBSS v2 blob.
+    pub fn serialize_v2(
+        cpu: CpuState,
+        timer: TimerState,
+        ppu: PpuState,
+        memory: &GameBoyMemory,
+    ) -> Vec<u8> {
+        // Pre-size to avoid realloc: fixed fields + worst-case MBC section
+        // (MBC3+RTC = 18 bytes + 8-byte header) + cart RAM section if present.
+        let cart_ram_len = memory.external_ram().map_or(0, |r| r.len());
+        let capacity = MIN_BLOB_SIZE
+            + SECTION_HEADER_SIZE + 18
+            + if cart_ram_len > 0 { SECTION_HEADER_SIZE + cart_ram_len } else { 0 };
+        let mut out = Vec::with_capacity(capacity);
+        out.extend_from_slice(MAGIC);
+        out.extend_from_slice(&VERSION_V2.to_le_bytes());
+        cpu.serialize(&mut out);
+        timer.serialize(&mut out);
+        ppu.serialize(&mut out);
+        memory.save_state_v2(&mut out);
+        out
+    }
+
+    /// Parse and validate a raw RBSS blob.
     ///
     /// Returns `Err` if the blob is too short, has a bad magic, or has an
     /// unsupported version. No emulator state is modified.
@@ -324,7 +368,7 @@ impl SaveState {
             return Err("invalid save state magic");
         }
         let version = u16::from_le_bytes([blob[MAGIC_SIZE], blob[MAGIC_SIZE + 1]]);
-        if version != VERSION {
+        if version != VERSION_V1 && version != VERSION_V2 {
             return Err("unsupported save state version");
         }
 
@@ -350,32 +394,28 @@ impl SaveState {
         let oam_range = cur..cur + OAM_SIZE;
         cur += OAM_SIZE;
 
-        let mbc = if cur + MBC_SIZE <= blob.len() {
-            let (m, n) = MbcState::parse(&blob, cur);
-            cur += n;
-            Some(m)
-        } else {
-            None
+        let (mbc_payload_range, cart_ram_range) = match version {
+            VERSION_V1 => parse_v1_tail(&blob, cur)?,
+            VERSION_V2 => parse_v2_sections(&blob, cur)?,
+            _ => unreachable!(),
         };
 
-        let cart_ram_range = if cur + CART_RAM_LEN_SIZE <= blob.len() {
-            let ram_len = u16::from_le_bytes([blob[cur], blob[cur + 1]]) as usize;
-            cur += CART_RAM_LEN_SIZE;
-            if ram_len > 0 && cur + ram_len <= blob.len() {
-                Some(cur..cur + ram_len)
+        let mbc = mbc_payload_range.as_ref().and_then(|range| {
+            if range.len() >= MBC_SIZE_V1_LEGACY {
+                Some(MbcState::parse(&blob, range.start).0)
             } else {
                 None
             }
-        } else {
-            None
-        };
+        });
 
         Ok(SaveState {
             blob,
+            version,
             cpu,
             timer,
             ppu,
             mbc,
+            mbc_payload_range,
             io_range,
             ie_offset,
             wram_range,
@@ -390,6 +430,16 @@ impl SaveState {
 
     pub fn mbc(&self) -> Option<&MbcState> {
         self.mbc.as_ref()
+    }
+
+    pub fn format_version(&self) -> u16 {
+        self.version
+    }
+
+    pub fn mbc_payload(&self) -> Option<&[u8]> {
+        self.mbc_payload_range
+            .as_ref()
+            .map(|r| &self.blob[r.clone()])
     }
 
     pub fn io_registers(&self) -> &[u8] {
@@ -412,5 +462,101 @@ impl SaveState {
     }
     pub fn cart_ram(&self) -> Option<&[u8]> {
         self.cart_ram_range.as_ref().map(|r| &self.blob[r.clone()])
+    }
+}
+
+fn parse_v1_tail(
+    blob: &[u8],
+    tail_start: usize,
+) -> Result<(Option<Range<usize>>, Option<Range<usize>>), &'static str> {
+    if tail_start == blob.len() {
+        return Ok((None, None));
+    }
+
+    for &mbc_len in &[MBC_SIZE_V1_MBC3_RTC, MBC_SIZE_V1_LEGACY, 0] {
+        let Some(len_offset) = tail_start.checked_add(mbc_len) else {
+            continue;
+        };
+        if len_offset + CART_RAM_LEN_SIZE_V1 > blob.len() {
+            continue;
+        }
+
+        let ram_len = u16::from_le_bytes([blob[len_offset], blob[len_offset + 1]]) as usize;
+        let ram_start = len_offset + CART_RAM_LEN_SIZE_V1;
+        let ram_end = ram_start + ram_len;
+        if ram_end == blob.len() {
+            let mbc = if mbc_len > 0 {
+                Some(tail_start..tail_start + mbc_len)
+            } else {
+                None
+            };
+            let ram = if ram_len > 0 {
+                Some(ram_start..ram_end)
+            } else {
+                None
+            };
+            return Ok((mbc, ram));
+        }
+    }
+
+    Err("invalid v1 save state tail")
+}
+
+fn parse_v2_sections(
+    blob: &[u8],
+    mut cur: usize,
+) -> Result<(Option<Range<usize>>, Option<Range<usize>>), &'static str> {
+    let mut mbc_payload_range = None;
+    let mut cart_ram_range = None;
+
+    while cur < blob.len() {
+        if cur + SECTION_HEADER_SIZE > blob.len() {
+            return Err("truncated v2 save state section header");
+        }
+
+        let tag = &blob[cur..cur + 4];
+        let len = u32::from_le_bytes(
+            blob[cur + 4..cur + 8]
+                .try_into()
+                .map_err(|_| "invalid v2 save state section length")?,
+        ) as usize;
+        cur += SECTION_HEADER_SIZE;
+
+        let end = cur
+            .checked_add(len)
+            .ok_or("v2 save state section length overflow")?;
+        if end > blob.len() {
+            return Err("truncated v2 save state section payload");
+        }
+
+        if tag == SECTION_MBC {
+            if len > 0 {
+                mbc_payload_range = Some(cur..end);
+            }
+        } else if tag == SECTION_CART_RAM && len > 0 {
+            cart_ram_range = Some(cur..end);
+        }
+
+        cur = end;
+    }
+
+    Ok((mbc_payload_range, cart_ram_range))
+}
+
+pub(crate) fn write_v2_section(out: &mut Vec<u8>, tag: &[u8; 4], payload: &[u8]) {
+    out.extend_from_slice(tag);
+    out.extend_from_slice(&(payload.len() as u32).to_le_bytes());
+    out.extend_from_slice(payload);
+}
+
+pub(crate) fn write_mbc_section(out: &mut Vec<u8>, payload: &[u8]) {
+    if !payload.is_empty() {
+        write_v2_section(out, SECTION_MBC, payload);
+    }
+}
+
+pub(crate) fn write_cart_ram_section(out: &mut Vec<u8>, payload: &[u8]) {
+    if !payload.is_empty() {
+        write_v2_section(out, SECTION_CART_RAM, payload);
     }
 }

--- a/core/src/gameboy.rs
+++ b/core/src/gameboy.rs
@@ -250,6 +250,22 @@ impl<W: WorkerTransport> GameBoy<W> {
     }
 
     pub fn save_state(&self) -> Vec<u8> {
+        self.serialize_save_state(SaveState::serialize)
+    }
+
+    pub fn save_state_v1(&self) -> Vec<u8> {
+        self.serialize_save_state(SaveState::serialize_v1)
+    }
+
+    fn serialize_save_state(
+        &self,
+        serialize: fn(
+            CpuState,
+            crate::cpu::save_state::TimerState,
+            crate::cpu::save_state::PpuState,
+            &GameBoyMemory,
+        ) -> Vec<u8>,
+    ) -> Vec<u8> {
         let cpu_state = CpuState {
             a: self.cpu.registers.a,
             b: self.cpu.registers.b,
@@ -266,7 +282,7 @@ impl<W: WorkerTransport> GameBoy<W> {
             cycle_counter: self.cycle_counter(),
         };
         let ppu_state = self.transport.snapshot_ppu_state(self.memory.io_slice());
-        SaveState::serialize(
+        serialize(
             cpu_state,
             self.timer.to_save_state(),
             ppu_state,

--- a/core/src/gameboy.rs
+++ b/core/src/gameboy.rs
@@ -135,6 +135,28 @@ impl<W: WorkerTransport> GameBoy<W> {
         self
     }
 
+    /// Reset the emulator to power-on state, preserving the cartridge ROM and battery RAM.
+    pub fn reset(&mut self) {
+        self.memory.soft_reset();
+        self.cpu.registers = Registers {
+            a: 0x01,
+            f: crate::cpu::registers::Flags::from_bits_truncate(0xB0),
+            b: 0x00,
+            c: 0x13,
+            d: 0x00,
+            e: 0xD8,
+            h: 0x01,
+            l: 0x4D,
+            pc: 0x0100,
+            sp: 0xFFFE,
+        };
+        self.cpu.halted = false;
+        self.cpu.ime = crate::cpu::sm83::ImeState::Disabled;
+        self.cycle_counter = 0;
+        self.apply_dmg_state();
+        self.push_worker_state();
+    }
+
     /// Seed IO registers to DMG post-boot-ROM state and sync the worker.
     pub fn apply_dmg_state(&mut self) {
         self.memory.write_io(LCDC_ADDR, 0x91);

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -5,5 +5,6 @@ pub mod cpu;
 pub mod gameboy;
 pub mod ipc;
 pub mod memory;
+pub mod storage;
 
 pub use gameboy::GameBoy;

--- a/core/src/memory/cartridge.rs
+++ b/core/src/memory/cartridge.rs
@@ -60,6 +60,8 @@ pub trait Cartridge {
     fn load_mbc_state(&mut self, _data: &[u8], _offset: usize) -> usize {
         0
     }
+    /// Reset MBC bank registers to power-on defaults. Cart RAM is preserved.
+    fn reset_mbc(&mut self) {}
 }
 
 // ── Header helpers ───────────────────────────────────────────────────────────
@@ -395,6 +397,13 @@ impl Cartridge for Mbc1 {
         self.ram_enabled = data[offset + 3] != 0;
         4
     }
+
+    fn reset_mbc(&mut self) {
+        self.rom_bank_lo = 1;
+        self.upper_bits = 0;
+        self.ram_mode = false;
+        self.ram_enabled = false;
+    }
 }
 
 // ── MBC1 Multicart ───────────────────────────────────────────────────────────
@@ -568,6 +577,13 @@ impl Cartridge for Mbc1Multicart {
         self.ram_mode = data[offset + 2] != 0;
         self.ram_enabled = data[offset + 3] != 0;
         4
+    }
+
+    fn reset_mbc(&mut self) {
+        self.rom_bank_lo = 1;
+        self.upper_bits = 0;
+        self.ram_mode = false;
+        self.ram_enabled = false;
     }
 }
 
@@ -876,6 +892,13 @@ impl Cartridge for Mbc3 {
         self.rtc_latched.day_hi = d[13];
         self.rtc_cycles = u32::from_le_bytes([d[14], d[15], d[16], d[17]]);
         SIZE
+    }
+
+    fn reset_mbc(&mut self) {
+        self.rom_bank = 1;
+        self.bank_or_rtc = 0;
+        self.ram_rtc_enabled = false;
+        self.latch_armed = false;
     }
 }
 

--- a/core/src/memory/memory.rs
+++ b/core/src/memory/memory.rs
@@ -581,6 +581,17 @@ impl GameBoyMemory {
         self.cartridge.set_external_ram(data);
     }
 
+    /// Reset RAM regions and MBC registers to power-on state. Cart RAM is preserved.
+    pub fn soft_reset(&mut self) {
+        self.wram.fill(0);
+        self.vram.fill(0);
+        self.hram.fill(0);
+        self.oam.fill(0);
+        self.io.fill(0);
+        self.ie = 0;
+        self.cartridge.reset_mbc();
+    }
+
     /// Direct read of an IO register. No bus events.
     /// Handles 0xFF00-0xFF7F from io array, 0xFFFF from ie field.
     pub fn read_io(&self, address: u16) -> u8 {

--- a/core/src/memory/memory.rs
+++ b/core/src/memory/memory.rs
@@ -8,7 +8,7 @@ use super::map::{
     ECHO_BASE, ECHO_END, EXT_RAM_BASE, EXT_RAM_END, IO_REG_BASE, IO_REG_END, OAM_BASE, OAM_END,
     ROM_BANKED_BASE, ROM_BANKED_END, ROM_FIXED_END, VRAM_BASE, VRAM_END, WRAM_BASE, WRAM_END,
 };
-use crate::cpu::save_state::SaveState;
+use crate::cpu::save_state::{write_cart_ram_section, write_mbc_section, SaveState};
 
 /// An event produced when a write occurs to a worker-mirrored address.
 #[derive(Debug, PartialEq, Clone, Copy)]
@@ -492,17 +492,9 @@ impl GameBoyMemory {
         self.ie = value;
     }
 
-    /// Serialize memory state into `out`.
-    /// IO registers (0x80 bytes) + IE (1 byte) + WRAM + HRAM + VRAM + OAM.
-    pub fn save_state(&self, out: &mut alloc::vec::Vec<u8>) {
-        for i in 0..0x80u16 {
-            out.push(self.read_io(0xFF00 + i));
-        }
-        out.push(self.ie);
-        out.extend_from_slice(self.wram());
-        out.extend_from_slice(self.hram());
-        out.extend_from_slice(self.vram());
-        out.extend_from_slice(self.oam());
+    /// Serialize memory state into the RBSS v1 tail.
+    pub fn save_state_v1(&self, out: &mut alloc::vec::Vec<u8>) {
+        self.save_fixed_regions(out);
         self.cartridge.save_mbc_state(out);
         // External RAM (cart SRAM): prefix with u16 LE length so load_state
         // can handle carts with no RAM (len=0) and varying RAM sizes.
@@ -517,6 +509,37 @@ impl GameBoyMemory {
         }
     }
 
+    /// Serialize memory state into the RBSS v2 tail.
+    pub fn save_state_v2(&self, out: &mut alloc::vec::Vec<u8>) {
+        self.save_fixed_regions(out);
+
+        let mut mbc = alloc::vec::Vec::new();
+        self.cartridge.save_mbc_state(&mut mbc);
+        write_mbc_section(out, &mbc);
+
+        if let Some(ram) = self.cartridge.external_ram() {
+            write_cart_ram_section(out, ram);
+        }
+    }
+
+    /// Backward-compatible alias for older call sites.
+    pub fn save_state(&self, out: &mut alloc::vec::Vec<u8>) {
+        self.save_state_v1(out);
+    }
+
+    /// Serialize fixed memory regions shared by RBSS v1 and v2.
+    /// IO registers (0x80 bytes) + IE (1 byte) + WRAM + HRAM + VRAM + OAM.
+    fn save_fixed_regions(&self, out: &mut alloc::vec::Vec<u8>) {
+        for i in 0..0x80u16 {
+            out.push(self.read_io(0xFF00 + i));
+        }
+        out.push(self.ie);
+        out.extend_from_slice(self.wram());
+        out.extend_from_slice(self.hram());
+        out.extend_from_slice(self.vram());
+        out.extend_from_slice(self.oam());
+    }
+
     /// Apply memory state from a parsed [`SaveState`]. Zero-copy for large regions.
     pub fn load_state(&mut self, state: &SaveState) {
         let io = state.io_registers();
@@ -528,7 +551,10 @@ impl GameBoyMemory {
         self.set_hram(state.hram());
         self.set_vram(state.vram());
         self.set_oam(state.oam());
-        if let Some(mbc) = state.mbc() {
+        if let Some(payload) = state.mbc_payload() {
+            self.cartridge.load_mbc_state(payload, 0);
+            self.refresh_rom_windows();
+        } else if let Some(mbc) = state.mbc() {
             // Reconstruct MBC register state via the existing load path.
             // We build a minimal 4-byte buffer and reuse load_mbc_state.
             let buf = [

--- a/core/src/storage.rs
+++ b/core/src/storage.rs
@@ -1,0 +1,153 @@
+use alloc::string::String;
+
+use sha2::{Digest, Sha256};
+
+pub const ROM_ID_LEN: usize = 32;
+pub const ROM_ID_HEX_LEN: usize = ROM_ID_LEN * 2;
+pub const ROM_ID_SHORT_HEX_LEN: usize = 8;
+pub const MAX_BATTERY_SAVE_BYTES: usize = 128 * 1024;
+pub const MAX_SAVE_STATE_BYTES: usize = 256 * 1024;
+
+const HEX: &[u8; 16] = b"0123456789abcdef";
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum StorageValueError {
+    EmptyBatterySave,
+    BatterySaveTooLarge,
+    EmptySaveState,
+    SaveStateTooLarge,
+    InvalidRomIdHexLength,
+    InvalidRomIdHexCharacter,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct RomId([u8; ROM_ID_LEN]);
+
+impl RomId {
+    pub fn for_bytes(bytes: &[u8]) -> Self {
+        let mut hasher = RomHasher::new();
+        hasher.update(bytes);
+        hasher.finalize()
+    }
+
+    pub fn from_bytes(bytes: [u8; ROM_ID_LEN]) -> Self {
+        Self(bytes)
+    }
+
+    pub fn from_hex(hex: &str) -> Result<Self, StorageValueError> {
+        if hex.len() != ROM_ID_HEX_LEN {
+            return Err(StorageValueError::InvalidRomIdHexLength);
+        }
+
+        let mut bytes = [0u8; ROM_ID_LEN];
+        let input = hex.as_bytes();
+        for (idx, byte) in bytes.iter_mut().enumerate() {
+            let hi = decode_hex_nibble(input[idx * 2])?;
+            let lo = decode_hex_nibble(input[idx * 2 + 1])?;
+            *byte = (hi << 4) | lo;
+        }
+
+        Ok(Self(bytes))
+    }
+
+    pub fn as_bytes(&self) -> &[u8; ROM_ID_LEN] {
+        &self.0
+    }
+
+    pub fn to_hex(&self) -> String {
+        encode_hex(&self.0)
+    }
+
+    pub fn short_hex(&self) -> String {
+        encode_hex(&self.0[..ROM_ID_SHORT_HEX_LEN / 2])
+    }
+}
+
+pub struct RomHasher {
+    hasher: Sha256,
+}
+
+impl RomHasher {
+    pub fn new() -> Self {
+        Self {
+            hasher: Sha256::new(),
+        }
+    }
+
+    pub fn update(&mut self, bytes: &[u8]) {
+        self.hasher.update(bytes);
+    }
+
+    pub fn finalize(self) -> RomId {
+        let digest = self.hasher.finalize();
+        let mut bytes = [0u8; ROM_ID_LEN];
+        bytes.copy_from_slice(&digest);
+        RomId(bytes)
+    }
+}
+
+impl Default for RomHasher {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct BatterySaveBytes<'a> {
+    data: &'a [u8],
+}
+
+impl<'a> BatterySaveBytes<'a> {
+    pub fn new(data: &'a [u8]) -> Result<Self, StorageValueError> {
+        if data.is_empty() {
+            return Err(StorageValueError::EmptyBatterySave);
+        }
+        if data.len() > MAX_BATTERY_SAVE_BYTES {
+            return Err(StorageValueError::BatterySaveTooLarge);
+        }
+        Ok(Self { data })
+    }
+
+    pub fn as_slice(&self) -> &'a [u8] {
+        self.data
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct SaveStateBytes<'a> {
+    data: &'a [u8],
+}
+
+impl<'a> SaveStateBytes<'a> {
+    pub fn new(data: &'a [u8]) -> Result<Self, StorageValueError> {
+        if data.is_empty() {
+            return Err(StorageValueError::EmptySaveState);
+        }
+        if data.len() > MAX_SAVE_STATE_BYTES {
+            return Err(StorageValueError::SaveStateTooLarge);
+        }
+        Ok(Self { data })
+    }
+
+    pub fn as_slice(&self) -> &'a [u8] {
+        self.data
+    }
+}
+
+fn encode_hex(bytes: &[u8]) -> String {
+    let mut out = String::with_capacity(bytes.len() * 2);
+    for byte in bytes {
+        out.push(HEX[(byte >> 4) as usize] as char);
+        out.push(HEX[(byte & 0x0F) as usize] as char);
+    }
+    out
+}
+
+fn decode_hex_nibble(byte: u8) -> Result<u8, StorageValueError> {
+    match byte {
+        b'0'..=b'9' => Ok(byte - b'0'),
+        b'a'..=b'f' => Ok(byte - b'a' + 10),
+        b'A'..=b'F' => Ok(byte - b'A' + 10),
+        _ => Err(StorageValueError::InvalidRomIdHexCharacter),
+    }
+}

--- a/core/tests/rom_identity.rs
+++ b/core/tests/rom_identity.rs
@@ -1,0 +1,59 @@
+use rustyboy_core::storage::{
+    BatterySaveBytes, RomHasher, RomId, SaveStateBytes, MAX_BATTERY_SAVE_BYTES,
+    MAX_SAVE_STATE_BYTES,
+};
+
+#[test]
+fn rom_id_matches_sha256_test_vector() {
+    let id = RomId::for_bytes(b"abc");
+
+    assert_eq!(
+        id.to_hex().as_str(),
+        "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad"
+    );
+    assert_eq!(id.short_hex().as_str(), "ba7816bf");
+}
+
+#[test]
+fn streaming_rom_hasher_matches_one_shot_hash() {
+    let mut hasher = RomHasher::new();
+    hasher.update(b"ab");
+    hasher.update(b"c");
+
+    assert_eq!(hasher.finalize(), RomId::for_bytes(b"abc"));
+}
+
+#[test]
+fn rom_id_hex_roundtrips_and_rejects_invalid_input() {
+    let id = RomId::for_bytes(b"rustyboy");
+    let hex = id.to_hex();
+
+    assert_eq!(RomId::from_hex(hex.as_str()).unwrap(), id);
+    assert!(RomId::from_hex("ba7816bf").is_err());
+    assert!(
+        RomId::from_hex("zz7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad",)
+            .is_err()
+    );
+}
+
+#[test]
+fn battery_save_boundaries_are_enforced_in_core() {
+    assert!(BatterySaveBytes::new(&[]).is_err());
+
+    let max = vec![0xAA; MAX_BATTERY_SAVE_BYTES];
+    assert_eq!(BatterySaveBytes::new(&max).unwrap().as_slice(), max);
+
+    let too_large = vec![0xAA; MAX_BATTERY_SAVE_BYTES + 1];
+    assert!(BatterySaveBytes::new(&too_large).is_err());
+}
+
+#[test]
+fn save_state_blob_size_boundary_is_enforced_in_core() {
+    assert!(SaveStateBytes::new(&[]).is_err());
+
+    let max = vec![0x55; MAX_SAVE_STATE_BYTES];
+    assert_eq!(SaveStateBytes::new(&max).unwrap().as_slice(), max);
+
+    let too_large = vec![0x55; MAX_SAVE_STATE_BYTES + 1];
+    assert!(SaveStateBytes::new(&too_large).is_err());
+}

--- a/core/tests/save_state.rs
+++ b/core/tests/save_state.rs
@@ -3,7 +3,7 @@
 mod common;
 
 use rustyboy_core::cpu::registers::{Flags, Registers};
-use rustyboy_core::cpu::save_state::SaveState;
+use rustyboy_core::cpu::save_state::{SaveState, VERSION_V1, VERSION_V2};
 use rustyboy_core::GameBoy;
 
 /// Build a minimal in-memory ROM with a NOP + JR -2 loop at 0x0100.
@@ -338,6 +338,107 @@ fn test_save_state_from_blob_rejects_bad_magic() {
 fn test_save_state_from_blob_rejects_too_short() {
     let blob = vec![0u8; 10];
     assert!(SaveState::from_blob(blob).is_err());
+}
+
+#[test]
+fn test_save_state_v1_blob_still_loads_after_v2_support() {
+    let rom = make_rom(0x03, 0, 0x02);
+    let mut gb = make_emulator(rom.clone());
+
+    for _ in 0..40 {
+        gb.step().unwrap();
+    }
+    let mut ram = vec![0u8; 0x2000];
+    ram[..4].copy_from_slice(&[0xCA, 0xFE, 0xBA, 0xBE]);
+    gb.set_external_ram(&ram);
+
+    let blob = gb.save_state_v1();
+    assert_eq!(u16::from_le_bytes([blob[4], blob[5]]), VERSION_V1);
+
+    let parsed = SaveState::from_blob(blob).expect("v1 blob should still parse");
+    assert_eq!(parsed.format_version(), VERSION_V1);
+    assert_eq!(
+        parsed.cart_ram().expect("cart RAM should be present")[..4],
+        [0xCA, 0xFE, 0xBA, 0xBE]
+    );
+
+    let mut restored = make_emulator(rom);
+    restored.load_state(parsed).expect("v1 load should work");
+    assert_eq!(
+        restored.external_ram().expect("restored cart RAM")[..4],
+        [0xCA, 0xFE, 0xBA, 0xBE]
+    );
+}
+
+#[test]
+fn test_save_state_v1_mbc3_extended_tail_is_detected() {
+    let mut rom = vec![0u8; 0x8000];
+    rom[0x0147] = 0x13; // MBC3+RAM+BATTERY
+    rom[0x0148] = 0x00;
+    rom[0x0149] = 0x02; // 8 KiB RAM
+    rom[0x0100] = 0x00;
+    rom[0x0101] = 0x18;
+    rom[0x0102] = 0xFE;
+
+    let mut gb = make_emulator(rom.clone());
+    gb.set_external_ram(&[0x5A; 0x2000]);
+
+    let blob = gb.save_state_v1();
+    let parsed = SaveState::from_blob(blob).expect("v1 MBC3 blob should parse");
+    assert_eq!(parsed.format_version(), VERSION_V1);
+    assert_eq!(
+        parsed
+            .mbc_payload()
+            .expect("MBC3 payload should be present")
+            .len(),
+        18
+    );
+    assert_eq!(
+        parsed.cart_ram().expect("cart RAM should be present").len(),
+        0x2000
+    );
+
+    let mut restored = make_emulator(rom);
+    restored
+        .load_state(parsed)
+        .expect("v1 MBC3 load should work");
+    assert_eq!(restored.external_ram().expect("restored cart RAM")[0], 0x5A);
+}
+
+#[test]
+fn test_save_state_v2_roundtrips_128k_cart_ram() {
+    let mut rom = vec![0u8; 0x8000];
+    rom[0x0147] = 0x13; // MBC3+RAM+BATTERY
+    rom[0x0148] = 0x00;
+    rom[0x0149] = 0x04; // 128 KiB RAM
+    rom[0x0100] = 0x00;
+    rom[0x0101] = 0x18;
+    rom[0x0102] = 0xFE;
+
+    let mut gb = make_emulator(rom.clone());
+    let mut ram = vec![0u8; 128 * 1024];
+    ram[0] = 0x11;
+    ram[0x7FFF] = 0x22;
+    ram[0x1_FFFF] = 0x33;
+    gb.set_external_ram(&ram);
+
+    let blob = gb.save_state();
+    assert_eq!(u16::from_le_bytes([blob[4], blob[5]]), VERSION_V2);
+
+    let parsed = SaveState::from_blob(blob).expect("v2 blob should parse");
+    assert_eq!(parsed.format_version(), VERSION_V2);
+    assert_eq!(
+        parsed.cart_ram().expect("cart RAM should be present").len(),
+        128 * 1024
+    );
+
+    let mut restored = make_emulator(rom);
+    restored.load_state(parsed).expect("v2 load should work");
+    let restored_ram = restored.external_ram().expect("restored cart RAM");
+    assert_eq!(restored_ram.len(), 128 * 1024);
+    assert_eq!(restored_ram[0], 0x11);
+    assert_eq!(restored_ram[0x7FFF], 0x22);
+    assert_eq!(restored_ram[0x1_FFFF], 0x33);
 }
 
 // ── Cycle counter preserved ───────────────────────────────────────────────────

--- a/platform/pico2w/src/flash_rom.rs
+++ b/platform/pico2w/src/flash_rom.rs
@@ -5,6 +5,7 @@ use embassy_rp::peripherals::FLASH;
 use embassy_rp::Peri;
 
 use rustyboy_core::memory::RomReader;
+use rustyboy_core::storage::{RomHasher, RomId};
 
 pub const FLASH_CAPACITY_BYTES: usize = 4 * 1024 * 1024;
 pub const FIRMWARE_SLOT_BYTES: usize = 512 * 1024;
@@ -15,7 +16,9 @@ pub const ROM_DATA_CAPACITY_BYTES: usize = FLASH_CAPACITY_BYTES - ROM_DATA_OFFSE
 
 const ROM_BANK_BYTES: usize = 0x4000;
 const HEADER_MAGIC: [u8; 8] = *b"RBROM1\0\0";
-const HEADER_VERSION: u32 = 1;
+const HEADER_VERSION_V1: u32 = 1;
+const HEADER_VERSION_V2: u32 = 2;
+const HEADER_VERSION: u32 = HEADER_VERSION_V2;
 // Layout:
 //   [0..8]   magic
 //   [8..12]  version
@@ -24,9 +27,11 @@ const HEADER_VERSION: u32 = 1;
 //   [20..24] bank_count
 //   [24..32] reserved (0xFF padding)
 //   [32..96] filename (null-terminated UTF-8, max 63 chars + null)
-const HEADER_LEN: usize = 96;
+//   [96..128] rom_id SHA-256 bytes (v2+, 0xFF padding if absent)
+const HEADER_LEN: usize = 128;
 const FILENAME_OFFSET: usize = 32;
 const FILENAME_MAX_BYTES: usize = 63; // + 1 null terminator
+const ROM_ID_OFFSET: usize = 96;
 const ROM_SIZE_CODE_OFFSET: usize = 0x0148;
 
 pub type OnboardFlash<'d> = Flash<'d, FLASH, Blocking, FLASH_CAPACITY_BYTES>;
@@ -35,6 +40,7 @@ pub type OnboardFlash<'d> = Flash<'d, FLASH, Blocking, FLASH_CAPACITY_BYTES>;
 pub struct FlashRomInfo {
     pub size_bytes: usize,
     pub bank_count: usize,
+    pub rom_id: Option<RomId>,
 }
 
 #[derive(Debug, Clone, Copy)]
@@ -121,6 +127,8 @@ pub struct RomStager {
     banks_written: usize,
     buf: alloc::boxed::Box<[u8; ROM_BANK_BYTES]>,
     filename: alloc::string::String,
+    rom_hasher: Option<RomHasher>,
+    rom_id: Option<RomId>,
 }
 
 impl RomStager {
@@ -137,6 +145,8 @@ impl RomStager {
         reader
             .read_bank(0, &mut *buf)
             .map_err(FlashRomStageError::Reader)?;
+        let mut rom_hasher = RomHasher::new();
+        rom_hasher.update(&*buf);
 
         let rom_size_code = buf[ROM_SIZE_CODE_OFFSET];
         let bank_count = rom_bank_count_from_code(rom_size_code)
@@ -164,6 +174,8 @@ impl RomStager {
             banks_written: 1,
             buf,
             filename: alloc::string::String::from(filename),
+            rom_hasher: Some(rom_hasher),
+            rom_id: None,
         })
     }
 
@@ -192,6 +204,9 @@ impl RomStager {
         reader
             .read_bank(self.banks_written, &mut *self.buf)
             .map_err(FlashRomStageError::Reader)?;
+        if let Some(hasher) = self.rom_hasher.as_mut() {
+            hasher.update(&*self.buf);
+        }
         flash
             .blocking_write(
                 (ROM_DATA_OFFSET + self.banks_written * ROM_BANK_BYTES) as u32,
@@ -211,11 +226,25 @@ impl RomStager {
         }
     }
 
-    fn make_info(&self) -> FlashRomInfo {
+    fn make_info(&mut self) -> FlashRomInfo {
         FlashRomInfo {
             size_bytes: self.bank_count * ROM_BANK_BYTES,
             bank_count: self.bank_count,
+            rom_id: Some(self.finalize_rom_id()),
         }
+    }
+
+    fn finalize_rom_id(&mut self) -> RomId {
+        if let Some(rom_id) = self.rom_id {
+            return rom_id;
+        }
+        let rom_id = self
+            .rom_hasher
+            .take()
+            .expect("ROM hasher finalized twice")
+            .finalize();
+        self.rom_id = Some(rom_id);
+        rom_id
     }
 }
 
@@ -235,7 +264,7 @@ fn parse_header(header: &[u8; HEADER_LEN]) -> Option<(FlashRomInfo, Option<heapl
     }
 
     let version = u32::from_le_bytes(header[8..12].try_into().ok()?);
-    if version != HEADER_VERSION {
+    if version != HEADER_VERSION_V1 && version != HEADER_VERSION_V2 {
         return None;
     }
 
@@ -259,6 +288,7 @@ fn parse_header(header: &[u8; HEADER_LEN]) -> Option<(FlashRomInfo, Option<heapl
     let info = FlashRomInfo {
         size_bytes,
         bank_count,
+        rom_id: parse_rom_id(header, version),
     };
 
     // Parse filename from bytes [FILENAME_OFFSET..FILENAME_OFFSET+64].
@@ -295,7 +325,22 @@ fn build_header(info: FlashRomInfo, filename: &str) -> [u8; HEADER_LEN] {
     let copy_len = name_bytes.len().min(FILENAME_MAX_BYTES);
     header[FILENAME_OFFSET..FILENAME_OFFSET + copy_len].copy_from_slice(&name_bytes[..copy_len]);
     header[FILENAME_OFFSET + copy_len] = 0;
+    if let Some(rom_id) = info.rom_id {
+        header[ROM_ID_OFFSET..ROM_ID_OFFSET + 32].copy_from_slice(rom_id.as_bytes());
+    }
     header
+}
+
+fn parse_rom_id(header: &[u8; HEADER_LEN], version: u32) -> Option<RomId> {
+    if version < HEADER_VERSION_V2 {
+        return None;
+    }
+    let bytes: [u8; 32] = header[ROM_ID_OFFSET..ROM_ID_OFFSET + 32].try_into().ok()?;
+    if bytes.iter().all(|&b| b == 0xFF) {
+        None
+    } else {
+        Some(RomId::from_bytes(bytes))
+    }
 }
 
 fn rom_bank_count_from_code(code: u8) -> Option<usize> {

--- a/platform/pico2w/src/lib.rs
+++ b/platform/pico2w/src/lib.rs
@@ -11,6 +11,7 @@ pub mod input;
 pub mod menu;
 #[cfg(target_arch = "arm")]
 pub mod multicore;
+pub mod save_storage;
 #[cfg(target_arch = "arm")]
 pub mod sd;
 #[cfg(target_arch = "arm")]

--- a/platform/pico2w/src/main.rs
+++ b/platform/pico2w/src/main.rs
@@ -167,6 +167,28 @@ pub(crate) fn refresh_save_slot_available(app: &mut App, sd_mgr: &PicoSdMgr) {
     app.save_slot_available = sd_mgr.save_state_exists(&rom_id, slot).unwrap_or(false);
 }
 
+pub(crate) fn boot_load_saves(rom_id: RomId, sd_mgr: &PicoSdMgr, gameboy: &mut PicoGameBoy) {
+    match sd_mgr.read_battery_save(&rom_id) {
+        Ok(Some(data)) => gameboy.set_external_ram(&data),
+        Ok(None) => {}
+        Err(e) => defmt::warn!("battery load failed: {:?}", defmt::Debug2Format(&e)),
+    }
+    let slot = SaveSlot::new(0).expect("slot 0 is valid");
+    match sd_mgr.read_save_state(&rom_id, slot) {
+        Ok(Some(blob)) => {
+            match rustyboy_core::cpu::save_state::SaveState::from_blob(blob) {
+                Ok(state) => {
+                    let _ = gameboy.load_state(state);
+                    info!("save state loaded on boot");
+                }
+                Err(msg) => defmt::warn!("boot save state parse failed: {}", msg),
+            }
+        }
+        Ok(None) => {}
+        Err(e) => defmt::warn!("boot save state read failed: {:?}", defmt::Debug2Format(&e)),
+    }
+}
+
 pub(crate) enum AppState {
     Running(RunningState),
     InGameMenu(InGameMenuState),
@@ -298,27 +320,7 @@ async fn main(_spawner: Spawner) {
                     );
                     let mut gb = PicoGameBoy::with_cartridge(p.CORE1, Box::new(cart));
                     if let Some(rom_id) = info.rom_id {
-                        match sd_mgr.read_battery_save(&rom_id) {
-                            Ok(Some(data)) => gb.set_external_ram(&data),
-                            Ok(None) => {}
-                            Err(e) => {
-                                defmt::warn!("battery load failed: {:?}", defmt::Debug2Format(&e))
-                            }
-                        }
-                        let slot = SaveSlot::new(0).expect("slot 0 is valid");
-                        match sd_mgr.read_save_state(&rom_id, slot) {
-                            Ok(Some(blob)) => {
-                                match rustyboy_core::cpu::save_state::SaveState::from_blob(blob) {
-                                    Ok(state) => {
-                                        let _ = gb.load_state(state);
-                                        info!("save state loaded on boot");
-                                    }
-                                    Err(msg) => defmt::warn!("boot save state parse failed: {}", msg),
-                                }
-                            }
-                            Ok(None) => {}
-                            Err(e) => defmt::warn!("boot save state read failed: {:?}", defmt::Debug2Format(&e)),
-                        }
+                        boot_load_saves(rom_id, &sd_mgr, &mut gb);
                     }
                     info!("ROM loaded, entering main loop");
                     (

--- a/platform/pico2w/src/main.rs
+++ b/platform/pico2w/src/main.rs
@@ -52,7 +52,7 @@ use rustyboy_pico2w::display::hw::{GameDisplay, HwDisplay};
 use rustyboy_pico2w::flash_rom::{new_onboard_flash, probe_staged_rom};
 use rustyboy_pico2w::input::{ButtonState, InputHandler};
 use rustyboy_pico2w::multicore::PicoGameBoy;
-use rustyboy_pico2w::save_storage::SaveSlot;
+use rustyboy_pico2w::save_storage::{boot_load_saves, BootSaves, SaveSlot};
 use rustyboy_pico2w::sd::{self, DummyClock};
 use rustyboy_pico2w::stack_probe;
 use rustyboy_pico2w::xip_cartridge::XipCartridge;
@@ -165,28 +165,6 @@ pub(crate) fn refresh_save_slot_available(app: &mut App, sd_mgr: &PicoSdMgr) {
     };
     let slot = SaveSlot::new(0).expect("slot 0 is valid");
     app.save_slot_available = sd_mgr.save_state_exists(&rom_id, slot).unwrap_or(false);
-}
-
-pub(crate) fn boot_load_saves(rom_id: RomId, sd_mgr: &PicoSdMgr, gameboy: &mut PicoGameBoy) {
-    match sd_mgr.read_battery_save(&rom_id) {
-        Ok(Some(data)) => gameboy.set_external_ram(&data),
-        Ok(None) => {}
-        Err(e) => defmt::warn!("battery load failed: {:?}", defmt::Debug2Format(&e)),
-    }
-    let slot = SaveSlot::new(0).expect("slot 0 is valid");
-    match sd_mgr.read_save_state(&rom_id, slot) {
-        Ok(Some(blob)) => {
-            match rustyboy_core::cpu::save_state::SaveState::from_blob(blob) {
-                Ok(state) => {
-                    let _ = gameboy.load_state(state);
-                    info!("save state loaded on boot");
-                }
-                Err(msg) => defmt::warn!("boot save state parse failed: {}", msg),
-            }
-        }
-        Ok(None) => {}
-        Err(e) => defmt::warn!("boot save state read failed: {:?}", defmt::Debug2Format(&e)),
-    }
 }
 
 pub(crate) enum AppState {
@@ -320,7 +298,24 @@ async fn main(_spawner: Spawner) {
                     );
                     let mut gb = PicoGameBoy::with_cartridge(p.CORE1, Box::new(cart));
                     if let Some(rom_id) = info.rom_id {
-                        boot_load_saves(rom_id, &sd_mgr, &mut gb);
+                        let battery_data = sd_mgr.read_battery_save(&rom_id)
+                            .unwrap_or_else(|e| { defmt::warn!("battery load failed: {:?}", defmt::Debug2Format(&e)); None });
+                        let slot = SaveSlot::new(0).expect("slot 0 is valid");
+                        let save_state_blob = sd_mgr.read_save_state(&rom_id, slot)
+                            .unwrap_or_else(|e| { defmt::warn!("boot save state read failed: {:?}", defmt::Debug2Format(&e)); None });
+                        match boot_load_saves(battery_data, save_state_blob) {
+                            None => {}
+                            Some(BootSaves::BatterySave(data)) => gb.set_external_ram(&data),
+                            Some(BootSaves::SaveState(state)) => {
+                                let _ = gb.load_state(state);
+                                info!("save state loaded on boot");
+                            }
+                            Some(BootSaves::Both { battery, save_state }) => {
+                                gb.set_external_ram(&battery);
+                                let _ = gb.load_state(save_state);
+                                info!("save state loaded on boot");
+                            }
+                        }
                     }
                     info!("ROM loaded, entering main loop");
                     (

--- a/platform/pico2w/src/main.rs
+++ b/platform/pico2w/src/main.rs
@@ -305,6 +305,20 @@ async fn main(_spawner: Spawner) {
                                 defmt::warn!("battery load failed: {:?}", defmt::Debug2Format(&e))
                             }
                         }
+                        let slot = SaveSlot::new(0).expect("slot 0 is valid");
+                        match sd_mgr.read_save_state(&rom_id, slot) {
+                            Ok(Some(blob)) => {
+                                match rustyboy_core::cpu::save_state::SaveState::from_blob(blob) {
+                                    Ok(state) => {
+                                        let _ = gb.load_state(state);
+                                        info!("save state loaded on boot");
+                                    }
+                                    Err(msg) => defmt::warn!("boot save state parse failed: {}", msg),
+                                }
+                            }
+                            Ok(None) => {}
+                            Err(e) => defmt::warn!("boot save state read failed: {:?}", defmt::Debug2Format(&e)),
+                        }
                     }
                     info!("ROM loaded, entering main loop");
                     (

--- a/platform/pico2w/src/main.rs
+++ b/platform/pico2w/src/main.rs
@@ -44,6 +44,7 @@ use embassy_rp::{bind_interrupts, dma};
 use embassy_time::{Delay, Duration};
 use embedded_hal_bus::spi::ExclusiveDevice;
 use embedded_sdmmc::SdCard;
+use rustyboy_core::storage::RomId;
 use {defmt_rtt as _, panic_probe as _};
 
 use rustyboy_pico2w::audio::{AudioBuffers, SAMPLE_RATE};
@@ -51,6 +52,7 @@ use rustyboy_pico2w::display::hw::{GameDisplay, HwDisplay};
 use rustyboy_pico2w::flash_rom::{new_onboard_flash, probe_staged_rom};
 use rustyboy_pico2w::input::{ButtonState, InputHandler};
 use rustyboy_pico2w::multicore::PicoGameBoy;
+use rustyboy_pico2w::save_storage::SaveSlot;
 use rustyboy_pico2w::sd::{self, DummyClock};
 use rustyboy_pico2w::stack_probe;
 use rustyboy_pico2w::xip_cartridge::XipCartridge;
@@ -123,9 +125,10 @@ pub(crate) fn poll_once<F: Future>(future: core::pin::Pin<&mut F>) -> bool {
 pub(crate) struct App {
     pub(crate) state: AppState,
     pub(crate) next_state: Option<AppState>,
-    pub(crate) save_slot: Option<Vec<u8>>,
+    pub(crate) save_slot_available: bool,
     pub(crate) previous_buttons: ButtonState,
     pub(crate) staged_rom_name: Option<heapless::String<64>>,
+    pub(crate) staged_rom_id: Option<RomId>,
     pub(crate) core1: Option<Peri<'static, CORE1>>,
 }
 
@@ -133,6 +136,35 @@ impl App {
     pub(crate) fn transition_to(&mut self, next: AppState) {
         self.next_state = Some(next);
     }
+}
+
+pub(crate) fn load_battery_save(app: &App, sd_mgr: &PicoSdMgr, gameboy: &mut PicoGameBoy) {
+    let Some(rom_id) = app.staged_rom_id else {
+        return;
+    };
+    match sd_mgr.read_battery_save(&rom_id) {
+        Ok(Some(data)) => gameboy.set_external_ram(&data),
+        Ok(None) => {}
+        Err(e) => defmt::warn!("battery load failed: {:?}", defmt::Debug2Format(&e)),
+    }
+}
+
+pub(crate) fn flush_battery_save(app: &App, sd_mgr: &PicoSdMgr, gameboy: &PicoGameBoy) {
+    let (Some(rom_id), Some(ram)) = (app.staged_rom_id, gameboy.external_ram()) else {
+        return;
+    };
+    if let Err(e) = sd_mgr.write_battery_save(&rom_id, ram) {
+        defmt::warn!("battery save failed: {:?}", defmt::Debug2Format(&e));
+    }
+}
+
+pub(crate) fn refresh_save_slot_available(app: &mut App, sd_mgr: &PicoSdMgr) {
+    let Some(rom_id) = app.staged_rom_id else {
+        app.save_slot_available = false;
+        return;
+    };
+    let slot = SaveSlot::new(0).expect("slot 0 is valid");
+    app.save_slot_available = sd_mgr.save_state_exists(&rom_id, slot).unwrap_or(false);
 }
 
 pub(crate) enum AppState {
@@ -249,7 +281,7 @@ async fn main(_spawner: Spawner) {
     let mut audio_samples = Vec::with_capacity(2048);
 
     // Build initial state: Running if a ROM is staged, else MainMenu.
-    let (initial_state, gameboy_init, staged_rom_name, core1_token) = match staged {
+    let (initial_state, gameboy_init, staged_rom_name, staged_rom_id, core1_token) = match staged {
         Some((info, name)) => {
             info!(
                 "staged ROM found in flash: {} banks ({} KiB)",
@@ -264,22 +296,38 @@ async fn main(_spawner: Spawner) {
                         "building GameBoy, clk={}",
                         embassy_rp::clocks::clk_sys_freq()
                     );
-                    let gb = PicoGameBoy::with_cartridge(p.CORE1, Box::new(cart));
+                    let mut gb = PicoGameBoy::with_cartridge(p.CORE1, Box::new(cart));
+                    if let Some(rom_id) = info.rom_id {
+                        match sd_mgr.read_battery_save(&rom_id) {
+                            Ok(Some(data)) => gb.set_external_ram(&data),
+                            Ok(None) => {}
+                            Err(e) => {
+                                defmt::warn!("battery load failed: {:?}", defmt::Debug2Format(&e))
+                            }
+                        }
+                    }
                     info!("ROM loaded, entering main loop");
-                    (AppState::Running(RunningState), Some(gb), name, None)
+                    (
+                        AppState::Running(RunningState),
+                        Some(gb),
+                        name,
+                        info.rom_id,
+                        None,
+                    )
                 }
                 Err(e) => {
                     defmt::error!("flash ROM mapping failed: {:?}", defmt::Debug2Format(&e));
                     let stub_app = App {
                         state: AppState::Running(RunningState),
                         next_state: None,
-                        save_slot: None,
+                        save_slot_available: false,
                         previous_buttons: ButtonState::default(),
                         staged_rom_name: None,
+                        staged_rom_id: None,
                         core1: None,
                     };
                     let next = MainMenuState::new(&mut game_disp, &stub_app).await;
-                    (AppState::MainMenu(next), None, None, Some(p.CORE1))
+                    (AppState::MainMenu(next), None, None, None, Some(p.CORE1))
                 }
             }
         }
@@ -288,13 +336,20 @@ async fn main(_spawner: Spawner) {
             let stub_app = App {
                 state: AppState::Running(RunningState),
                 next_state: None,
-                save_slot: None,
+                save_slot_available: false,
                 previous_buttons: ButtonState::default(),
                 staged_rom_name: None,
+                staged_rom_id: None,
                 core1: None,
             };
             let menu_state = MainMenuState::new(&mut game_disp, &stub_app).await;
-            (AppState::MainMenu(menu_state), None, None, Some(p.CORE1))
+            (
+                AppState::MainMenu(menu_state),
+                None,
+                None,
+                None,
+                Some(p.CORE1),
+            )
         }
     };
 
@@ -306,11 +361,13 @@ async fn main(_spawner: Spawner) {
     let mut app = App {
         state: initial_state,
         next_state: None,
-        save_slot: None,
+        save_slot_available: false,
         previous_buttons: ButtonState::default(),
         staged_rom_name,
+        staged_rom_id,
         core1: core1_token,
     };
+    refresh_save_slot_available(&mut app, &sd_mgr);
 
     #[cfg(feature = "fps")]
     let mut tracker = perf::PerfTracker::new();
@@ -331,6 +388,7 @@ async fn main(_spawner: Spawner) {
                         &mut game_disp,
                         &mut i2s,
                         &mut input,
+                        &mut sd_mgr,
                         &mut audio_buffers,
                         &mut audio_samples,
                     )
@@ -347,6 +405,7 @@ async fn main(_spawner: Spawner) {
                         gameboy.as_mut().expect("InGameMenu without GameBoy"),
                         &mut game_disp,
                         &mut input,
+                        &mut sd_mgr,
                     )
                     .await;
             }

--- a/platform/pico2w/src/menu.rs
+++ b/platform/pico2w/src/menu.rs
@@ -38,6 +38,7 @@ pub enum MenuEffect {
     Resume,
     Save,
     Load,
+    Reset,
     Quit,
     Continue,
     ShowRoms,
@@ -120,7 +121,7 @@ pub trait MenuLogic {
 // In-game pause menu
 // ---------------------------------------------------------------------------
 
-const INGAME_ITEMS: &[&str] = &["RESUME", "SAVE", "LOAD", "QUIT"];
+const INGAME_ITEMS: &[&str] = &["RESUME", "SAVE", "LOAD", "RESET", "QUIT"];
 
 pub struct InGameMenu {
     selected: usize,
@@ -135,8 +136,8 @@ impl InGameMenu {
 impl MenuLogic for InGameMenu {
     /// `context_flag` = save slot available (enables Load).
     fn frame(&self, save_available: bool) -> MenuFrame<'_> {
-        static ALL_ENABLED: [bool; 4] = [true, true, true, true];
-        static LOAD_DISABLED: [bool; 4] = [true, true, false, true];
+        static ALL_ENABLED: [bool; 5] = [true, true, true, true, true];
+        static LOAD_DISABLED: [bool; 5] = [true, true, false, true, true];
         MenuFrame {
             title: "PAUSED",
             items: INGAME_ITEMS,
@@ -168,7 +169,8 @@ impl MenuLogic for InGameMenu {
                 0 => MenuEffect::Resume,
                 1 => MenuEffect::Save,
                 2 => MenuEffect::Load,
-                3 => MenuEffect::Quit,
+                3 => MenuEffect::Reset,
+                4 => MenuEffect::Quit,
                 _ => MenuEffect::None,
             };
         }
@@ -449,7 +451,7 @@ mod tests {
         for _ in 0..10 {
             menu.handle(press_down());
         }
-        assert_eq!(menu.selected, INGAME_ITEMS.len() - 1);
+        assert_eq!(menu.selected, INGAME_ITEMS.len() - 1); // QUIT
     }
 
     #[test]
@@ -474,9 +476,18 @@ mod tests {
     }
 
     #[test]
-    fn ingame_confirm_on_quit_returns_quit() {
+    fn ingame_confirm_on_reset_returns_reset() {
         let mut menu = InGameMenu::new();
         for _ in 0..3 {
+            menu.handle(press_down());
+        } // -> RESET
+        assert_eq!(menu.handle(press_a()), MenuEffect::Reset);
+    }
+
+    #[test]
+    fn ingame_confirm_on_quit_returns_quit() {
+        let mut menu = InGameMenu::new();
+        for _ in 0..4 {
             menu.handle(press_down());
         } // -> QUIT
         assert_eq!(menu.handle(press_a()), MenuEffect::Quit);
@@ -500,17 +511,16 @@ mod tests {
     fn ingame_frame_disables_load_without_save() {
         let menu = InGameMenu::new();
         let frame = menu.frame(false);
-        assert!(
-            !frame.enabled[2],
-            "LOAD should be disabled with no save slot"
-        );
+        let load_idx = INGAME_ITEMS.iter().position(|&s| s == "LOAD").unwrap();
+        assert!(!frame.enabled[load_idx], "LOAD should be disabled with no save slot");
     }
 
     #[test]
     fn ingame_frame_enables_load_with_save() {
         let menu = InGameMenu::new();
         let frame = menu.frame(true);
-        assert!(frame.enabled[2], "LOAD should be enabled with a save slot");
+        let load_idx = INGAME_ITEMS.iter().position(|&s| s == "LOAD").unwrap();
+        assert!(frame.enabled[load_idx], "LOAD should be enabled with a save slot");
     }
 
     // --- MainMenu navigation ---

--- a/platform/pico2w/src/multicore.rs
+++ b/platform/pico2w/src/multicore.rs
@@ -976,6 +976,10 @@ impl PicoGameBoy {
     pub fn load_state(&mut self, state: SaveState) -> Result<(), &'static str> {
         self.gb.load_state(state)
     }
+
+    pub fn reset(&mut self) {
+        self.gb.reset();
+    }
     /// Flush pending commands and halt core1 in a WFE loop.
     ///
     /// After this returns, core1 will never read from flash again, making it

--- a/platform/pico2w/src/multicore.rs
+++ b/platform/pico2w/src/multicore.rs
@@ -961,6 +961,14 @@ impl PicoGameBoy {
         self.gb.read_memory(address)
     }
 
+    pub fn external_ram(&self) -> Option<&[u8]> {
+        self.gb.external_ram()
+    }
+
+    pub fn set_external_ram(&mut self, data: &[u8]) {
+        self.gb.set_external_ram(data);
+    }
+
     pub fn save_state(&self) -> Vec<u8> {
         self.gb.save_state()
     }

--- a/platform/pico2w/src/save_storage.rs
+++ b/platform/pico2w/src/save_storage.rs
@@ -1,0 +1,55 @@
+use alloc::string::String;
+
+use rustyboy_core::storage::RomId;
+
+pub const SAVE_ROOT_DIR: &str = "SAVES";
+pub const SAVE_SLOT_COUNT: u8 = 3;
+
+const BATTERY_SAVE_FILE: &str = "BATT.SAV";
+const SAVE_STATE_EXT: &str = ".RBS";
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SaveStorageError {
+    InvalidSlot,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct SaveSlot(u8);
+
+impl SaveSlot {
+    pub fn new(index: u8) -> Result<Self, SaveStorageError> {
+        if index < SAVE_SLOT_COUNT {
+            Ok(Self(index))
+        } else {
+            Err(SaveStorageError::InvalidSlot)
+        }
+    }
+
+    pub fn index(self) -> u8 {
+        self.0
+    }
+}
+
+pub fn rom_save_dir_name(rom_id: &RomId) -> String {
+    upper_ascii(rom_id.short_hex().as_str())
+}
+
+pub fn battery_save_filename() -> &'static str {
+    BATTERY_SAVE_FILE
+}
+
+pub fn save_state_filename(slot: SaveSlot) -> String {
+    let mut name = String::with_capacity(9);
+    name.push_str("SLOT");
+    name.push((b'0' + slot.index()) as char);
+    name.push_str(SAVE_STATE_EXT);
+    name
+}
+
+fn upper_ascii(value: &str) -> String {
+    let mut out = String::with_capacity(value.len());
+    for byte in value.bytes() {
+        out.push(byte.to_ascii_uppercase() as char);
+    }
+    out
+}

--- a/platform/pico2w/src/save_storage.rs
+++ b/platform/pico2w/src/save_storage.rs
@@ -1,5 +1,7 @@
 use alloc::string::String;
+use alloc::vec::Vec;
 
+use rustyboy_core::cpu::save_state::SaveState;
 use rustyboy_core::storage::RomId;
 
 pub const SAVE_ROOT_DIR: &str = "SAVES";
@@ -44,6 +46,34 @@ pub fn save_state_filename(slot: SaveSlot) -> String {
     name.push((b'0' + slot.index()) as char);
     name.push_str(SAVE_STATE_EXT);
     name
+}
+
+pub enum BootSaves {
+    BatterySave(Vec<u8>),
+    SaveState(SaveState),
+    Both { battery: Vec<u8>, save_state: SaveState },
+}
+
+/// Determine the boot start state from raw SD data.
+///
+/// `battery_data` and `save_state_blob` are the raw bytes read from the SD
+/// card (or `None` if the file was absent or the read failed). Returns `None`
+/// when neither file was present; otherwise returns the variant that describes
+/// which mutations the caller should apply to the GameBoy.
+pub fn boot_load_saves(
+    battery_data: Option<Vec<u8>>,
+    save_state_blob: Option<Vec<u8>>,
+) -> Option<BootSaves> {
+    let save_state = save_state_blob.and_then(|blob| SaveState::from_blob(blob).ok());
+    match (battery_data, save_state) {
+        (None, None) => None,
+        (Some(data), None) => Some(BootSaves::BatterySave(data)),
+        (None, Some(state)) => Some(BootSaves::SaveState(state)),
+        (Some(data), Some(state)) => Some(BootSaves::Both {
+            battery: data,
+            save_state: state,
+        }),
+    }
 }
 
 fn upper_ascii(value: &str) -> String {

--- a/platform/pico2w/src/save_storage.rs
+++ b/platform/pico2w/src/save_storage.rs
@@ -83,3 +83,79 @@ fn upper_ascii(value: &str) -> String {
     }
     out
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rustyboy_core::cpu::registers::{Flags, Registers};
+    use rustyboy_core::GameBoy;
+
+    fn make_save_state_blob() -> Vec<u8> {
+        let mut rom = vec![0u8; 0x8000];
+        rom[0x0100] = 0x00;
+        rom[0x0101] = 0x18;
+        rom[0x0102] = 0xFE;
+        GameBoy::new(rom)
+            .with_registers(Registers {
+                a: 0x01,
+                f: Flags::from_bits_truncate(0xB0),
+                b: 0x00,
+                c: 0x13,
+                d: 0x00,
+                e: 0xD8,
+                h: 0x01,
+                l: 0x4D,
+                pc: 0x0100,
+                sp: 0xFFFE,
+            })
+            .with_dmg_state()
+            .save_state()
+    }
+
+    #[test]
+    fn returns_none_when_both_absent() {
+        assert!(boot_load_saves(None, None).is_none());
+    }
+
+    #[test]
+    fn returns_battery_save_when_only_battery_present() {
+        let battery = vec![0xAA; 64];
+        match boot_load_saves(Some(battery.clone()), None).unwrap() {
+            BootSaves::BatterySave(data) => assert_eq!(data, battery),
+            _ => panic!("expected BatterySave variant"),
+        }
+    }
+
+    #[test]
+    fn returns_save_state_when_only_blob_present() {
+        let blob = make_save_state_blob();
+        assert!(matches!(
+            boot_load_saves(None, Some(blob)).unwrap(),
+            BootSaves::SaveState(_)
+        ));
+    }
+
+    #[test]
+    fn returns_both_when_both_present() {
+        let battery = vec![0xBB; 32];
+        let blob = make_save_state_blob();
+        match boot_load_saves(Some(battery.clone()), Some(blob)).unwrap() {
+            BootSaves::Both { battery: b, .. } => assert_eq!(b, battery),
+            _ => panic!("expected Both variant"),
+        }
+    }
+
+    #[test]
+    fn returns_none_when_blob_is_invalid_and_battery_absent() {
+        assert!(boot_load_saves(None, Some(vec![0xFF; 16])).is_none());
+    }
+
+    #[test]
+    fn falls_back_to_battery_when_blob_is_invalid() {
+        let battery = vec![0xCC; 8];
+        match boot_load_saves(Some(battery.clone()), Some(vec![0xFF; 16])).unwrap() {
+            BootSaves::BatterySave(data) => assert_eq!(data, battery),
+            _ => panic!("expected BatterySave fallback variant"),
+        }
+    }
+}

--- a/platform/pico2w/src/sd.rs
+++ b/platform/pico2w/src/sd.rs
@@ -6,8 +6,12 @@ use embedded_sdmmc::{
     VolumeIdx, VolumeManager,
 };
 
+use crate::save_storage::{
+    battery_save_filename, rom_save_dir_name, save_state_filename, SaveSlot, SAVE_ROOT_DIR,
+};
 use core::cmp::Ordering;
 use rustyboy_core::memory::RomReader;
+use rustyboy_core::storage::{BatterySaveBytes, RomId, SaveStateBytes, StorageValueError};
 
 // ── Time source ───────────────────────────────────────────────────────────────
 
@@ -23,6 +27,7 @@ impl TimeSource for DummyClock {
 #[derive(Debug)]
 pub enum SdError<E: core::fmt::Debug> {
     Sdmmc(embedded_sdmmc::Error<E>),
+    InvalidValue(StorageValueError),
     NoRomFound,
     OutOfMemory,
 }
@@ -178,6 +183,129 @@ where
             }
         }
     }
+
+    pub fn write_battery_save(&self, rom_id: &RomId, data: &[u8]) -> Result<(), SdError<D::Error>> {
+        BatterySaveBytes::new(data).map_err(SdError::InvalidValue)?;
+        self.with_rom_save_dir(rom_id, true, |mgr, dir| {
+            write_file(mgr, dir, battery_save_filename(), data)
+        })
+    }
+
+    pub fn read_battery_save(&self, rom_id: &RomId) -> Result<Option<Vec<u8>>, SdError<D::Error>> {
+        let Some(data) = self.with_existing_rom_save_dir(rom_id, |mgr, dir| {
+            read_file_optional(mgr, dir, battery_save_filename())
+        })?
+        else {
+            return Ok(None);
+        };
+
+        if let Some(data) = data.as_ref() {
+            BatterySaveBytes::new(data).map_err(SdError::InvalidValue)?;
+        }
+        Ok(data)
+    }
+
+    pub fn write_save_state(
+        &self,
+        rom_id: &RomId,
+        slot: SaveSlot,
+        data: &[u8],
+    ) -> Result<(), SdError<D::Error>> {
+        SaveStateBytes::new(data).map_err(SdError::InvalidValue)?;
+        let filename = save_state_filename(slot);
+        self.with_rom_save_dir(rom_id, true, |mgr, dir| {
+            write_file(mgr, dir, filename.as_str(), data)
+        })
+    }
+
+    pub fn read_save_state(
+        &self,
+        rom_id: &RomId,
+        slot: SaveSlot,
+    ) -> Result<Option<Vec<u8>>, SdError<D::Error>> {
+        let filename = save_state_filename(slot);
+        let Some(data) = self.with_existing_rom_save_dir(rom_id, |mgr, dir| {
+            read_file_optional(mgr, dir, filename.as_str())
+        })?
+        else {
+            return Ok(None);
+        };
+
+        if let Some(data) = data.as_ref() {
+            SaveStateBytes::new(data).map_err(SdError::InvalidValue)?;
+        }
+        Ok(data)
+    }
+
+    pub fn save_state_exists(
+        &self,
+        rom_id: &RomId,
+        slot: SaveSlot,
+    ) -> Result<bool, SdError<D::Error>> {
+        let filename = save_state_filename(slot);
+        let Some(exists) = self.with_existing_rom_save_dir(rom_id, |mgr, dir| {
+            file_exists(mgr, dir, filename.as_str())
+        })?
+        else {
+            return Ok(false);
+        };
+        Ok(exists)
+    }
+
+    fn with_rom_save_dir<R>(
+        &self,
+        rom_id: &RomId,
+        create: bool,
+        f: impl FnOnce(&VolumeManager<D, T>, RawDirectory) -> Result<R, SdError<D::Error>>,
+    ) -> Result<R, SdError<D::Error>> {
+        let volume = self.mgr.open_raw_volume(VolumeIdx(0))?;
+        let root = match self.mgr.open_root_dir(volume) {
+            Ok(root) => root,
+            Err(e) => {
+                let _ = self.mgr.close_volume(volume);
+                return Err(SdError::Sdmmc(e));
+            }
+        };
+
+        let saves = match open_save_dir(&self.mgr, root, SAVE_ROOT_DIR, create) {
+            Ok(dir) => dir,
+            Err(e) => {
+                let _ = self.mgr.close_dir(root);
+                let _ = self.mgr.close_volume(volume);
+                return Err(e);
+            }
+        };
+
+        let rom_dir_name = rom_save_dir_name(rom_id);
+        let rom_dir = match open_save_dir(&self.mgr, saves, rom_dir_name.as_str(), create) {
+            Ok(dir) => dir,
+            Err(e) => {
+                let _ = self.mgr.close_dir(saves);
+                let _ = self.mgr.close_dir(root);
+                let _ = self.mgr.close_volume(volume);
+                return Err(e);
+            }
+        };
+
+        let mut result = f(&self.mgr, rom_dir);
+        close_dir_if_ok(&self.mgr, rom_dir, &mut result);
+        close_dir_if_ok(&self.mgr, saves, &mut result);
+        close_dir_if_ok(&self.mgr, root, &mut result);
+        close_volume_if_ok(&self.mgr, volume, &mut result);
+        result
+    }
+
+    fn with_existing_rom_save_dir<R>(
+        &self,
+        rom_id: &RomId,
+        f: impl FnOnce(&VolumeManager<D, T>, RawDirectory) -> Result<R, SdError<D::Error>>,
+    ) -> Result<Option<R>, SdError<D::Error>> {
+        match self.with_rom_save_dir(rom_id, false, f) {
+            Ok(value) => Ok(Some(value)),
+            Err(SdError::Sdmmc(embedded_sdmmc::Error::NotFound)) => Ok(None),
+            Err(e) => Err(e),
+        }
+    }
 }
 
 // ── SdRomReader ───────────────────────────────────────────────────────────────
@@ -292,6 +420,170 @@ fn ascii_upper(byte: u8) -> u8 {
         byte - 32
     } else {
         byte
+    }
+}
+
+fn open_save_dir<D, T>(
+    mgr: &VolumeManager<D, T>,
+    parent: RawDirectory,
+    name: &str,
+    create: bool,
+) -> Result<RawDirectory, SdError<D::Error>>
+where
+    D: BlockDevice,
+    D::Error: core::fmt::Debug,
+    T: TimeSource,
+{
+    match mgr.open_dir(parent, name) {
+        Ok(dir) => Ok(dir),
+        Err(embedded_sdmmc::Error::NotFound) if create => {
+            match mgr.make_dir_in_dir(parent, name) {
+                Ok(()) | Err(embedded_sdmmc::Error::DirAlreadyExists) => {}
+                Err(e) => return Err(SdError::Sdmmc(e)),
+            }
+            mgr.open_dir(parent, name).map_err(SdError::Sdmmc)
+        }
+        Err(e) => Err(SdError::Sdmmc(e)),
+    }
+}
+
+fn write_file<D, T>(
+    mgr: &VolumeManager<D, T>,
+    dir: RawDirectory,
+    name: &str,
+    data: &[u8],
+) -> Result<(), SdError<D::Error>>
+where
+    D: BlockDevice,
+    D::Error: core::fmt::Debug,
+    T: TimeSource,
+{
+    let file = mgr.open_file_in_dir(dir, name, Mode::ReadWriteCreateOrTruncate)?;
+    let mut result = mgr.write(file, data).map_err(SdError::Sdmmc);
+    close_file_if_ok(mgr, file, &mut result);
+    result
+}
+
+fn read_file_optional<D, T>(
+    mgr: &VolumeManager<D, T>,
+    dir: RawDirectory,
+    name: &str,
+) -> Result<Option<Vec<u8>>, SdError<D::Error>>
+where
+    D: BlockDevice,
+    D::Error: core::fmt::Debug,
+    T: TimeSource,
+{
+    let file = match mgr.open_file_in_dir(dir, name, Mode::ReadOnly) {
+        Ok(file) => file,
+        Err(embedded_sdmmc::Error::NotFound) => return Ok(None),
+        Err(e) => return Err(SdError::Sdmmc(e)),
+    };
+
+    let result = read_open_file(mgr, file);
+    let mut result = result.map(Some);
+    close_file_if_ok(mgr, file, &mut result);
+    result
+}
+
+fn file_exists<D, T>(
+    mgr: &VolumeManager<D, T>,
+    dir: RawDirectory,
+    name: &str,
+) -> Result<bool, SdError<D::Error>>
+where
+    D: BlockDevice,
+    D::Error: core::fmt::Debug,
+    T: TimeSource,
+{
+    let file = match mgr.open_file_in_dir(dir, name, Mode::ReadOnly) {
+        Ok(file) => file,
+        Err(embedded_sdmmc::Error::NotFound) => return Ok(false),
+        Err(e) => return Err(SdError::Sdmmc(e)),
+    };
+    let mut result = Ok(true);
+    close_file_if_ok(mgr, file, &mut result);
+    result
+}
+
+fn read_open_file<D, T>(
+    mgr: &VolumeManager<D, T>,
+    file: RawFile,
+) -> Result<Vec<u8>, SdError<D::Error>>
+where
+    D: BlockDevice,
+    D::Error: core::fmt::Debug,
+    T: TimeSource,
+{
+    let len = mgr.file_length(file)? as usize;
+    let mut data = Vec::new();
+    data.try_reserve_exact(len)
+        .map_err(|_| SdError::OutOfMemory)?;
+    data.resize(len, 0);
+
+    let mut total = 0;
+    while total < len {
+        let read = mgr.read(file, &mut data[total..])?;
+        if read == 0 {
+            break;
+        }
+        total += read;
+    }
+    data.truncate(total);
+    Ok(data)
+}
+
+fn close_file_if_ok<D, T, R>(
+    mgr: &VolumeManager<D, T>,
+    file: RawFile,
+    result: &mut Result<R, SdError<D::Error>>,
+) where
+    D: BlockDevice,
+    D::Error: core::fmt::Debug,
+    T: TimeSource,
+{
+    if result.is_ok() {
+        if let Err(e) = mgr.close_file(file) {
+            *result = Err(SdError::Sdmmc(e));
+        }
+    } else {
+        let _ = mgr.close_file(file);
+    }
+}
+
+fn close_dir_if_ok<D, T, R>(
+    mgr: &VolumeManager<D, T>,
+    dir: RawDirectory,
+    result: &mut Result<R, SdError<D::Error>>,
+) where
+    D: BlockDevice,
+    D::Error: core::fmt::Debug,
+    T: TimeSource,
+{
+    if result.is_ok() {
+        if let Err(e) = mgr.close_dir(dir) {
+            *result = Err(SdError::Sdmmc(e));
+        }
+    } else {
+        let _ = mgr.close_dir(dir);
+    }
+}
+
+fn close_volume_if_ok<D, T, R>(
+    mgr: &VolumeManager<D, T>,
+    volume: RawVolume,
+    result: &mut Result<R, SdError<D::Error>>,
+) where
+    D: BlockDevice,
+    D::Error: core::fmt::Debug,
+    T: TimeSource,
+{
+    if result.is_ok() {
+        if let Err(e) = mgr.close_volume(volume) {
+            *result = Err(SdError::Sdmmc(e));
+        }
+    } else {
+        let _ = mgr.close_volume(volume);
     }
 }
 

--- a/platform/pico2w/src/state/in_game_menu.rs
+++ b/platform/pico2w/src/state/in_game_menu.rs
@@ -59,8 +59,8 @@ impl InGameMenuState {
                         Err(e) => warn!("state save failed: {:?}", defmt::Debug2Format(&e)),
                     }
                 }
-                let frame = self.menu.frame(app.save_slot_available);
-                game_disp.draw_menu(&frame).await;
+                game_disp.draw_letterbox_bars().await;
+                app.transition_to(AppState::Running(RunningState));
             }
             MenuEffect::Load => {
                 if let Some(rom_id) = app.staged_rom_id {

--- a/platform/pico2w/src/state/in_game_menu.rs
+++ b/platform/pico2w/src/state/in_game_menu.rs
@@ -81,6 +81,11 @@ impl InGameMenuState {
                 game_disp.draw_letterbox_bars().await;
                 app.transition_to(AppState::Running(RunningState));
             }
+            MenuEffect::Reset => {
+                gameboy.reset();
+                game_disp.draw_letterbox_bars().await;
+                app.transition_to(AppState::Running(RunningState));
+            }
             MenuEffect::Quit => {
                 flush_battery_save(app, sd_mgr, gameboy);
                 let next = MainMenuState::new(game_disp, app).await;

--- a/platform/pico2w/src/state/in_game_menu.rs
+++ b/platform/pico2w/src/state/in_game_menu.rs
@@ -5,9 +5,10 @@ use rustyboy_pico2w::display::hw::GameDisplay;
 use rustyboy_pico2w::input::InputHandler;
 use rustyboy_pico2w::menu::{InGameMenu, MenuEffect, MenuInput, MenuLogic};
 use rustyboy_pico2w::multicore::PicoGameBoy;
+use rustyboy_pico2w::save_storage::SaveSlot;
 
 use super::{MainMenuState, RunningState};
-use crate::{App, AppState};
+use crate::{flush_battery_save, App, AppState, PicoSdMgr};
 
 pub struct InGameMenuState {
     menu: InGameMenu,
@@ -16,7 +17,7 @@ pub struct InGameMenuState {
 impl InGameMenuState {
     pub async fn new(game_disp: &mut GameDisplay<'static>, app: &App) -> Self {
         let menu = InGameMenu::new();
-        let frame = menu.frame(app.save_slot.is_some());
+        let frame = menu.frame(app.save_slot_available);
         game_disp.draw_menu(&frame).await;
         Self { menu }
     }
@@ -27,6 +28,7 @@ impl InGameMenuState {
         gameboy: &mut PicoGameBoy,
         game_disp: &mut GameDisplay<'static>,
         input: &mut InputHandler<'static>,
+        sd_mgr: &mut PicoSdMgr,
     ) {
         Timer::after(Duration::from_millis(33)).await;
 
@@ -40,7 +42,7 @@ impl InGameMenuState {
 
         match self.menu.handle(menu_input) {
             MenuEffect::None => {
-                let frame = self.menu.frame(app.save_slot.is_some());
+                let frame = self.menu.frame(app.save_slot_available);
                 game_disp.draw_menu(&frame).await;
             }
             MenuEffect::Resume => {
@@ -48,25 +50,39 @@ impl InGameMenuState {
                 app.transition_to(AppState::Running(RunningState));
             }
             MenuEffect::Save => {
-                app.save_slot = Some(gameboy.save_state());
-                let frame = self.menu.frame(true);
+                flush_battery_save(app, sd_mgr, gameboy);
+                if let Some(rom_id) = app.staged_rom_id {
+                    let slot = SaveSlot::new(0).expect("slot 0 is valid");
+                    let blob = gameboy.save_state();
+                    match sd_mgr.write_save_state(&rom_id, slot, &blob) {
+                        Ok(()) => app.save_slot_available = true,
+                        Err(e) => warn!("state save failed: {:?}", defmt::Debug2Format(&e)),
+                    }
+                }
+                let frame = self.menu.frame(app.save_slot_available);
                 game_disp.draw_menu(&frame).await;
             }
             MenuEffect::Load => {
-                if let Some(blob) = app.save_slot.as_ref() {
-                    match SaveState::from_blob(blob.clone()) {
-                        Ok(save_state) => {
-                            let _ = gameboy.load_state(save_state);
-                        }
-                        Err(message) => {
-                            warn!("load failed: {}", message);
-                        }
+                if let Some(rom_id) = app.staged_rom_id {
+                    let slot = SaveSlot::new(0).expect("slot 0 is valid");
+                    match sd_mgr.read_save_state(&rom_id, slot) {
+                        Ok(Some(blob)) => match SaveState::from_blob(blob) {
+                            Ok(save_state) => {
+                                let _ = gameboy.load_state(save_state);
+                            }
+                            Err(message) => {
+                                warn!("load failed: {}", message);
+                            }
+                        },
+                        Ok(None) => app.save_slot_available = false,
+                        Err(e) => warn!("state read failed: {:?}", defmt::Debug2Format(&e)),
                     }
                 }
                 game_disp.draw_letterbox_bars().await;
                 app.transition_to(AppState::Running(RunningState));
             }
             MenuEffect::Quit => {
+                flush_battery_save(app, sd_mgr, gameboy);
                 let next = MainMenuState::new(game_disp, app).await;
                 app.transition_to(AppState::MainMenu(next));
             }

--- a/platform/pico2w/src/state/loading.rs
+++ b/platform/pico2w/src/state/loading.rs
@@ -11,7 +11,9 @@ use rustyboy_pico2w::multicore::PicoGameBoy;
 use rustyboy_pico2w::xip_cartridge::XipCartridge;
 
 use super::{MainMenuState, RunningState};
-use crate::{App, AppState, PicoSdMgr};
+use crate::{
+    flush_battery_save, load_battery_save, refresh_save_slot_available, App, AppState, PicoSdMgr,
+};
 
 pub struct LoadingState {
     pub(crate) filename: heapless::String<64>,
@@ -28,6 +30,9 @@ impl LoadingState {
         game_disp: &mut GameDisplay<'static>,
         watchdog: &mut Watchdog,
     ) {
+        if let Some(existing_gb) = gameboy.as_ref() {
+            flush_battery_save(app, sd_mgr, existing_gb);
+        }
         let had_game = halt_running_game(gameboy);
         let stage_result = self
             .ensure_rom_staged(app, flash, sd_mgr, game_disp, watchdog)
@@ -35,7 +40,7 @@ impl LoadingState {
 
         match stage_result {
             Ok(info) => {
-                self.enter_staged_rom(app, gameboy, game_disp, watchdog, had_game, info)
+                self.enter_staged_rom(app, gameboy, sd_mgr, game_disp, watchdog, had_game, info)
                     .await;
             }
             Err(_) => {
@@ -75,16 +80,18 @@ impl LoadingState {
         &self,
         app: &mut App,
         gameboy: &mut Option<PicoGameBoy>,
+        sd_mgr: &mut PicoSdMgr,
         game_disp: &mut GameDisplay<'static>,
         watchdog: &mut Watchdog,
         had_game: bool,
         info: FlashRomInfo,
     ) {
         app.staged_rom_name = Some(self.filename.clone());
+        app.staged_rom_id = info.rom_id;
         if had_game {
             restart_after_rom_switch(watchdog);
         } else {
-            start_first_rom(app, gameboy, game_disp, info).await;
+            start_first_rom(app, gameboy, sd_mgr, game_disp, info).await;
         }
     }
 }
@@ -114,6 +121,7 @@ fn rom_matches_staged(app: &App, filename: &str) -> bool {
 async fn start_first_rom(
     app: &mut App,
     gameboy: &mut Option<PicoGameBoy>,
+    sd_mgr: &mut PicoSdMgr,
     game_disp: &mut GameDisplay<'static>,
     info: FlashRomInfo,
 ) {
@@ -123,7 +131,10 @@ async fn start_first_rom(
         .expect("CORE1 consumed without a running game");
     match XipCartridge::from_staged_flash(info) {
         Ok(cart) => {
-            *gameboy = Some(PicoGameBoy::with_cartridge(core1, Box::new(cart)));
+            let mut gb = PicoGameBoy::with_cartridge(core1, Box::new(cart));
+            load_battery_save(app, sd_mgr, &mut gb);
+            *gameboy = Some(gb);
+            refresh_save_slot_available(app, sd_mgr);
             game_disp.draw_letterbox_bars().await;
             app.transition_to(AppState::Running(RunningState));
         }

--- a/platform/pico2w/src/state/running.rs
+++ b/platform/pico2w/src/state/running.rs
@@ -8,7 +8,10 @@ use rustyboy_pico2w::input::InputHandler;
 use rustyboy_pico2w::multicore::PicoGameBoy;
 
 use super::InGameMenuState;
-use crate::{poll_once, App, AppState, CYCLES_PER_FRAME};
+use crate::{
+    flush_battery_save, poll_once, refresh_save_slot_available, App, AppState, PicoSdMgr,
+    CYCLES_PER_FRAME,
+};
 
 pub struct RunningState;
 
@@ -20,6 +23,7 @@ impl RunningState {
         game_disp: &mut GameDisplay<'static>,
         i2s: &mut PioI2sOut<'static, PIO0, 0>,
         input: &mut InputHandler<'static>,
+        sd_mgr: &mut PicoSdMgr,
         audio_buffers: &mut AudioBuffers,
         audio_samples: &mut Vec<i16>,
     ) {
@@ -56,6 +60,8 @@ impl RunningState {
         };
 
         if open_menu {
+            flush_battery_save(app, sd_mgr, gameboy);
+            refresh_save_slot_available(app, sd_mgr);
             let next = InGameMenuState::new(game_disp, app).await;
             app.transition_to(AppState::InGameMenu(next));
         }

--- a/platform/pico2w/tests/save_storage.rs
+++ b/platform/pico2w/tests/save_storage.rs
@@ -1,0 +1,24 @@
+use rustyboy_core::storage::RomId;
+use rustyboy_pico2w::save_storage::{
+    battery_save_filename, rom_save_dir_name, save_state_filename, SaveSlot, SAVE_ROOT_DIR,
+};
+
+#[test]
+fn save_paths_are_fat_short_name_compatible() {
+    let rom_id = RomId::for_bytes(b"abc");
+
+    assert_eq!(SAVE_ROOT_DIR, "SAVES");
+    assert_eq!(rom_save_dir_name(&rom_id).as_str(), "BA7816BF");
+    assert_eq!(battery_save_filename(), "BATT.SAV");
+    assert_eq!(
+        save_state_filename(SaveSlot::new(2).unwrap()).as_str(),
+        "SLOT2.RBS"
+    );
+}
+
+#[test]
+fn save_slot_rejects_out_of_range_slots() {
+    assert_eq!(SaveSlot::new(0).unwrap().index(), 0);
+    assert_eq!(SaveSlot::new(2).unwrap().index(), 2);
+    assert!(SaveSlot::new(3).is_err());
+}

--- a/platform/pico2w/tests/save_storage.rs
+++ b/platform/pico2w/tests/save_storage.rs
@@ -22,3 +22,4 @@ fn save_slot_rejects_out_of_range_slots() {
     assert_eq!(SaveSlot::new(2).unwrap().index(), 2);
     assert!(SaveSlot::new(3).is_err());
 }
+

--- a/platform/web/client/static/app.js
+++ b/platform/web/client/static/app.js
@@ -87,6 +87,7 @@ const state = {
   user:         null,   // logged-in user object | null
   activeMenu:   null,   // MenuRenderer | null (canvas-based menu)
   currentRomName: null, // name of the currently loaded ROM
+  currentRomId: null,   // SHA-256 hex of the currently loaded ROM bytes
   batterySaveTimer: null, // setInterval id for periodic battery save upload
   paused:       false,  // true when emulation loop is suspended for in-game menu
   menuPending:  false,  // true while showInGameMenu fetch is in-flight; blocks re-entry
@@ -154,9 +155,24 @@ function stopAudio() {
 
 // ── Battery saves ──────────────────────────────────────────────────────────
 
-async function loadBatterySave(romName) {
+async function sha256Hex(bytes) {
+  const digest = await crypto.subtle.digest('SHA-256', bytes);
+  return [...new Uint8Array(digest)]
+    .map(b => b.toString(16).padStart(2, '0'))
+    .join('');
+}
+
+function romScopedHeaders(romId = state.currentRomId, extra = {}) {
+  const headers = { ...extra };
+  if (romId) headers['x-rustyboy-rom-id'] = romId;
+  return headers;
+}
+
+async function loadBatterySave(romName, romId = state.currentRomId) {
   try {
-    const res = await fetch(`/api/battery-saves/${encodeURIComponent(romName)}`);
+    const res = await fetch(`/api/battery-saves/${encodeURIComponent(romName)}`, {
+      headers: romScopedHeaders(romId),
+    });
     if (res.ok) {
       const buf = await res.arrayBuffer();
       if (buf.byteLength > 0) {
@@ -169,14 +185,14 @@ async function loadBatterySave(romName) {
   }
 }
 
-async function uploadBatterySave(romName) {
+async function uploadBatterySave(romName, romId = state.currentRomId) {
   if (!state.emulator) return;
   const data = state.emulator.get_battery_save();
   if (!data || data.length === 0) return;
   try {
     await fetch(`/api/battery-saves/${encodeURIComponent(romName)}`, {
       method: 'PUT',
-      headers: { 'content-type': 'application/octet-stream' },
+      headers: romScopedHeaders(romId, { 'content-type': 'application/octet-stream' }),
       body: data,
     });
     log.debug(`battery save uploaded: ${data.length} bytes`);
@@ -378,10 +394,12 @@ async function showLoginError() {
 // ── Main menu / ROM list ───────────────────────────────────────────────────
 
 /** Returns the ID of the most recent save state for a ROM, or null if none. */
-async function fetchLatestSaveId(romName) {
+async function fetchLatestSaveId(romName, romId = state.currentRomId) {
   if (!romName) return null;
   try {
-    const res = await fetch(`/api/save-states/${encodeURIComponent(romName)}/latest`);
+    const res = await fetch(`/api/save-states/${encodeURIComponent(romName)}/latest`, {
+      headers: romScopedHeaders(romId),
+    });
     if (!res.ok) return null;
     const data = await res.json();
     return data.id || null;
@@ -391,12 +409,14 @@ async function fetchLatestSaveId(romName) {
 }
 
 /** Returns true if any save states exist. Pass a romName to scope to that ROM. */
-async function fetchHasSaves(romName) {
+async function fetchHasSaves(romName, romId = state.currentRomId) {
   try {
     const url = romName
       ? `/api/save-states/${encodeURIComponent(romName)}`
       : '/api/save-states';
-    const res = await fetch(url);
+    const res = await fetch(url, {
+      headers: romName ? romScopedHeaders(romId) : {},
+    });
     if (!res.ok) return false;
     const data = await res.json();
     return data.length > 0;
@@ -448,11 +468,7 @@ async function continueLatestSave() {
     const roms = await res.json(); // [{rom_name, last_saved}, ...] sorted newest first
     if (roms.length === 0) { showMainMenu(); return; }
     const romName = roms[0].rom_name;
-    // Get the latest save state for that ROM
-    const latestRes = await fetch(`/api/save-states/${encodeURIComponent(romName)}/latest`);
-    if (!latestRes.ok) { showMainMenu(); return; }
-    const latestMeta = await latestRes.json();
-    await launchRomWithSaveState(romName, latestMeta.id);
+    await launchRom(romName);
   } catch (_) {
     showMainMenu();
   }
@@ -517,17 +533,7 @@ function showCanvasError(msg) {
 // ── Launch / stop ──────────────────────────────────────────────────────────
 
 async function launchRom(name) {
-  // Check for a latest save state to auto-load
-  let saveStateId = null;
-  try {
-    const res = await fetch(`/api/save-states/${encodeURIComponent(name)}/latest`);
-    if (res.ok) {
-      const meta = await res.json();
-      saveStateId = meta.id;
-    }
-  } catch (_) {}
-
-  await launchRomWithSaveState(name, saveStateId);
+  await launchRomWithSaveState(name, undefined);
 }
 
 async function launchRomWithSaveState(name, saveStateId) {
@@ -542,6 +548,11 @@ async function launchRomWithSaveState(name, saveStateId) {
     showCanvasError('LOAD ERROR');
     log.error(err);
     return;
+  }
+  const romId = await sha256Hex(bytes);
+
+  if (saveStateId === undefined) {
+    saveStateId = await fetchLatestSaveId(name, romId);
   }
 
   // Tear down previous
@@ -558,6 +569,7 @@ async function launchRomWithSaveState(name, saveStateId) {
 
   state.lastRomName = name;
   state.currentRomName = name;
+  state.currentRomId = romId;
   localStorage.setItem('lastRom', name);
   state.running = true;
   state.paused = false;
@@ -575,7 +587,7 @@ async function launchRomWithSaveState(name, saveStateId) {
       log.warn(`save state load failed: ${e}`);
     }
   } else {
-    await loadBatterySave(name);
+    await loadBatterySave(name, romId);
   }
   startBatterySaveTimer(name);
 
@@ -609,6 +621,7 @@ async function stopEmulation() {
     state.emulator = null;
   }
   state.currentRomName = null;
+  state.currentRomId = null;
   state.running = false;
   state.paused = false;
   state.menuPending = false;
@@ -743,7 +756,7 @@ async function saveCurrentState() {
     const blob = state.emulator.save_state();
     await fetch(`/api/save-states/${encodeURIComponent(state.currentRomName)}`, {
       method: 'POST',
-      headers: { 'content-type': 'application/octet-stream' },
+      headers: romScopedHeaders(state.currentRomId, { 'content-type': 'application/octet-stream' }),
       body: blob,
     });
     showSavedOverlay();
@@ -772,7 +785,9 @@ function showSavedOverlay() {
 async function showSaveStateSlots(romName, onBack) {
   let saves = [];
   try {
-    const res = await fetch(`/api/save-states/${encodeURIComponent(romName)}`);
+    const res = await fetch(`/api/save-states/${encodeURIComponent(romName)}`, {
+      headers: romScopedHeaders(),
+    });
     if (res.ok) saves = await res.json();
   } catch (_) {}
 

--- a/platform/web/server/Cargo.toml
+++ b/platform/web/server/Cargo.toml
@@ -25,6 +25,7 @@ reqwest = { version = "0.11", default-features = false, features = ["json", "rus
 jsonwebtoken = { version = "10.3.0", features = ["rust_crypto"] }
 time = "0.3"
 base64 = "0.22"
+rustyboy-core = { path = "../../../core" }
 
 [dev-dependencies]
 tower = { version = "0.4", features = ["util"] }

--- a/platform/web/server/migrations/0003_rom_identity.sql
+++ b/platform/web/server/migrations/0003_rom_identity.sql
@@ -1,0 +1,27 @@
+ALTER TABLE save_states ADD COLUMN rom_id TEXT;
+ALTER TABLE save_states ADD COLUMN payload_hash TEXT;
+
+CREATE INDEX IF NOT EXISTS idx_save_states_user_rom_id ON save_states(user_id, rom_id);
+
+CREATE TABLE battery_saves_new (
+    id           TEXT    PRIMARY KEY NOT NULL,
+    user_id      TEXT    NOT NULL REFERENCES users(id),
+    rom_id       TEXT,
+    rom_name     TEXT    NOT NULL,
+    payload_hash TEXT,
+    data         BLOB    NOT NULL,
+    updated_at   INTEGER NOT NULL
+);
+
+INSERT INTO battery_saves_new (id, user_id, rom_name, data, updated_at)
+    SELECT id, user_id, rom_name, data, updated_at FROM battery_saves;
+
+DROP TABLE battery_saves;
+ALTER TABLE battery_saves_new RENAME TO battery_saves;
+
+CREATE INDEX IF NOT EXISTS idx_battery_saves_user_rom_name
+    ON battery_saves(user_id, rom_name);
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_battery_saves_user_rom_id
+    ON battery_saves(user_id, rom_id)
+    WHERE rom_id IS NOT NULL;

--- a/platform/web/server/src/db.rs
+++ b/platform/web/server/src/db.rs
@@ -29,10 +29,12 @@ pub struct User {
 pub struct SaveState {
     pub id: String,
     pub user_id: String,
+    pub rom_id: Option<String>,
     pub rom_name: String,
     pub slot_name: String,
     pub created_at: i64,
     pub updated_at: i64,
+    pub payload_hash: Option<String>,
     pub data: Vec<u8>,
 }
 
@@ -40,7 +42,9 @@ pub struct SaveState {
 pub struct BatterySave {
     pub id: String,
     pub user_id: String,
+    pub rom_id: Option<String>,
     pub rom_name: String,
+    pub payload_hash: Option<String>,
     pub data: Vec<u8>,
     pub updated_at: i64,
 }
@@ -188,46 +192,77 @@ impl Database {
         slot_name: &str,
         data: Vec<u8>,
     ) -> Result<SaveState, sqlx::Error> {
+        self.upsert_save_state_with_rom_id(user_id, None, rom_name, slot_name, data)
+            .await
+    }
+
+    pub async fn upsert_save_state_with_rom_id(
+        &self,
+        user_id: &str,
+        rom_id: Option<&str>,
+        rom_name: &str,
+        slot_name: &str,
+        data: Vec<u8>,
+    ) -> Result<SaveState, sqlx::Error> {
         let now = now_secs();
 
         // Check if a save state already exists for this slot
-        let existing = sqlx::query(
-            "SELECT id, created_at FROM save_states
+        let existing = if let Some(rom_id) = rom_id {
+            sqlx::query(
+                "SELECT id, created_at FROM save_states
+             WHERE user_id = ? AND rom_id = ? AND slot_name = ?",
+            )
+            .bind(user_id)
+            .bind(rom_id)
+            .bind(slot_name)
+            .fetch_optional(&self.pool)
+            .await?
+        } else {
+            sqlx::query(
+                "SELECT id, created_at FROM save_states
              WHERE user_id = ? AND rom_name = ? AND slot_name = ?",
-        )
-        .bind(user_id)
-        .bind(rom_name)
-        .bind(slot_name)
-        .fetch_optional(&self.pool)
-        .await?;
+            )
+            .bind(user_id)
+            .bind(rom_name)
+            .bind(slot_name)
+            .fetch_optional(&self.pool)
+            .await?
+        };
 
         if let Some(row) = existing {
             let id: String = row.get("id");
             let created_at: i64 = row.get("created_at");
-            sqlx::query("UPDATE save_states SET data = ?, updated_at = ? WHERE id = ?")
-                .bind(&data)
-                .bind(now)
-                .bind(&id)
-                .execute(&self.pool)
-                .await?;
+            sqlx::query(
+                "UPDATE save_states SET rom_id = ?, rom_name = ?, data = ?, updated_at = ? WHERE id = ?",
+            )
+            .bind(rom_id)
+            .bind(rom_name)
+            .bind(&data)
+            .bind(now)
+            .bind(&id)
+            .execute(&self.pool)
+            .await?;
             return Ok(SaveState {
                 id,
                 user_id: user_id.to_string(),
+                rom_id: rom_id.map(str::to_string),
                 rom_name: rom_name.to_string(),
                 slot_name: slot_name.to_string(),
                 created_at,
                 updated_at: now,
+                payload_hash: None,
                 data,
             });
         }
 
         let id = new_id();
         sqlx::query(
-            "INSERT INTO save_states (id, user_id, rom_name, slot_name, created_at, updated_at, data)
-             VALUES (?, ?, ?, ?, ?, ?, ?)",
+            "INSERT INTO save_states (id, user_id, rom_id, rom_name, slot_name, created_at, updated_at, payload_hash, data)
+             VALUES (?, ?, ?, ?, ?, ?, ?, NULL, ?)",
         )
         .bind(&id)
         .bind(user_id)
+        .bind(rom_id)
         .bind(rom_name)
         .bind(slot_name)
         .bind(now)
@@ -239,10 +274,12 @@ impl Database {
         Ok(SaveState {
             id,
             user_id: user_id.to_string(),
+            rom_id: rom_id.map(str::to_string),
             rom_name: rom_name.to_string(),
             slot_name: slot_name.to_string(),
             created_at: now,
             updated_at: now,
+            payload_hash: None,
             data,
         })
     }
@@ -252,25 +289,51 @@ impl Database {
         user_id: &str,
         rom_name: &str,
     ) -> Result<Vec<SaveState>, sqlx::Error> {
-        let rows = sqlx::query(
-            "SELECT id, user_id, rom_name, slot_name, created_at, updated_at, data
+        self.list_save_states_with_rom_id(user_id, None, rom_name)
+            .await
+    }
+
+    pub async fn list_save_states_with_rom_id(
+        &self,
+        user_id: &str,
+        rom_id: Option<&str>,
+        rom_name: &str,
+    ) -> Result<Vec<SaveState>, sqlx::Error> {
+        let rows = if let Some(rom_id) = rom_id {
+            sqlx::query(
+                "SELECT id, user_id, rom_id, rom_name, slot_name, created_at, updated_at, payload_hash, data
+             FROM save_states
+             WHERE user_id = ? AND (rom_id = ? OR (rom_id IS NULL AND rom_name = ?))
+             ORDER BY rom_id IS NOT NULL DESC, updated_at DESC",
+            )
+            .bind(user_id)
+            .bind(rom_id)
+            .bind(rom_name)
+            .fetch_all(&self.pool)
+            .await?
+        } else {
+            sqlx::query(
+                "SELECT id, user_id, rom_id, rom_name, slot_name, created_at, updated_at, payload_hash, data
              FROM save_states WHERE user_id = ? AND rom_name = ?
              ORDER BY updated_at DESC",
-        )
-        .bind(user_id)
-        .bind(rom_name)
-        .fetch_all(&self.pool)
-        .await?;
+            )
+            .bind(user_id)
+            .bind(rom_name)
+            .fetch_all(&self.pool)
+            .await?
+        };
 
         Ok(rows
             .into_iter()
             .map(|r| SaveState {
                 id: r.get("id"),
                 user_id: r.get("user_id"),
+                rom_id: r.get("rom_id"),
                 rom_name: r.get("rom_name"),
                 slot_name: r.get("slot_name"),
                 created_at: r.get("created_at"),
                 updated_at: r.get("updated_at"),
+                payload_hash: r.get("payload_hash"),
                 data: r.get("data"),
             })
             .collect())
@@ -278,7 +341,7 @@ impl Database {
 
     pub async fn get_save_state(&self, id: &str) -> Result<Option<SaveState>, sqlx::Error> {
         let row = sqlx::query(
-            "SELECT id, user_id, rom_name, slot_name, created_at, updated_at, data
+            "SELECT id, user_id, rom_id, rom_name, slot_name, created_at, updated_at, payload_hash, data
              FROM save_states WHERE id = ?",
         )
         .bind(id)
@@ -288,10 +351,12 @@ impl Database {
         Ok(row.map(|r| SaveState {
             id: r.get("id"),
             user_id: r.get("user_id"),
+            rom_id: r.get("rom_id"),
             rom_name: r.get("rom_name"),
             slot_name: r.get("slot_name"),
             created_at: r.get("created_at"),
             updated_at: r.get("updated_at"),
+            payload_hash: r.get("payload_hash"),
             data: r.get("data"),
         }))
     }
@@ -302,23 +367,50 @@ impl Database {
         user_id: &str,
         rom_name: &str,
     ) -> Result<Option<SaveState>, sqlx::Error> {
-        let row = sqlx::query(
-            "SELECT id, user_id, rom_name, slot_name, created_at, updated_at, data
+        self.get_latest_save_state_with_rom_id(user_id, None, rom_name)
+            .await
+    }
+
+    pub async fn get_latest_save_state_with_rom_id(
+        &self,
+        user_id: &str,
+        rom_id: Option<&str>,
+        rom_name: &str,
+    ) -> Result<Option<SaveState>, sqlx::Error> {
+        let row = if let Some(rom_id) = rom_id {
+            sqlx::query(
+                "SELECT id, user_id, rom_id, rom_name, slot_name, created_at, updated_at, payload_hash, data
+             FROM save_states
+             WHERE user_id = ? AND (rom_id = ? OR (rom_id IS NULL AND rom_name = ?))
+             ORDER BY rom_id IS NOT NULL DESC, updated_at DESC
+             LIMIT 1",
+            )
+            .bind(user_id)
+            .bind(rom_id)
+            .bind(rom_name)
+            .fetch_optional(&self.pool)
+            .await?
+        } else {
+            sqlx::query(
+                "SELECT id, user_id, rom_id, rom_name, slot_name, created_at, updated_at, payload_hash, data
              FROM save_states WHERE user_id = ? AND rom_name = ?
              ORDER BY updated_at DESC LIMIT 1",
-        )
-        .bind(user_id)
-        .bind(rom_name)
-        .fetch_optional(&self.pool)
-        .await?;
+            )
+            .bind(user_id)
+            .bind(rom_name)
+            .fetch_optional(&self.pool)
+            .await?
+        };
 
         Ok(row.map(|r| SaveState {
             id: r.get("id"),
             user_id: r.get("user_id"),
+            rom_id: r.get("rom_id"),
             rom_name: r.get("rom_name"),
             slot_name: r.get("slot_name"),
             created_at: r.get("created_at"),
             updated_at: r.get("updated_at"),
+            payload_hash: r.get("payload_hash"),
             data: r.get("data"),
         }))
     }
@@ -338,6 +430,38 @@ impl Database {
         rom_name: &str,
         keep: usize,
     ) -> Result<(), sqlx::Error> {
+        self.prune_save_states_with_rom_id(user_id, None, rom_name, keep)
+            .await
+    }
+
+    pub async fn prune_save_states_with_rom_id(
+        &self,
+        user_id: &str,
+        rom_id: Option<&str>,
+        rom_name: &str,
+        keep: usize,
+    ) -> Result<(), sqlx::Error> {
+        if let Some(rom_id) = rom_id {
+            sqlx::query(
+                "DELETE FROM save_states
+             WHERE user_id = ? AND rom_id = ?
+               AND id NOT IN (
+                 SELECT id FROM save_states
+                 WHERE user_id = ? AND rom_id = ?
+                 ORDER BY updated_at DESC
+                 LIMIT ?
+               )",
+            )
+            .bind(user_id)
+            .bind(rom_id)
+            .bind(user_id)
+            .bind(rom_id)
+            .bind(keep as i64)
+            .execute(&self.pool)
+            .await?;
+            return Ok(());
+        }
+
         sqlx::query(
             "DELETE FROM save_states
              WHERE user_id = ? AND rom_name = ?
@@ -387,18 +511,40 @@ impl Database {
         rom_name: &str,
         data: Vec<u8>,
     ) -> Result<BatterySave, sqlx::Error> {
+        self.upsert_battery_save_with_rom_id(user_id, None, rom_name, data)
+            .await
+    }
+
+    pub async fn upsert_battery_save_with_rom_id(
+        &self,
+        user_id: &str,
+        rom_id: Option<&str>,
+        rom_name: &str,
+        data: Vec<u8>,
+    ) -> Result<BatterySave, sqlx::Error> {
         let now = now_secs();
 
-        let existing =
+        let existing = if let Some(rom_id) = rom_id {
+            sqlx::query("SELECT id FROM battery_saves WHERE user_id = ? AND rom_id = ?")
+                .bind(user_id)
+                .bind(rom_id)
+                .fetch_optional(&self.pool)
+                .await?
+        } else {
             sqlx::query("SELECT id FROM battery_saves WHERE user_id = ? AND rom_name = ?")
                 .bind(user_id)
                 .bind(rom_name)
                 .fetch_optional(&self.pool)
-                .await?;
+                .await?
+        };
 
         if let Some(row) = existing {
             let id: String = row.get("id");
-            sqlx::query("UPDATE battery_saves SET data = ?, updated_at = ? WHERE id = ?")
+            sqlx::query(
+                "UPDATE battery_saves SET rom_id = ?, rom_name = ?, data = ?, updated_at = ? WHERE id = ?",
+            )
+                .bind(rom_id)
+                .bind(rom_name)
                 .bind(&data)
                 .bind(now)
                 .bind(&id)
@@ -407,7 +553,9 @@ impl Database {
             return Ok(BatterySave {
                 id,
                 user_id: user_id.to_string(),
+                rom_id: rom_id.map(str::to_string),
                 rom_name: rom_name.to_string(),
+                payload_hash: None,
                 data,
                 updated_at: now,
             });
@@ -415,11 +563,12 @@ impl Database {
 
         let id = new_id();
         sqlx::query(
-            "INSERT INTO battery_saves (id, user_id, rom_name, data, updated_at)
-             VALUES (?, ?, ?, ?, ?)",
+            "INSERT INTO battery_saves (id, user_id, rom_id, rom_name, payload_hash, data, updated_at)
+             VALUES (?, ?, ?, ?, NULL, ?, ?)",
         )
         .bind(&id)
         .bind(user_id)
+        .bind(rom_id)
         .bind(rom_name)
         .bind(&data)
         .bind(now)
@@ -429,7 +578,9 @@ impl Database {
         Ok(BatterySave {
             id,
             user_id: user_id.to_string(),
+            rom_id: rom_id.map(str::to_string),
             rom_name: rom_name.to_string(),
+            payload_hash: None,
             data,
             updated_at: now,
         })
@@ -464,19 +615,46 @@ impl Database {
         user_id: &str,
         rom_name: &str,
     ) -> Result<Option<BatterySave>, sqlx::Error> {
-        let row = sqlx::query(
-            "SELECT id, user_id, rom_name, data, updated_at
+        self.get_battery_save_with_rom_id(user_id, None, rom_name)
+            .await
+    }
+
+    pub async fn get_battery_save_with_rom_id(
+        &self,
+        user_id: &str,
+        rom_id: Option<&str>,
+        rom_name: &str,
+    ) -> Result<Option<BatterySave>, sqlx::Error> {
+        let row = if let Some(rom_id) = rom_id {
+            sqlx::query(
+                "SELECT id, user_id, rom_id, rom_name, payload_hash, data, updated_at
+             FROM battery_saves
+             WHERE user_id = ? AND (rom_id = ? OR (rom_id IS NULL AND rom_name = ?))
+             ORDER BY rom_id IS NOT NULL DESC, updated_at DESC
+             LIMIT 1",
+            )
+            .bind(user_id)
+            .bind(rom_id)
+            .bind(rom_name)
+            .fetch_optional(&self.pool)
+            .await?
+        } else {
+            sqlx::query(
+                "SELECT id, user_id, rom_id, rom_name, payload_hash, data, updated_at
              FROM battery_saves WHERE user_id = ? AND rom_name = ?",
-        )
-        .bind(user_id)
-        .bind(rom_name)
-        .fetch_optional(&self.pool)
-        .await?;
+            )
+            .bind(user_id)
+            .bind(rom_name)
+            .fetch_optional(&self.pool)
+            .await?
+        };
 
         Ok(row.map(|r| BatterySave {
             id: r.get("id"),
             user_id: r.get("user_id"),
+            rom_id: r.get("rom_id"),
             rom_name: r.get("rom_name"),
+            payload_hash: r.get("payload_hash"),
             data: r.get("data"),
             updated_at: r.get("updated_at"),
         }))
@@ -702,6 +880,32 @@ mod tests {
         .await
         .unwrap();
         assert_eq!(row_count, 1);
+    }
+
+    #[tokio::test]
+    async fn test_battery_saves_with_rom_id_do_not_collide_on_rom_name() {
+        let db = new_db().await;
+        let user = db
+            .upsert_user("sub_rom_id", "romid@example.com", "Rom Id", None)
+            .await
+            .unwrap();
+        let rom_id_a = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+        let rom_id_b = "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb";
+
+        db.upsert_battery_save_with_rom_id(&user.id, Some(rom_id_a), "pokemon.gb", vec![1])
+            .await
+            .unwrap();
+        db.upsert_battery_save_with_rom_id(&user.id, Some(rom_id_b), "pokemon.gb", vec![2])
+            .await
+            .unwrap();
+
+        let fetched = db
+            .get_battery_save_with_rom_id(&user.id, Some(rom_id_a), "pokemon.gb")
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(fetched.data, vec![1]);
+        assert_eq!(fetched.rom_id.as_deref(), Some(rom_id_a));
     }
 
     #[tokio::test]

--- a/platform/web/server/src/lib.rs
+++ b/platform/web/server/src/lib.rs
@@ -6,12 +6,13 @@ use auth::{AuthUser, DbExt, JwtSecretExt};
 use axum::{
     body::Bytes,
     extract::{Path, Request, State},
-    http::{HeaderValue, StatusCode},
+    http::{HeaderMap, HeaderValue, StatusCode},
     middleware::{self, Next},
     response::{IntoResponse, Json, Response},
     routing::{delete, get, post},
     Router,
 };
+use rustyboy_core::storage::{BatterySaveBytes, RomId, SaveStateBytes};
 use std::{path::PathBuf, sync::Arc};
 use tower_http::services::ServeDir;
 
@@ -171,9 +172,18 @@ async fn api_auth_method(State(state): State<Arc<AppState>>) -> impl IntoRespons
 async fn get_battery_save(
     auth: AuthUser,
     Path(rom_name): Path<String>,
+    headers: HeaderMap,
     State(state): State<Arc<AppState>>,
 ) -> impl IntoResponse {
-    match state.db.get_battery_save(&auth.user_id, &rom_name).await {
+    let rom_id = match rom_id_from_headers(&headers) {
+        Ok(rom_id) => rom_id,
+        Err(status) => return status.into_response(),
+    };
+    match state
+        .db
+        .get_battery_save_with_rom_id(&auth.user_id, rom_id.as_deref(), &rom_name)
+        .await
+    {
         Ok(Some(bs)) => (
             StatusCode::OK,
             [("content-type", "application/octet-stream")],
@@ -188,15 +198,20 @@ async fn get_battery_save(
 async fn put_battery_save(
     auth: AuthUser,
     Path(rom_name): Path<String>,
+    headers: HeaderMap,
     State(state): State<Arc<AppState>>,
     body: Bytes,
 ) -> impl IntoResponse {
-    if body.is_empty() {
+    if BatterySaveBytes::new(&body).is_err() {
         return StatusCode::BAD_REQUEST.into_response();
     }
+    let rom_id = match rom_id_from_headers(&headers) {
+        Ok(rom_id) => rom_id,
+        Err(status) => return status.into_response(),
+    };
     match state
         .db
-        .upsert_battery_save(&auth.user_id, &rom_name, body.to_vec())
+        .upsert_battery_save_with_rom_id(&auth.user_id, rom_id.as_deref(), &rom_name, body.to_vec())
         .await
     {
         Ok(_) => StatusCode::NO_CONTENT.into_response(),
@@ -227,15 +242,25 @@ async fn list_roms_with_saves(
 async fn list_save_states(
     auth: AuthUser,
     Path(rom_name): Path<String>,
+    headers: HeaderMap,
     State(state): State<Arc<AppState>>,
 ) -> impl IntoResponse {
-    match state.db.list_save_states(&auth.user_id, &rom_name).await {
+    let rom_id = match rom_id_from_headers(&headers) {
+        Ok(rom_id) => rom_id,
+        Err(status) => return status.into_response(),
+    };
+    match state
+        .db
+        .list_save_states_with_rom_id(&auth.user_id, rom_id.as_deref(), &rom_name)
+        .await
+    {
         Ok(saves) => {
             let items: Vec<_> = saves
                 .into_iter()
                 .map(|s| {
                     serde_json::json!({
                         "id": s.id,
+                        "rom_id": s.rom_id,
                         "slot_name": s.slot_name,
                         "created_at": s.created_at,
                         "updated_at": s.updated_at,
@@ -252,15 +277,21 @@ async fn list_save_states(
 async fn get_latest_save_state(
     auth: AuthUser,
     Path(rom_name): Path<String>,
+    headers: HeaderMap,
     State(state): State<Arc<AppState>>,
 ) -> impl IntoResponse {
+    let rom_id = match rom_id_from_headers(&headers) {
+        Ok(rom_id) => rom_id,
+        Err(status) => return status.into_response(),
+    };
     match state
         .db
-        .get_latest_save_state(&auth.user_id, &rom_name)
+        .get_latest_save_state_with_rom_id(&auth.user_id, rom_id.as_deref(), &rom_name)
         .await
     {
         Ok(Some(s)) => Json(serde_json::json!({
             "id": s.id,
+            "rom_id": s.rom_id,
             "slot_name": s.slot_name,
             "created_at": s.created_at,
             "updated_at": s.updated_at,
@@ -275,29 +306,41 @@ async fn get_latest_save_state(
 async fn post_save_state(
     auth: AuthUser,
     Path(rom_name): Path<String>,
+    headers: HeaderMap,
     State(state): State<Arc<AppState>>,
     body: Bytes,
 ) -> impl IntoResponse {
-    if body.is_empty() {
+    if SaveStateBytes::new(&body).is_err() {
         return StatusCode::BAD_REQUEST.into_response();
     }
+    let rom_id = match rom_id_from_headers(&headers) {
+        Ok(rom_id) => rom_id,
+        Err(status) => return status.into_response(),
+    };
     // Auto-generate slot name from current unix timestamp
     let slot_name = now_unix_secs().to_string();
     match state
         .db
-        .upsert_save_state(&auth.user_id, &rom_name, &slot_name, body.to_vec())
+        .upsert_save_state_with_rom_id(
+            &auth.user_id,
+            rom_id.as_deref(),
+            &rom_name,
+            &slot_name,
+            body.to_vec(),
+        )
         .await
     {
         Ok(s) => {
             // Keep only the 5 most recent saves per user+rom; silently ignore prune errors
             let _ = state
                 .db
-                .prune_save_states(&auth.user_id, &rom_name, 5)
+                .prune_save_states_with_rom_id(&auth.user_id, rom_id.as_deref(), &rom_name, 5)
                 .await;
             (
                 StatusCode::CREATED,
                 Json(serde_json::json!({
                     "id": s.id,
+                    "rom_id": s.rom_id,
                     "slot_name": s.slot_name,
                     "created_at": s.created_at,
                     "updated_at": s.updated_at,
@@ -307,6 +350,15 @@ async fn post_save_state(
         }
         Err(_) => StatusCode::INTERNAL_SERVER_ERROR.into_response(),
     }
+}
+
+fn rom_id_from_headers(headers: &HeaderMap) -> Result<Option<String>, StatusCode> {
+    let Some(value) = headers.get("x-rustyboy-rom-id") else {
+        return Ok(None);
+    };
+    let value = value.to_str().map_err(|_| StatusCode::BAD_REQUEST)?;
+    RomId::from_hex(value).map_err(|_| StatusCode::BAD_REQUEST)?;
+    Ok(Some(value.to_ascii_lowercase()))
 }
 
 /// GET /api/save-states/by-id/:id/data — download save state blob

--- a/platform/web/server/tests/http.rs
+++ b/platform/web/server/tests/http.rs
@@ -318,6 +318,48 @@ async fn test_put_battery_save_overwrites() {
     assert_eq!(body.as_ref(), &[9u8, 8, 7]);
 }
 
+#[tokio::test]
+async fn test_battery_saves_can_be_scoped_by_rom_id() {
+    let (app, cookie) = authed_app().await;
+    let rom_id_a = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+    let rom_id_b = "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb";
+
+    for (rom_id, data) in [(rom_id_a, vec![1u8, 2, 3]), (rom_id_b, vec![4u8, 5, 6])] {
+        let res = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .method("PUT")
+                    .uri("/api/battery-saves/pokemon.gb")
+                    .header("cookie", &cookie)
+                    .header("x-rustyboy-rom-id", rom_id)
+                    .header("content-type", "application/octet-stream")
+                    .body(Body::from(data))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(res.status(), StatusCode::NO_CONTENT);
+    }
+
+    let res = app
+        .oneshot(
+            Request::builder()
+                .uri("/api/battery-saves/pokemon.gb")
+                .header("cookie", &cookie)
+                .header("x-rustyboy-rom-id", rom_id_a)
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(res.status(), StatusCode::OK);
+    let body = axum::body::to_bytes(res.into_body(), usize::MAX)
+        .await
+        .unwrap();
+    assert_eq!(body.as_ref(), &[1, 2, 3]);
+}
+
 // ── Save state endpoint tests ─────────────────────────────────────────────────
 
 #[tokio::test]
@@ -600,6 +642,66 @@ async fn test_get_latest_save_state() {
     // The second upload has a unique slot_name (timestamp); both may share the same
     // second, but the id of the last insert should match.
     assert_eq!(latest["id"].as_str().unwrap(), id2);
+}
+
+#[tokio::test]
+async fn test_save_states_can_be_scoped_by_rom_id() {
+    let (app, cookie) = authed_app().await;
+    let rom_id_a = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+    let rom_id_b = "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb";
+
+    for (rom_id, data) in [(rom_id_a, vec![1u8]), (rom_id_b, vec![2u8])] {
+        let res = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/api/save-states/tetris.gb")
+                    .header("cookie", &cookie)
+                    .header("x-rustyboy-rom-id", rom_id)
+                    .header("content-type", "application/octet-stream")
+                    .body(Body::from(data))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(res.status(), StatusCode::CREATED);
+    }
+
+    let latest = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .uri("/api/save-states/tetris.gb/latest")
+                .header("cookie", &cookie)
+                .header("x-rustyboy-rom-id", rom_id_a)
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(latest.status(), StatusCode::OK);
+    let body = axum::body::to_bytes(latest.into_body(), usize::MAX)
+        .await
+        .unwrap();
+    let meta: serde_json::Value = serde_json::from_slice(&body).unwrap();
+    assert_eq!(meta["rom_id"].as_str(), Some(rom_id_a));
+    let id = meta["id"].as_str().unwrap();
+
+    let data = app
+        .oneshot(
+            Request::builder()
+                .uri(format!("/api/save-states/by-id/{id}/data"))
+                .header("cookie", &cookie)
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    let body = axum::body::to_bytes(data.into_body(), usize::MAX)
+        .await
+        .unwrap();
+    assert_eq!(body.as_ref(), &[1]);
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Summary

- **Core**: RBSS v2 save state format with tagged sections (MBC registers, cart RAM); ROM identity via SHA-256 used as the SD directory key; `BatterySaveBytes`/`SaveStateBytes` value types with size validation
- **Pico2W firmware**: SD card save/load for save states (`SAVES/<ROM_ID>/SLOT0.RBS`) and battery saves (`SAVES/<ROM_ID>/BATT.SAV`); in-game menu wires up save/load slot 0 and battery flushing on exit; fixes OOM panic during save (Vec realloc to 33 KB was exhausting the 128 KB heap — now pre-sized to exact capacity)
- **Web server**: DB schema + HTTP endpoints for cloud save sync; migration `0003_rom_identity.sql`

## Test plan

- [ ] Flash `cargo build --release` and trigger save from in-game menu — confirm no panic in RTT log
- [ ] Power-cycle and load state — confirm game resumes at saved position
- [ ] Confirm battery save written to SD (`SAVES/<ROM_ID>/BATT.SAV`)
- [ ] Run `cargo test -p rustyboy-core` — save state and ROM identity tests pass
- [ ] Run web server tests (`cargo test -p rustyboy-web-server`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)