### PR TITLE
Switch web controls to nipplejs

### DIFF
--- a/platform/web/client/package-lock.json
+++ b/platform/web/client/package-lock.json
@@ -7,6 +7,9 @@
     "": {
       "name": "rustyboy-web-client-build",
       "version": "0.1.0",
+      "dependencies": {
+        "nipplejs": "^1.0.4"
+      },
       "devDependencies": {
         "esbuild": "^0.25.5",
         "typescript": "^5.8.3"
@@ -495,6 +498,12 @@
         "@esbuild/win32-ia32": "0.25.12",
         "@esbuild/win32-x64": "0.25.12"
       }
+    },
+    "node_modules/nipplejs": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/nipplejs/-/nipplejs-1.0.4.tgz",
+      "integrity": "sha512-YtvRZDuyWQ+tOj0nUjfnZt4ZQmJVWfK9+yPmV5OXpQ4k4AkOGcSfKvSXbPNkV0ERqc4eakkBSZ7/Wyx1y6h/Sg==",
+      "license": "MIT"
     },
     "node_modules/typescript": {
       "version": "5.9.3",

--- a/platform/web/client/package.json
+++ b/platform/web/client/package.json
@@ -10,5 +10,8 @@
   "devDependencies": {
     "esbuild": "^0.25.5",
     "typescript": "^5.8.3"
+  },
+  "dependencies": {
+    "nipplejs": "^1.0.4"
   }
 }

--- a/platform/web/client/src-ts/app.ts
+++ b/platform/web/client/src-ts/app.ts
@@ -1204,13 +1204,7 @@ function sendButton(idx: number, pressed: boolean): void {
     state.emulator.set_button(idx, pressed);
   } else if (handleMenuButton(idx, pressed)) {
     log.debug(`sendButton → menu idx=${idx}`);
-  } else if (!pressed) {
-    handleMenuInput(idx);
   }
-}
-
-function handleMenuInput(_idx: number): void {
-  // No-op: all menu navigation is handled by MenuRenderer via sendButton → activeMenu
 }
 
 function bindButtons(): void {

--- a/platform/web/client/src-ts/app.ts
+++ b/platform/web/client/src-ts/app.ts
@@ -4,6 +4,7 @@
  */
 
 import init, { EmulatorHandle, WasmMenuRenderer } from 'rustyboy-wasm';
+import { create as createNipple } from 'nipplejs';
 import type { MenuItem, MenuOptions, MenuRendererInstance } from './types.js';
 
 // ── Wasm URL (must match ?v= in index.html) ───────────────────────────────────
@@ -392,6 +393,7 @@ async function boot(): Promise<void> {
 
   const authed = await checkAuth();
   bindButtons();
+  setupDpad();
   bindKeyboard();
   if (!authed) {
     showLoginScreen();
@@ -546,19 +548,34 @@ async function fetchHasSaves(romName: string | null, romId: string | null = stat
   } catch (_) { return false; }
 }
 
-async function showMainMenu(): Promise<void> {
+function showMainMenu(): void {
   log.event('showMainMenu');
   menuOverlay.classList.add('hidden');
+  const gen = ++state.menuGen;
 
-  const items: MenuItem[] = [
-    { label: 'CONTINUE', value: 'continue' },
-    { label: 'GAMES',    value: 'games' },
-  ];
+  // Render synchronously so a menu is active immediately — otherwise B/back
+  // (onBack → showMainMenu) would leave a window with no active menu while we
+  // await the save-state check. CONTINUE is prepended a moment later once we've
+  // confirmed a save exists; with none (the common case) the menu is stable.
+  renderMainMenu(false);
+
+  hasSaveState()
+    .then((has) => { if (has && state.menuGen === gen) renderMainMenu(true); })
+    .catch(() => {});
+}
+
+/** (Re)build the main menu. CONTINUE is only present when a save state exists. */
+function renderMainMenu(hasSave: boolean): void {
+  const items: MenuItem[] = [];
+  if (hasSave) items.push({ label: 'CONTINUE', value: 'continue' });
+  items.push({ label: 'GAMES',  value: 'games' });
+  items.push({ label: 'LOGOUT', value: 'logout' });
 
   const rawName = state.user?.display_name ?? state.user?.email ?? '';
   const name    = rawName.replace(/@[^@]+$/, '');
   const footer  = name ? `HELLO, ${name.toUpperCase()}` : '▲▼ MOVE  A SELECT';
 
+  state.activeMenu?.hide();
   const menu = new window.MenuRenderer(canvas);
   state.activeMenu = menu;
   menu.show({
@@ -569,17 +586,34 @@ async function showMainMenu(): Promise<void> {
       state.activeMenu = null;
       if (item.value === 'continue') {
         await continueLatestSave();
+      } else if (item.value === 'logout') {
+        doLogout();
       } else {
         showRomList();
       }
     },
     onBack: () => { showMainMenu(); },
-    onSelectBtn: () => {
-      fetch('/auth/logout', { method: 'POST' }).finally(() => {
-        window.location.href = '/?logged_out=1';
-      });
-    },
+    onSelectBtn: () => { doLogout(); },
   });
+}
+
+/** Log out server-side, then reload to the (now unauthenticated) login screen. */
+function doLogout(): void {
+  fetch('/auth/logout', { method: 'POST' }).finally(() => {
+    window.location.href = '/?logged_out=1';
+  });
+}
+
+/** Whether the user has at least one save state to resume via CONTINUE. */
+async function hasSaveState(): Promise<boolean> {
+  try {
+    const res = await fetch('/api/save-states');
+    if (!res.ok) return false;
+    const roms = await res.json() as Array<{ rom_name: string }>;
+    return roms.length > 0;
+  } catch (_) {
+    return false;
+  }
 }
 
 /** CONTINUE: find the most recently saved game across all ROMs and resume it. */
@@ -1096,26 +1130,81 @@ const PAUSE_BUTTON_KEY_MAP: Record<number, string> = {
   6: 'Select',
 };
 
+const MENU_REPEAT_KEYS = new Set(['ArrowUp', 'ArrowDown', 'w', 's']);
+const MENU_REPEAT_DELAY_MS = 320;
+const MENU_REPEAT_INTERVAL_MS = 115;
+let menuRepeatKey: string | null = null;
+let menuRepeatDelayTimer: number | null = null;
+let menuRepeatIntervalTimer: number | null = null;
+
+function stopMenuRepeat(key?: string): void {
+  if (key && menuRepeatKey !== key) return;
+  if (menuRepeatDelayTimer !== null) {
+    window.clearTimeout(menuRepeatDelayTimer);
+    menuRepeatDelayTimer = null;
+  }
+  if (menuRepeatIntervalTimer !== null) {
+    window.clearInterval(menuRepeatIntervalTimer);
+    menuRepeatIntervalTimer = null;
+  }
+  menuRepeatKey = null;
+}
+
+function sendMenuKey(key: string): boolean {
+  if (!state.activeMenu?.isActive()) {
+    stopMenuRepeat();
+    return false;
+  }
+  state.activeMenu.handleInput(key);
+  return true;
+}
+
+function startMenuRepeat(key: string): void {
+  if (!MENU_REPEAT_KEYS.has(key)) {
+    sendMenuKey(key);
+    return;
+  }
+  if (menuRepeatKey === key) return;
+  stopMenuRepeat();
+
+  menuRepeatKey = key;
+  if (!sendMenuKey(key)) return;
+  menuRepeatDelayTimer = window.setTimeout(() => {
+    menuRepeatDelayTimer = null;
+    if (!sendMenuKey(key)) return;
+    menuRepeatIntervalTimer = window.setInterval(() => {
+      sendMenuKey(key);
+    }, MENU_REPEAT_INTERVAL_MS);
+  }, MENU_REPEAT_DELAY_MS);
+}
+
+function handleMenuButton(idx: number, pressed: boolean): boolean {
+  const key = PAUSE_BUTTON_KEY_MAP[idx];
+  if (!key || !state.activeMenu?.isActive()) return false;
+
+  if (MENU_REPEAT_KEYS.has(key)) {
+    if (pressed) startMenuRepeat(key);
+    else stopMenuRepeat(key);
+    return true;
+  }
+
+  if (!pressed) sendMenuKey(key);
+  return true;
+}
+
 function sendButton(idx: number, pressed: boolean): void {
   log.event(`sendButton idx=${idx} pressed=${pressed}`);
 
   if (state.paused) {
-    if (!pressed && state.activeMenu?.isActive()) {
-      const key = PAUSE_BUTTON_KEY_MAP[idx];
-      log.debug(`sendButton (paused) → menu key=${key}`);
-      if (key) state.activeMenu.handleInput(key);
-    }
+    if (handleMenuButton(idx, pressed)) log.debug(`sendButton (paused) → menu idx=${idx}`);
     return;
   }
 
   if (state.emulator) {
     state.emulator.set_button(idx, pressed);
+  } else if (handleMenuButton(idx, pressed)) {
+    log.debug(`sendButton → menu idx=${idx}`);
   } else if (!pressed) {
-    if (state.activeMenu?.isActive()) {
-      const key = PAUSE_BUTTON_KEY_MAP[idx];
-      log.debug(`sendButton → menu key=${key}`);
-      if (key) { state.activeMenu.handleInput(key); return; }
-    }
     handleMenuInput(idx);
   }
 }
@@ -1176,6 +1265,183 @@ function bindButtons(): void {
   powerBtn.addEventListener('pointercancel', () => { powerBtn.classList.remove('pressed'); });
 }
 
+// ── On-screen D-pad (nipplejs) ─────────────────────────────────────────────────
+//
+// The four directions used to be four separate <button data-btn> cells, each
+// grabbing a pointer capture on press. That capture is what made the controls
+// feel broken: once your thumb landed on a cell you couldn't roll onto a
+// diagonal or slide between directions, and sliding off a cell could strand a
+// held direction. We replace them with a single nipplejs static joystick over
+// the #dpadZone well. Its `move` event gives a normalized vector we threshold
+// into up to two simultaneous directions (real diagonals); `end` releases all.
+// Everything downstream still flows through sendButton(), so the menu/pause
+// handling and keyboard path are unchanged.
+
+const DPAD_DIR_IDX = { right: 0, left: 1, up: 2, down: 3 } as const;
+type DpadDir = keyof typeof DPAD_DIR_IDX;
+
+// Fraction of the joystick vector an axis must reach to register as pressed.
+// Keep vertical slightly stricter because its current activation zone feels
+// right; horizontal engages earlier so left/right are less far from center.
+const DPAD_X_THRESHOLD = 0.4;
+const DPAD_Y_THRESHOLD = 0.5;
+const DPAD_JOYSTICK_SIZE = 132;
+
+const dpadHeld: Record<DpadDir, boolean> = { right: false, left: false, up: false, down: false };
+const DPAD_RELEASED: Record<DpadDir, boolean> = { right: false, left: false, up: false, down: false };
+let activeDpadPointerId: number | null = null;
+const activeDpadTouchIds = new Set<number>();
+let dpadManager: ReturnType<typeof createNipple> | null = null;
+
+/** Diff the desired direction state against what's held and emit only changes. */
+function applyDpadState(next: Record<DpadDir, boolean>): void {
+  for (const dir of Object.keys(next) as DpadDir[]) {
+    if (next[dir] === dpadHeld[dir]) continue;
+    dpadHeld[dir] = next[dir];
+    sendButton(DPAD_DIR_IDX[dir], next[dir]);
+  }
+}
+
+function isDpadHeld(): boolean {
+  return Object.values(dpadHeld).some(Boolean);
+}
+
+function forceReleaseEmulatorDpadButtons(): void {
+  if (!state.emulator) return;
+  for (const dir of Object.keys(DPAD_DIR_IDX) as DpadDir[]) {
+    state.emulator.set_button(DPAD_DIR_IDX[dir], false);
+  }
+}
+
+function restDpadJoystick(): void {
+  try {
+    dpadManager?.getJoystickByUid()?.end();
+  } catch (_) {
+    // If nipplejs is already mid-cleanup, the app-level release above is still
+    // the important part. A fresh pointerdown will reuse/recreate the joystick.
+  }
+}
+
+function releaseDpad(resetJoystick = false): void {
+  activeDpadPointerId = null;
+  activeDpadTouchIds.clear();
+  stopMenuRepeat();
+  applyDpadState(DPAD_RELEASED);
+  if (resetJoystick) {
+    forceReleaseEmulatorDpadButtons();
+    restDpadJoystick();
+  }
+}
+
+function startMenuRepeatFromDpadPoint(clientX: number, clientY: number): void {
+  if (!state.activeMenu?.isActive()) return;
+  if (state.emulator && !state.paused) return;
+
+  const zone = document.getElementById('dpadZone');
+  if (!zone) return;
+
+  const rect = zone.getBoundingClientRect();
+  const centerY = rect.top + rect.height / 2;
+  const threshold = DPAD_Y_THRESHOLD * (DPAD_JOYSTICK_SIZE / 2);
+  const dy = clientY - centerY;
+
+  if (dy < -threshold) startMenuRepeat('ArrowUp');
+  else if (dy > threshold) startMenuRepeat('ArrowDown');
+}
+
+function trackDpadPointerStart(evt: PointerEvent): void {
+  if (activeDpadPointerId !== null && activeDpadPointerId !== evt.pointerId) {
+    releaseDpad(true);
+  }
+  activeDpadPointerId = evt.pointerId;
+  startMenuRepeatFromDpadPoint(evt.clientX, evt.clientY);
+}
+
+function releaseDpadPointer(evt: PointerEvent, resetJoystick = false): void {
+  if (activeDpadPointerId !== null && evt.pointerId !== activeDpadPointerId) return;
+  if (activeDpadPointerId === null && !isDpadHeld()) return;
+  releaseDpad(resetJoystick);
+}
+
+function releaseDpadPointerAndReset(evt: PointerEvent): void {
+  releaseDpadPointer(evt, true);
+}
+
+function trackDpadTouchStart(evt: TouchEvent): void {
+  if (activeDpadTouchIds.size > 0) releaseDpad(true);
+  for (const touch of Array.from(evt.changedTouches)) {
+    activeDpadTouchIds.add(touch.identifier);
+    startMenuRepeatFromDpadPoint(touch.clientX, touch.clientY);
+  }
+}
+
+function releaseDpadTouch(evt: TouchEvent): void {
+  if (activeDpadTouchIds.size === 0) {
+    if (isDpadHeld()) releaseDpad(true);
+    return;
+  }
+
+  for (const touch of Array.from(evt.changedTouches)) {
+    if (activeDpadTouchIds.has(touch.identifier)) {
+      releaseDpad(true);
+      return;
+    }
+  }
+}
+
+function releaseDpadOnHidden(): void {
+  if (document.visibilityState !== 'visible') releaseDpad(true);
+}
+
+function releaseDpadAndReset(): void {
+  releaseDpad(true);
+}
+
+function setupDpad(): void {
+  const zone = document.getElementById('dpadZone');
+  if (!zone) return; // e2e fixture / non-index pages have no d-pad zone
+
+  zone.addEventListener('pointerdown', trackDpadPointerStart, { capture: true });
+  document.addEventListener('pointerup', releaseDpadPointer, true);
+  document.addEventListener('pointercancel', releaseDpadPointerAndReset, true);
+  document.addEventListener('lostpointercapture', releaseDpadPointerAndReset, true);
+
+  zone.addEventListener('touchstart', trackDpadTouchStart, { capture: true, passive: true });
+  document.addEventListener('touchend', releaseDpadTouch, true);
+  document.addEventListener('touchcancel', releaseDpadTouch, true);
+
+  window.addEventListener('blur', releaseDpadAndReset);
+  window.addEventListener('pagehide', releaseDpadAndReset);
+  window.addEventListener('contextmenu', releaseDpadAndReset);
+  document.addEventListener('visibilitychange', releaseDpadOnHidden);
+
+  dpadManager = createNipple({
+    zone,
+    mode: 'static',
+    position: { top: '50%', left: '50%' },
+    size: 132,
+    threshold: 0.15,
+    fadeTime: 0,
+    restJoystick: true,
+    restOpacity: 1,
+    color: { back: 'transparent', front: '#6E7290' },
+  });
+
+  dpadManager.on('move', (evt) => {
+    const d = evt.data;
+    if (!d?.vector) return;
+    applyDpadState({
+      right: d.vector.x >  DPAD_X_THRESHOLD,
+      left:  d.vector.x < -DPAD_X_THRESHOLD,
+      up:    d.vector.y >  DPAD_Y_THRESHOLD,
+      down:  d.vector.y < -DPAD_Y_THRESHOLD,
+    });
+  });
+
+  // nipplejs does not emit a final centred `move` before `end`, so release here.
+  dpadManager.on('end', () => releaseDpad());
+}
+
 // ── Keyboard support ──────────────────────────────────────────────────────────
 
 const KEY_MAP: Record<string, number> = {
@@ -1202,7 +1468,9 @@ function bindKeyboard(): void {
 
     if (state.activeMenu?.isActive() && MENU_NAV_KEYS.has(e.key)) {
       e.preventDefault();
-      state.activeMenu.handleInput(e.key === 'Shift' ? 'Select' : e.key);
+      const menuKey = e.key === 'Shift' ? 'Select' : e.key;
+      if (MENU_REPEAT_KEYS.has(menuKey)) startMenuRepeat(menuKey);
+      else sendMenuKey(menuKey);
       return;
     }
 
@@ -1228,6 +1496,8 @@ function bindKeyboard(): void {
   document.addEventListener('keyup', (e) => {
     log.debug(`keyup key=${e.key}`);
     heldKeys.delete(e.key);
+    const menuKey = e.key === 'Shift' ? 'Select' : e.key;
+    if (MENU_REPEAT_KEYS.has(menuKey)) stopMenuRepeat(menuKey);
     const idx = KEY_MAP[e.key];
     if (idx === undefined || idx === -1) return;
     e.preventDefault();

--- a/platform/web/client/src-ts/menu.ts
+++ b/platform/web/client/src-ts/menu.ts
@@ -94,7 +94,7 @@ class MenuRenderer implements MenuRendererInstance {
 
   // Wasm renderer — produces every menu frame; this class blits it + forwards input.
   private _wasm: WasmRendererLike | null = null;
-  private _animationRafId: number | null = null;
+  private _marqueeRafId: number | null = null;
   private _offscreenCanvas: HTMLCanvasElement | null = null;
   private _offscreenCtx: CanvasRenderingContext2D | null = null;
   private _imageData: ImageData | null = null;
@@ -114,6 +114,18 @@ class MenuRenderer implements MenuRendererInstance {
   /** Title of the currently showing menu (undefined when hidden). */
   get title(): string | undefined {
     return this._opts?.title;
+  }
+
+  /** Index of the highlighted item. Selection state lives in the wasm renderer;
+   *  this getter/setter mirrors it so callers can read or move the cursor
+   *  without reaching into the wasm object directly. */
+  get _selIdx(): number {
+    return this._wasm ? this._wasm.selected_index() : -1;
+  }
+  set _selIdx(idx: number) {
+    if (!this._wasm) return;
+    this._wasm.set_selected(idx);
+    this.render();
   }
 
   show(options: MenuOptions): void {
@@ -255,22 +267,22 @@ class MenuRenderer implements MenuRendererInstance {
   }
 
   private _startAnimation(): void {
-    if (this._animationRafId !== null) return;
+    if (this._marqueeRafId !== null) return;
     const loop = (): void => {
       if (!this._active || !this._wasm) {
-        this._animationRafId = null;
+        this._marqueeRafId = null;
         return;
       }
       this.render();
-      this._animationRafId = requestAnimationFrame(loop);
+      this._marqueeRafId = requestAnimationFrame(loop);
     };
-    this._animationRafId = requestAnimationFrame(loop);
+    this._marqueeRafId = requestAnimationFrame(loop);
   }
 
   private _stopAnimation(): void {
-    if (this._animationRafId !== null) {
-      cancelAnimationFrame(this._animationRafId);
-      this._animationRafId = null;
+    if (this._marqueeRafId !== null) {
+      cancelAnimationFrame(this._marqueeRafId);
+      this._marqueeRafId = null;
     }
   }
 

--- a/platform/web/client/static/index.html
+++ b/platform/web/client/static/index.html
@@ -6,7 +6,7 @@
   <meta name="apple-mobile-web-app-capable" content="yes" />
   <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent" />
   <title>rustyboy</title>
-  <link rel="stylesheet" href="/static/style.css?v=gemini-marquee-vcenter-20260629" />
+  <link rel="stylesheet" href="/static/style.css?v=nipplejs-dpad-20260701-touchrepeat" />
 </head>
 <body>
 
@@ -74,15 +74,9 @@
       <!-- Controls area -->
       <div class="controls-area">
 
-        <!-- Left: D-pad -->
+        <!-- Left: D-pad — nipplejs joystick zone (see setupDpad in app.ts) -->
         <div class="dpad-wrap">
-          <div class="dpad">
-            <button class="dpad-btn dpad-up"    data-btn="2" aria-label="Up"></button>
-            <button class="dpad-btn dpad-left"  data-btn="1" aria-label="Left"></button>
-            <div class="dpad-center"><div class="dpad-nub"></div></div>
-            <button class="dpad-btn dpad-right" data-btn="0" aria-label="Right"></button>
-            <button class="dpad-btn dpad-down"  data-btn="3" aria-label="Down"></button>
-          </div>
+          <div class="dpad-zone" id="dpadZone" role="group" aria-label="D-pad"></div>
         </div>
 
         <!-- Right: A / B (magenta, diagonal) -->
@@ -131,7 +125,7 @@
     </div>
   </div>
 
-  <script src="/static/menu.js?v=gemini-marquee-vcenter-20260629"></script>
-  <script type="module" src="/static/app.js?v=gemini-marquee-vcenter-20260629"></script>
+  <script src="/static/menu.js?v=nipplejs-dpad-20260701-touchrepeat"></script>
+  <script type="module" src="/static/app.js?v=nipplejs-dpad-20260701-touchrepeat"></script>
 </body>
 </html>

--- a/platform/web/client/static/style.css
+++ b/platform/web/client/static/style.css
@@ -496,43 +496,34 @@ body {
 }
 
 /* ── D-Pad ────────────────────────────────────────────── */
+/* A recessed circular "well" that hosts a nipplejs static joystick. nipplejs
+   injects .joystick > .back + .front into this zone and drives the thumb-stick;
+   input handling lives in setupDpad() in app.ts. The zone must be positioned
+   (position: relative) so nipplejs can place the nub against it. */
 .dpad-wrap { flex: 0 0 auto; }
 
-.dpad {
+.dpad-zone {
+  position: relative;
   width: clamp(120px, 33vw, 152px);
   height: clamp(120px, 33vw, 152px);
-  display: grid;
-  grid-template-columns: 1fr 1fr 1fr;
-  grid-template-rows: 1fr 1fr 1fr;
-  filter: drop-shadow(0 3px 4px rgba(0,0,0,0.5));
-}
-
-.dpad-btn {
-  background: var(--btn-dpad);
-  border: none;
-  cursor: pointer;
+  border-radius: 50%;
+  background:
+    radial-gradient(circle at 50% 36%,
+      var(--btn-dpad-hi) 0%, var(--btn-dpad) 58%, var(--btn-dpad-shadow) 100%);
+  box-shadow:
+    inset 0 3px 7px rgba(0,0,0,0.55),
+    inset 0 -2px 3px rgba(255,255,255,0.05),
+    0 3px 4px rgba(0,0,0,0.5);
   touch-action: none;
   -webkit-tap-highlight-color: transparent;
-  transition: background 0.06s;
 }
-.dpad-btn:active, .dpad-btn.pressed { background: var(--btn-dpad-hi); }
 
-.dpad-up    { grid-column: 2; grid-row: 1; border-radius: 4px 4px 0 0;
-              box-shadow: inset 0 2px 0 rgba(255,255,255,0.08); }
-.dpad-left  { grid-column: 1; grid-row: 2; border-radius: 4px 0 0 4px;
-              box-shadow: inset 2px 0 0 rgba(255,255,255,0.08); }
-.dpad-center{ grid-column: 2; grid-row: 2; background: var(--btn-dpad);
-              pointer-events: none; display: flex; align-items: center; justify-content: center; }
-.dpad-nub {
-  width: 30%;
-  height: 30%;
-  border-radius: 50%;
-  background: #1A1C28;
+/* Give the nipplejs thumb-nub a subtle raised edge so it reads as a stick. */
+.dpad-zone .front {
+  box-shadow:
+    inset 0 2px 2px rgba(255,255,255,0.12),
+    0 2px 3px rgba(0,0,0,0.45);
 }
-.dpad-right { grid-column: 3; grid-row: 2; border-radius: 0 4px 4px 0;
-              box-shadow: inset -2px 0 0 rgba(255,255,255,0.08); }
-.dpad-down  { grid-column: 2; grid-row: 3; border-radius: 0 0 4px 4px;
-              box-shadow: inset 0 -2px 0 rgba(255,255,255,0.08); }
 
 /* ── A / B buttons ────────────────────────────────────── */
 .ab-wrap { flex: 0 0 auto; }

--- a/platform/web/e2e/fixtures/app_test.html
+++ b/platform/web/e2e/fixtures/app_test.html
@@ -17,9 +17,13 @@
   <button id="powerBtn"></button>
   <div class="power-led" id="powerLed"></div>
   <div class="reset-led" id="resetLed"></div>
-  <!-- D-pad and action buttons matching index.html data-btn indices -->
-  <button data-btn="2" id="btn-up">Up</button>
-  <button data-btn="3" id="btn-down">Down</button>
+  <!-- D-pad zone and action buttons matching index.html controls -->
+  <div
+    id="dpadZone"
+    role="group"
+    aria-label="D-pad"
+    style="position:relative;width:152px;height:152px;touch-action:none"
+  ></div>
   <button data-btn="4" id="btn-a">A</button>
   <button data-btn="5" id="btn-b">B</button>
 

--- a/platform/web/e2e/fixtures/menu_test.html
+++ b/platform/web/e2e/fixtures/menu_test.html
@@ -3,6 +3,12 @@
 <head><meta charset="UTF-8"></head>
 <body>
   <canvas id="testCanvas" width="160" height="144"></canvas>
+  <!-- Expose the wasm menu renderer the same way app.ts does at boot, so the
+       WASM-backed MenuRenderer can actually render into the canvas. -->
+  <script type="module">
+    import { WasmMenuRenderer } from '/static/rustyboy_web_client.js';
+    window.RustyBoyWasmMenuRenderer = WasmMenuRenderer;
+  </script>
   <script src="/static/menu.js"></script>
 </body>
 </html>

--- a/platform/web/e2e/server.cjs
+++ b/platform/web/e2e/server.cjs
@@ -14,22 +14,43 @@ const MIME = {
   '.wasm': 'application/wasm',
 };
 
-// Test state controlled by the test suite via POST /test/control
-let mockState = {
-  authed:     false,   // whether /api/me returns 200 or 401
-  roms:       ['Tetris.gb', 'Mario.gb', 'Zelda.gb'],
-  saveStates: [],      // array of {id, rom_name, slot_name, updated_at}
-};
+// Per-test isolated state. Each test sends a unique `x-rb-test` header (see
+// tests/fixtures.js); state is bucketed by that id so tests running in parallel
+// never share or clobber one another. Requests with no header fall back to a
+// single default bucket (only hit by ad-hoc manual browsing).
+const states = new Map();
+function defaultState() {
+  return {
+    authed:     false,   // whether /api/me returns 200 or 401
+    roms:       ['Tetris.gb', 'Mario.gb', 'Zelda.gb'],
+    saveStates: [],      // array of {id, rom_name, slot_name, updated_at}
+  };
+}
+function cookieValue(req, name) {
+  const cookie = req.headers.cookie || '';
+  const found = cookie
+    .split(';')
+    .map(part => part.trim())
+    .find(part => part.startsWith(`${name}=`));
+  return found ? decodeURIComponent(found.slice(name.length + 1)) : null;
+}
+function getState(req) {
+  const id = req.headers['x-rb-test'] || cookieValue(req, 'rbTestId') || '__default__';
+  let st = states.get(id);
+  if (!st) { st = defaultState(); states.set(id, st); }
+  return st;
+}
 
 http.createServer((req, res) => {
   const url = req.url.split('?')[0];
+  const st = getState(req);
 
   // ── Test control endpoint ──────────────────────────────────────────────────
   if (req.method === 'POST' && url === '/test/control') {
     let body = '';
     req.on('data', d => { body += d; });
     req.on('end', () => {
-      try { Object.assign(mockState, JSON.parse(body)); } catch (_) {}
+      try { Object.assign(st, JSON.parse(body)); } catch (_) {}
       res.writeHead(200);
       res.end('ok');
     });
@@ -38,7 +59,7 @@ http.createServer((req, res) => {
 
   // ── Mock API endpoints ─────────────────────────────────────────────────────
   if (url === '/api/me') {
-    if (mockState.authed) {
+    if (st.authed) {
       res.writeHead(200, { 'Content-Type': 'application/json' });
       res.end(JSON.stringify({ id: 'test-user', display_name: 'Test User', email: 'test@test.com', avatar_url: null }));
     } else {
@@ -50,13 +71,13 @@ http.createServer((req, res) => {
 
   if (url === '/api/roms') {
     res.writeHead(200, { 'Content-Type': 'application/json' });
-    res.end(JSON.stringify(mockState.roms));
+    res.end(JSON.stringify(st.roms));
     return;
   }
 
   // /auth/google: simulate instant login by setting authed and redirecting back
   if (url === '/auth/google') {
-    mockState.authed = true;
+    st.authed = true;
     res.writeHead(302, { 'Location': '/test/app' });
     res.end();
     return;
@@ -64,7 +85,7 @@ http.createServer((req, res) => {
 
   // /auth/logout: clear auth, redirect to login
   if (req.method === 'POST' && url === '/auth/logout') {
-    mockState.authed = false;
+    st.authed = false;
     res.writeHead(200);
     res.end('ok');
     return;
@@ -79,9 +100,9 @@ http.createServer((req, res) => {
 
   // /api/save-states — list roms with saves
   if (req.method === 'GET' && url === '/api/save-states') {
-    const romsWithSaves = [...new Set(mockState.saveStates.map(s => s.rom_name))]
+    const romsWithSaves = [...new Set(st.saveStates.map(s => s.rom_name))]
       .map(rom => {
-        const latest = mockState.saveStates
+        const latest = st.saveStates
           .filter(s => s.rom_name === rom)
           .sort((a, b) => b.updated_at - a.updated_at)[0];
         return { rom_name: rom, last_saved: latest.updated_at };
@@ -96,7 +117,7 @@ http.createServer((req, res) => {
   const latestMatch = url.match(/^\/api\/save-states\/([^/]+)\/latest$/);
   if (req.method === 'GET' && latestMatch) {
     const rom = decodeURIComponent(latestMatch[1]);
-    const saves = mockState.saveStates
+    const saves = st.saveStates
       .filter(s => s.rom_name === rom)
       .sort((a, b) => b.updated_at - a.updated_at);
     if (saves.length === 0) {
@@ -112,7 +133,7 @@ http.createServer((req, res) => {
   if (romSavesMatch) {
     const rom = decodeURIComponent(romSavesMatch[1]);
     if (req.method === 'GET') {
-      const saves = mockState.saveStates
+      const saves = st.saveStates
         .filter(s => s.rom_name === rom)
         .sort((a, b) => b.updated_at - a.updated_at)
         .map(({ id, slot_name, updated_at }) => ({ id, slot_name, updated_at }));
@@ -124,7 +145,7 @@ http.createServer((req, res) => {
       const id = `mock-ss-${Date.now()}`;
       const slot_name = String(Date.now());
       const updated_at = Math.floor(Date.now() / 1000);
-      mockState.saveStates.push({ id, rom_name: rom, slot_name, updated_at });
+      st.saveStates.push({ id, rom_name: rom, slot_name, updated_at });
       res.writeHead(201, { 'Content-Type': 'application/json' });
       res.end(JSON.stringify({ id, slot_name, updated_at }));
       return;
@@ -135,7 +156,7 @@ http.createServer((req, res) => {
   const deleteMatch = url.match(/^\/api\/save-states\/by-id\/([^/]+)$/);
   if (req.method === 'DELETE' && deleteMatch) {
     const id = deleteMatch[1];
-    mockState.saveStates = mockState.saveStates.filter(s => s.id !== id);
+    st.saveStates = st.saveStates.filter(s => s.id !== id);
     res.writeHead(204); res.end(); return;
   }
 
@@ -143,7 +164,7 @@ http.createServer((req, res) => {
   const dataMatch = url.match(/^\/api\/save-states\/by-id\/([^/]+)\/data$/);
   if (req.method === 'GET' && dataMatch) {
     const id = dataMatch[1];
-    const ss = mockState.saveStates.find(s => s.id === id);
+    const ss = st.saveStates.find(s => s.id === id);
     if (!ss) { res.writeHead(404); res.end(); return; }
     res.writeHead(200, { 'Content-Type': 'application/octet-stream' });
     res.end(Buffer.alloc(16)); // fake blob

--- a/platform/web/e2e/tests/button_stuck.spec.js
+++ b/platform/web/e2e/tests/button_stuck.spec.js
@@ -1,33 +1,24 @@
 /**
- * Stuck-button regression test.
+ * D-pad release regression tests.
  *
- * Hypothesis: if pointer capture is lost while a d-pad button is held (e.g.
- * because the finger slid off the element), the browser fires lostpointercapture
- * but NOT pointerup on the element.  Without a lostpointercapture handler the
- * emulator never receives set_button(idx, false), leaving the button stuck.
- *
- * The test:
- *   1. Start the emulator running (ROM launched).
- *   2. Spy on EmulatorHandle.set_button calls.
- *   3. Fire pointerdown on a d-pad button (simulates press).
- *   4. Fire lostpointercapture on that button WITHOUT a preceding pointerup
- *      (simulates the browser dropping capture mid-slide).
- *   5. Assert that set_button(idx, false) was called — i.e. the release reached
- *      the emulator.
+ * The production D-pad is a nipplejs static joystick. A direction press is
+ * emitted when the pointer moves far enough from center; every end path must
+ * release any held direction so the emulator never sees a stuck button.
  */
 
-import { test, expect } from '@playwright/test';
+import { test, expect } from './fixtures.js';
 
 const BASE = 'http://localhost:3737';
 
-async function setServerState(request, state) {
-  await request.post(`${BASE}/test/control`, { data: state });
+async function setServerState(target, state) {
+  const api = target.request ?? target;
+  await api.post(`${BASE}/test/control`, { data: state });
 }
 
 async function loadApp(page) {
   await page.goto(`${BASE}/test/app`);
   await page.waitForFunction(
-    () => typeof window.MenuRenderer === 'function' && window.__appState && window.__appState.activeMenu !== undefined,
+    () => typeof window.MenuRenderer === 'function' && window.__appState?.activeMenu?.isActive?.(),
     { timeout: 5000 }
   );
 }
@@ -69,38 +60,84 @@ async function installSpy(page) {
   });
 }
 
-/** Fire a synthetic PointerEvent of the given type on an element. */
-async function firePointerEvent(page, selector, type, pointerId = 1) {
-  await page.evaluate(([sel, evType, pid]) => {
-    const el = document.querySelector(sel);
-    if (!el) throw new Error(`Element not found: ${sel}`);
-    const ev = new PointerEvent(evType, {
+async function startDpadDrag(page, direction, pointerId = 23) {
+  await page.evaluate(([dir, pid]) => {
+    const zone = document.getElementById('dpadZone');
+    if (!zone) throw new Error('startDpadDrag: no #dpadZone');
+
+    const rect = zone.getBoundingClientRect();
+    const centerX = rect.left + rect.width / 2;
+    const centerY = rect.top + rect.height / 2;
+    const distance = 58;
+    const offsets = {
+      up: [0, -distance],
+      down: [0, distance],
+      left: [-distance, 0],
+      right: [distance, 0],
+    };
+    const [dx, dy] = offsets[dir];
+
+    const fire = (target, type, x, y, buttons) => {
+      target.dispatchEvent(new PointerEvent(type, {
+        bubbles: true,
+        cancelable: true,
+        pointerId: pid,
+        pointerType: 'touch',
+        isPrimary: true,
+        buttons,
+        clientX: x,
+        clientY: y,
+      }));
+    };
+
+    fire(zone, 'pointerdown', centerX, centerY, 1);
+    fire(document, 'pointermove', centerX + dx, centerY + dy, 1);
+  }, [direction, pointerId]);
+}
+
+async function endDpadDrag(page, endType = 'pointerup', pointerId = 23) {
+  await page.evaluate(([end, pid]) => {
+    const zone = document.getElementById('dpadZone');
+    if (!zone) throw new Error('endDpadDrag: no #dpadZone');
+
+    const rect = zone.getBoundingClientRect();
+    const centerX = rect.left + rect.width / 2;
+    const centerY = rect.top + rect.height / 2;
+
+    document.dispatchEvent(new PointerEvent(end, {
       bubbles: true,
       cancelable: true,
       pointerId: pid,
       pointerType: 'touch',
       isPrimary: true,
-      clientX: el.getBoundingClientRect().left + 5,
-      clientY: el.getBoundingClientRect().top  + 5,
-    });
-    el.dispatchEvent(ev);
-  }, [selector, type, pointerId]);
+      buttons: 0,
+      clientX: centerX,
+      clientY: centerY,
+    }));
+  }, [endType, pointerId]);
+}
+
+async function dpadDrag(page, direction, endType = 'pointerup') {
+  await startDpadDrag(page, direction);
+  await endDpadDrag(page, endType);
+}
+
+async function dpadFrontTransform(page) {
+  return page.evaluate(() => {
+    const front = document.querySelector('#dpadZone .front');
+    return front ? getComputedStyle(front).transform : '';
+  });
 }
 
 // ── Tests ────────────────────────────────────────────────────────────────────
 
-test('B2: normal tap sends exactly one press and one release to emulator', async ({ page, request }) => {
-  await setServerState(request, { authed: true, roms: ['Tetris.gb'] });
+test('B2: normal joystick drag sends exactly one press and one release to emulator', async ({ page, request }) => {
+  await setServerState(page, { authed: true, roms: ['Tetris.gb'] });
   await loadApp(page);
   await launchRom(page);
   await installSpy(page);
 
-  const selector = '[data-btn="2"]';
-
-  // Full tap: pointerdown → pointerup → lostpointercapture (browser fires all three)
-  await firePointerEvent(page, selector, 'pointerdown');
-  await firePointerEvent(page, selector, 'pointerup');
-  await firePointerEvent(page, selector, 'lostpointercapture');
+  await dpadDrag(page, 'up');
 
   const calls = await page.evaluate(() => window._buttonCalls);
   const presses   = calls.filter(c => c.btn === 2 && c.pressed === true);
@@ -110,29 +147,80 @@ test('B2: normal tap sends exactly one press and one release to emulator', async
   expect(releases.length).toBe(1);
 });
 
-test('B1: lostpointercapture without pointerup sends button release to emulator', async ({ page, request }) => {
-  await setServerState(request, { authed: true, roms: ['Tetris.gb'] });
+test('B1: pointercancel releases held joystick direction', async ({ page, request }) => {
+  await setServerState(page, { authed: true, roms: ['Tetris.gb'] });
   await loadApp(page);
   await launchRom(page);
   await installSpy(page);
 
-  // btn-up is data-btn="2" (Up, index 2)
-  const selector = '[data-btn="2"]';
+  await dpadDrag(page, 'up', 'pointercancel');
 
-  // Press: pointerdown
-  await firePointerEvent(page, selector, 'pointerdown');
+  const calls = await page.evaluate(() => window._buttonCalls);
+  expect(calls.some(c => c.btn === 2 && c.pressed === true)).toBe(true);
+  expect(calls.some(c => c.btn === 2 && c.pressed === false)).toBe(true);
+});
 
-  // Verify press was recorded
-  const afterPress = await page.evaluate(() => window._buttonCalls);
-  expect(afterPress.some(c => c.btn === 2 && c.pressed === true)).toBe(true);
+test('B1: lostpointercapture without pointerup releases held joystick direction', async ({ page, request }) => {
+  await setServerState(page, { authed: true, roms: ['Tetris.gb'] });
+  await loadApp(page);
+  await launchRom(page);
+  await installSpy(page);
 
-  // Clear the log so we can cleanly check for the release
+  await dpadDrag(page, 'up', 'lostpointercapture');
+
+  const calls = await page.evaluate(() => window._buttonCalls);
+  expect(calls.some(c => c.btn === 2 && c.pressed === true)).toBe(true);
+  expect(calls.some(c => c.btn === 2 && c.pressed === false)).toBe(true);
+});
+
+test('B1: lostpointercapture recenters visual joystick and accepts next drag', async ({ page, request }) => {
+  await setServerState(page, { authed: true, roms: ['Tetris.gb'] });
+  await loadApp(page);
+  await launchRom(page);
+  await installSpy(page);
+
+  await startDpadDrag(page, 'up', 23);
+  await endDpadDrag(page, 'lostpointercapture', 23);
+  await expect.poll(() => dpadFrontTransform(page)).toBe('matrix(1, 0, 0, 1, 0, 0)');
+
   await page.evaluate(() => { window._buttonCalls = []; });
+  await startDpadDrag(page, 'right', 24);
+  await endDpadDrag(page, 'pointerup', 24);
 
-  // Simulate pointer capture being lost WITHOUT a pointerup
-  await firePointerEvent(page, selector, 'lostpointercapture');
+  const calls = await page.evaluate(() => window._buttonCalls);
+  expect(calls.some(c => c.btn === 0 && c.pressed === true)).toBe(true);
+  expect(calls.some(c => c.btn === 0 && c.pressed === false)).toBe(true);
+});
 
-  // Release must have reached the emulator
-  const afterLost = await page.evaluate(() => window._buttonCalls);
-  expect(afterLost.some(c => c.btn === 2 && c.pressed === false)).toBe(true);
+test('B1: window blur releases held joystick direction', async ({ page, request }) => {
+  await setServerState(page, { authed: true, roms: ['Tetris.gb'] });
+  await loadApp(page);
+  await launchRom(page);
+  await installSpy(page);
+
+  await startDpadDrag(page, 'up');
+  await page.evaluate(() => window.dispatchEvent(new Event('blur')));
+
+  const calls = await page.evaluate(() => window._buttonCalls);
+  expect(calls.some(c => c.btn === 2 && c.pressed === true)).toBe(true);
+  expect(calls.some(c => c.btn === 2 && c.pressed === false)).toBe(true);
+});
+
+test('B1: ending another pointer does not release held joystick direction', async ({ page, request }) => {
+  await setServerState(page, { authed: true, roms: ['Tetris.gb'] });
+  await loadApp(page);
+  await launchRom(page);
+  await installSpy(page);
+
+  await startDpadDrag(page, 'right', 23);
+  await endDpadDrag(page, 'pointerup', 99);
+
+  let calls = await page.evaluate(() => window._buttonCalls);
+  expect(calls.some(c => c.btn === 0 && c.pressed === true)).toBe(true);
+  expect(calls.some(c => c.btn === 0 && c.pressed === false)).toBe(false);
+
+  await endDpadDrag(page, 'pointerup', 23);
+
+  calls = await page.evaluate(() => window._buttonCalls);
+  expect(calls.some(c => c.btn === 0 && c.pressed === false)).toBe(true);
 });

--- a/platform/web/e2e/tests/fixtures.js
+++ b/platform/web/e2e/tests/fixtures.js
@@ -1,0 +1,43 @@
+import { test as base, expect } from '@playwright/test';
+import { randomUUID } from 'node:crypto';
+
+const BASE_URL = 'http://localhost:3737';
+
+/**
+ * Test fixtures that give every test its own isolated mock-server state.
+ *
+ * Each test gets a unique `rbTestId`, sent as the `x-rb-test` header on BOTH:
+ *   - the browser context (so the app's own fetches — /api/me, /api/roms,
+ *     /api/save-states, /auth/* — carry it), and
+ *   - the APIRequestContext used by helpers like setServerState().
+ *
+ * server.cjs buckets all mutable state by that id, so no state is shared
+ * between tests and the suite is safe to run fully in parallel.
+ */
+export const test = base.extend({
+  rbTestId: async ({}, use) => {
+    await use(randomUUID());
+  },
+
+  // Replace the built-in `request` fixture with one tagged with the test id.
+  request: async ({ playwright, rbTestId }, use) => {
+    const request = await playwright.request.newContext({
+      baseURL: BASE_URL,
+      extraHTTPHeaders: { 'x-rb-test': rbTestId },
+    });
+    await use(request);
+    await request.dispose();
+  },
+});
+
+// Tag the browser context (and therefore every page/fetch request) with the id.
+test.beforeEach(async ({ context, rbTestId }) => {
+  await context.route('**/*', route => {
+    const headers = { ...route.request().headers(), 'x-rb-test': rbTestId };
+    route.continue({ headers });
+  });
+  await context.addCookies([{ name: 'rbTestId', value: rbTestId, url: BASE_URL }]);
+  await context.setExtraHTTPHeaders({ 'x-rb-test': rbTestId });
+});
+
+export { expect };

--- a/platform/web/e2e/tests/menu.spec.js
+++ b/platform/web/e2e/tests/menu.spec.js
@@ -1,4 +1,4 @@
-import { test, expect } from '@playwright/test';
+import { test, expect } from './fixtures.js';
 
 // Helpers ----------------------------------------------------------------
 
@@ -7,7 +7,11 @@ import { test, expect } from '@playwright/test';
  */
 async function loadMenuPage(page) {
   await page.goto('/test/menu');
-  await page.waitForFunction(() => typeof window.MenuRenderer === 'function');
+  // Wait for both the adapter (menu.js) and the wasm renderer it delegates to.
+  await page.waitForFunction(
+    () => typeof window.MenuRenderer === 'function' &&
+          typeof window.RustyBoyWasmMenuRenderer === 'function'
+  );
   return page.locator('#testCanvas');
 }
 
@@ -219,59 +223,60 @@ test('tap on item calls onSelect', async ({ page }) => {
   expect(tapped.value).toBe('tetris');
 });
 
-// Marquee tests — title scrolling behavior
+// Rendering / animation — the adapter blits the wasm renderer's frame each RAF
+// tick. Title marquee scrolling itself lives in the wasm renderer and is
+// covered there; here we assert the adapter drives and reflects wasm state.
 
-test('short title has zero marquee offset', async ({ page }) => {
+test('animation loop runs while the menu is active', async ({ page }) => {
   await loadMenuPage(page);
   await showMenu(page, {
-    title: 'HI',
+    title: 'GAMES',
     items: [{ label: 'x', value: 'x' }],
   });
 
-  // Short title fits — marquee offset should stay 0
-  await page.waitForTimeout(200);
-  const offset = await page.evaluate(() => window._testMenu._marqueeOffset);
-  expect(offset).toBe(0);
+  // show() starts the RAF loop that re-blits the wasm frame each tick.
+  const rafActive = await page.evaluate(() => window._testMenu._marqueeRafId !== null);
+  expect(rafActive).toBe(true);
 });
 
-test('long title starts at zero offset then scrolls after 1s pause', async ({ page }) => {
+test('selection highlight renders at the selected item row', async ({ page }) => {
   await loadMenuPage(page);
-  // Title long enough to overflow the 160px header at 8px monospace
   await showMenu(page, {
-    title: 'SUPER LONG GAME TITLE THAT WILL NOT FIT',
-    items: [{ label: 'x', value: 'x' }],
+    title: 'GAMES',
+    items: [
+      { label: 'A', value: 'a' },
+      { label: 'B', value: 'b' },
+      { label: 'C', value: 'c' },
+    ],
   });
 
-  // Immediately after show, offset should be 0 (in the pause phase)
-  const offsetAtStart = await page.evaluate(() => window._testMenu._marqueeOffset);
-  expect(offsetAtStart).toBe(0);
+  // With selection at row 0, the highlight band (C1) covers y=16..23; a lower
+  // unselected row is background (C0). Proves wasm selection reaches the canvas.
+  const highlighted = await getPixel(page, 80, 20);
+  expect(highlighted.slice(0, 3)).toEqual(hexToRgb('#306230'));
 
-  // After >1s the scroll should have begun (offset > 0)
-  await page.waitForTimeout(1400);
-  const offsetAfterPause = await page.evaluate(() => window._testMenu._marqueeOffset);
-  expect(offsetAfterPause).toBeGreaterThan(0);
+  const background = await getPixel(page, 80, 40);
+  expect(background.slice(0, 3)).toEqual(hexToRgb('#0F380F'));
 });
 
-test('marquee resets to zero after title scrolls fully off screen', async ({ page }) => {
+test('rendered selection highlight follows keyboard navigation', async ({ page }) => {
   await loadMenuPage(page);
   await showMenu(page, {
-    title: 'SUPER LONG GAME TITLE THAT WILL NOT FIT',
-    items: [{ label: 'x', value: 'x' }],
+    title: 'GAMES',
+    items: [
+      { label: 'A', value: 'a' },
+      { label: 'B', value: 'b' },
+      { label: 'C', value: 'c' },
+    ],
   });
 
-  // _marqueeScrollMax is the total px to scroll before reset (TEXT_PAD + titleWidth)
-  // Fast-forward: force scroll phase with phaseAt far in the past so elapsed > scrollMax
-  await page.evaluate(() => {
-    const menu = window._testMenu;
-    menu._marqueePhase   = 'scroll';
-    menu._marqueePhaseAt = performance.now() - 100000; // 100s ago → way past any title width
-  });
+  // Move down one row; the highlight band moves from row 0 (y~20) to row 1 (y~28).
+  await page.evaluate(() => window._testMenu.handleInput('ArrowDown'));
 
-  // Give one RAF tick to process
-  await page.waitForTimeout(100);
-
-  const offset = await page.evaluate(() => window._testMenu._marqueeOffset);
-  expect(offset).toBe(0);
+  const row0 = await getPixel(page, 80, 20); // now background
+  const row1 = await getPixel(page, 80, 28); // now highlighted
+  expect(row0.slice(0, 3)).toEqual(hexToRgb('#0F380F'));
+  expect(row1.slice(0, 3)).toEqual(hexToRgb('#306230'));
 });
 
 test('marquee RAF loop stops when hide() is called', async ({ page }) => {

--- a/platform/web/e2e/tests/traversal.spec.js
+++ b/platform/web/e2e/tests/traversal.spec.js
@@ -1140,7 +1140,7 @@ test('T33: touch ending outside canvas bounds does not trigger menu selection', 
     const rect = canvas.getBoundingClientRect();
     const insideX = rect.left + rect.width / 2;
     const insideY = rect.top  + rect.height / 2;
-    // End touch 500px below canvas (where d-pad buttons are)
+    // End touch 500px below the canvas, in the controls area.
     const outsideX = rect.left + rect.width / 2;
     const outsideY = rect.bottom + 500;
 

--- a/platform/web/e2e/tests/traversal.spec.js
+++ b/platform/web/e2e/tests/traversal.spec.js
@@ -15,7 +15,6 @@
  *     T2  Login screen: ArrowDown wraps (single item wraps back to 0)
  *     T3  Login screen: ArrowUp wraps (single item wraps back to 0)
  *     T4  Login screen: Enter triggers /auth/google → lands on main menu
- *     T5  Login screen: tap on item triggers login
  *
  *   Main menu:
  *     T6  Load while logged in → main menu shown (not login screen)
@@ -27,8 +26,7 @@
  *     T12 Main menu: ArrowDown + Enter on LOGOUT → login screen shown
  *
  *   ROM list:
- *     T13 ROM list: shows all ROMs
- *     T14 ROM list: ArrowDown moves selection
+ *     T14 ROM list: shows all ROMs and ArrowDown moves selection
  *     T15 ROM list: ArrowDown wraps at end
  *     T16 ROM list: ArrowUp from first item wraps to last
  *     T17 ROM list: Escape → back to main menu
@@ -44,24 +42,25 @@
  *     T23 Error screen: Escape → back to main menu
  */
 
-import { test, expect } from '@playwright/test';
+import { test, expect } from './fixtures.js';
 
 // ── Helpers ─────────────────────────────────────────────────────────────────
 
 const BASE = 'http://localhost:3737';
 
 /** Reset mock server state before each test. */
-async function setServerState(request, state) {
-  await request.post(`${BASE}/test/control`, { data: state });
+async function setServerState(target, state) {
+  const api = target.request ?? target;
+  await api.post(`${BASE}/test/control`, { data: state });
 }
 
 /** Load the app fixture page and wait for boot() to finish. */
 async function loadApp(page) {
   await page.goto(`${BASE}/test/app`);
   // Wait for MenuRenderer to be available (menu.js loaded) and for boot() to
-  // have called showLoginScreen() or showMainMenu() (activeMenu set).
+  // have called showLoginScreen() or showMainMenu() (activeMenu active).
   await page.waitForFunction(
-    () => typeof window.MenuRenderer === 'function' && window.__appState && window.__appState.activeMenu !== undefined,
+    () => typeof window.MenuRenderer === 'function' && window.__appState?.activeMenu?.isActive?.(),
     { timeout: 5000 }
   );
 }
@@ -155,7 +154,7 @@ async function menuKey(page, key) {
 
 // T1: Unauthenticated → login screen
 test('T1: unauthenticated load shows login screen', async ({ page, request }) => {
-  await setServerState(request, { authed: false, roms: ['Tetris.gb'] });
+  await setServerState(page, { authed: false, roms: ['Tetris.gb'] });
   await loadApp(page);
 
   const title = await activeMenuTitle(page);
@@ -167,7 +166,7 @@ test('T1: unauthenticated load shows login screen', async ({ page, request }) =>
 
 // T2: Login screen ArrowDown wraps (single item)
 test('T2: login screen ArrowDown wraps on single item', async ({ page, request }) => {
-  await setServerState(request, { authed: false, roms: [] });
+  await setServerState(page, { authed: false, roms: [] });
   await loadApp(page);
 
   await menuKey(page, 'ArrowDown');
@@ -177,7 +176,7 @@ test('T2: login screen ArrowDown wraps on single item', async ({ page, request }
 
 // T3: Login screen ArrowUp wraps
 test('T3: login screen ArrowUp wraps on single item', async ({ page, request }) => {
-  await setServerState(request, { authed: false, roms: [] });
+  await setServerState(page, { authed: false, roms: [] });
   await loadApp(page);
 
   await menuKey(page, 'ArrowUp');
@@ -187,7 +186,7 @@ test('T3: login screen ArrowUp wraps on single item', async ({ page, request }) 
 
 // T4: Login screen Enter → navigates to /auth/google → lands on main menu
 test('T4: login Enter triggers auth and lands on main menu', async ({ page, request }) => {
-  await setServerState(request, { authed: false, roms: ['Tetris.gb'] });
+  await setServerState(page, { authed: false, roms: ['Tetris.gb'] });
   await loadApp(page);
 
   // Verify we're on login
@@ -213,33 +212,9 @@ test('T4: login Enter triggers auth and lands on main menu', async ({ page, requ
   expect(await activeMenuItems(page)).toContain('games');
 });
 
-// T5: Login screen tap on item triggers login
-test('T5: login screen tap on first item triggers navigation to /auth/google', async ({ page, request }) => {
-  await setServerState(request, { authed: false, roms: ['Tetris.gb'] });
-  await loadApp(page);
-
-  await Promise.all([
-    page.waitForNavigation({ waitUntil: 'networkidle' }),
-    page.evaluate(() => {
-      const s = window.__appState;
-      if (s && s.activeMenu) s.activeMenu.handleTap(80, 22); // tap first item row
-    }),
-  ]);
-
-  await page.waitForFunction(
-    () => window.__appState && window.__appState.activeMenu &&
-          window.__appState.activeMenu._opts &&
-          window.__appState.activeMenu._opts.items &&
-          window.__appState.activeMenu._opts.items.some(i => i.value === 'games'),
-    { timeout: 5000 }
-  );
-
-  expect(await activeMenuItems(page)).toContain('games');
-});
-
 // T6: Authenticated load → main menu
 test('T6: authenticated load shows main menu', async ({ page, request }) => {
-  await setServerState(request, { authed: true, roms: ['Tetris.gb'] });
+  await setServerState(page, { authed: true, roms: ['Tetris.gb'] });
   await loadApp(page);
 
   const title = await activeMenuTitle(page);
@@ -252,8 +227,9 @@ test('T6: authenticated load shows main menu', async ({ page, request }) => {
 
 // T7: Main menu default selection is GAMES (idx 0)
 test('T7: main menu default selection is GAMES', async ({ page, request }) => {
-  await setServerState(request, { authed: true, roms: ['Tetris.gb'] });
+  await setServerState(page, { authed: true, roms: ['Tetris.gb'] });
   await loadApp(page);
+  await ensureMainMenu(page);
 
   const idx = await activeMenuSelIdx(page);
   expect(idx).toBe(0);
@@ -264,8 +240,9 @@ test('T7: main menu default selection is GAMES', async ({ page, request }) => {
 
 // T8: Main menu ArrowDown moves to LOGOUT
 test('T8: main menu ArrowDown selects LOGOUT', async ({ page, request }) => {
-  await setServerState(request, { authed: true, roms: ['Tetris.gb'] });
+  await setServerState(page, { authed: true, roms: ['Tetris.gb'] });
   await loadApp(page);
+  await ensureMainMenu(page);
 
   await menuKey(page, 'ArrowDown');
 
@@ -278,8 +255,9 @@ test('T8: main menu ArrowDown selects LOGOUT', async ({ page, request }) => {
 
 // T9: Main menu ArrowDown wraps from LOGOUT back to PLAY
 test('T9: main menu ArrowDown wraps from last item to first', async ({ page, request }) => {
-  await setServerState(request, { authed: true, roms: ['Tetris.gb'] });
+  await setServerState(page, { authed: true, roms: ['Tetris.gb'] });
   await loadApp(page);
+  await ensureMainMenu(page);
 
   await menuKey(page, 'ArrowDown'); // → LOGOUT (idx 1)
   await menuKey(page, 'ArrowDown'); // → wraps to PLAY (idx 0)
@@ -290,8 +268,9 @@ test('T9: main menu ArrowDown wraps from last item to first', async ({ page, req
 
 // T10: Main menu ArrowUp from PLAY wraps to LOGOUT
 test('T10: main menu ArrowUp from first item wraps to last', async ({ page, request }) => {
-  await setServerState(request, { authed: true, roms: ['Tetris.gb'] });
+  await setServerState(page, { authed: true, roms: ['Tetris.gb'] });
   await loadApp(page);
+  await ensureMainMenu(page);
 
   await menuKey(page, 'ArrowUp'); // from PLAY → LOGOUT
 
@@ -304,8 +283,9 @@ test('T10: main menu ArrowUp from first item wraps to last', async ({ page, requ
 
 // T11: Main menu Enter on PLAY → ROM list
 test('T11: main menu Enter on PLAY shows ROM list', async ({ page, request }) => {
-  await setServerState(request, { authed: true, roms: ['Tetris.gb', 'Mario.gb'] });
+  await setServerState(page, { authed: true, roms: ['Tetris.gb', 'Mario.gb'] });
   await loadApp(page);
+  await ensureMainMenu(page);
 
   await menuKey(page, 'Enter'); // PLAY is default selection
 
@@ -321,8 +301,9 @@ test('T11: main menu Enter on PLAY shows ROM list', async ({ page, request }) =>
 
 // T12: Main menu LOGOUT → back to login screen
 test('T12: main menu LOGOUT shows login screen', async ({ page, request }) => {
-  await setServerState(request, { authed: true, roms: ['Tetris.gb'] });
+  await setServerState(page, { authed: true, roms: ['Tetris.gb'] });
   await loadApp(page);
+  await ensureMainMenu(page);
 
   await menuKey(page, 'ArrowDown'); // → LOGOUT
   await menuKey(page, 'Enter');
@@ -340,13 +321,13 @@ test('T12: main menu LOGOUT shows login screen', async ({ page, request }) => {
   expect(await activeMenuItems(page)).toContain('login');
 });
 
-// T13: ROM list shows all ROMs
-test('T13: ROM list shows all available ROMs', async ({ page, request }) => {
-  await setServerState(request, { authed: true, roms: ['Tetris.gb', 'Mario.gb', 'Zelda.gb'] });
+// T14: ROM list shows ROMs and ArrowDown moves selection
+test('T14: ROM list shows ROMs and ArrowDown moves selection down', async ({ page, request }) => {
+  await setServerState(page, { authed: true, roms: ['Tetris.gb', 'Mario.gb', 'Zelda.gb'] });
   await loadApp(page);
+  await ensureMainMenu(page);
 
   await menuKey(page, 'Enter'); // open ROM list
-
   await page.waitForFunction(
     () => window.__appState && window.__appState.activeMenu &&
           window.__appState.activeMenu._opts &&
@@ -359,20 +340,6 @@ test('T13: ROM list shows all available ROMs', async ({ page, request }) => {
   expect(items).toContain('Mario.gb');
   expect(items).toContain('Zelda.gb');
   expect(items).toHaveLength(3);
-});
-
-// T14: ROM list ArrowDown moves selection
-test('T14: ROM list ArrowDown moves selection down', async ({ page, request }) => {
-  await setServerState(request, { authed: true, roms: ['Tetris.gb', 'Mario.gb', 'Zelda.gb'] });
-  await loadApp(page);
-
-  await menuKey(page, 'Enter'); // open ROM list
-  await page.waitForFunction(
-    () => window.__appState && window.__appState.activeMenu &&
-          window.__appState.activeMenu._opts &&
-          window.__appState.activeMenu._opts.title === 'SELECT GAME',
-    { timeout: 3000 }
-  );
 
   expect(await activeMenuSelIdx(page)).toBe(0);
   await menuKey(page, 'ArrowDown');
@@ -383,8 +350,9 @@ test('T14: ROM list ArrowDown moves selection down', async ({ page, request }) =
 
 // T15: ROM list ArrowDown wraps at end
 test('T15: ROM list ArrowDown wraps from last to first', async ({ page, request }) => {
-  await setServerState(request, { authed: true, roms: ['Tetris.gb', 'Mario.gb', 'Zelda.gb'] });
+  await setServerState(page, { authed: true, roms: ['Tetris.gb', 'Mario.gb', 'Zelda.gb'] });
   await loadApp(page);
+  await ensureMainMenu(page);
 
   await menuKey(page, 'Enter');
   await page.waitForFunction(
@@ -403,8 +371,9 @@ test('T15: ROM list ArrowDown wraps from last to first', async ({ page, request 
 
 // T16: ROM list ArrowUp from first wraps to last
 test('T16: ROM list ArrowUp from first item wraps to last', async ({ page, request }) => {
-  await setServerState(request, { authed: true, roms: ['Tetris.gb', 'Mario.gb', 'Zelda.gb'] });
+  await setServerState(page, { authed: true, roms: ['Tetris.gb', 'Mario.gb', 'Zelda.gb'] });
   await loadApp(page);
+  await ensureMainMenu(page);
 
   await menuKey(page, 'Enter');
   await page.waitForFunction(
@@ -423,8 +392,9 @@ test('T16: ROM list ArrowUp from first item wraps to last', async ({ page, reque
 
 // T17: ROM list Escape → back to main menu
 test('T17: ROM list Escape returns to main menu', async ({ page, request }) => {
-  await setServerState(request, { authed: true, roms: ['Tetris.gb'] });
+  await setServerState(page, { authed: true, roms: ['Tetris.gb'] });
   await loadApp(page);
+  await ensureMainMenu(page);
 
   await menuKey(page, 'Enter'); // open ROM list
   await page.waitForFunction(
@@ -450,8 +420,9 @@ test('T17: ROM list Escape returns to main menu', async ({ page, request }) => {
 
 // T18: ROM list Enter launches selected ROM (menu dismissed, emulator running)
 test('T18: ROM list Enter on selected ROM launches emulator', async ({ page, request }) => {
-  await setServerState(request, { authed: true, roms: ['Tetris.gb', 'Mario.gb'] });
+  await setServerState(page, { authed: true, roms: ['Tetris.gb', 'Mario.gb'] });
   await loadApp(page);
+  await ensureMainMenu(page);
 
   await menuKey(page, 'Enter'); // open ROM list
   await page.waitForFunction(
@@ -474,8 +445,9 @@ test('T18: ROM list Enter on selected ROM launches emulator', async ({ page, req
 
 // T19: ROM list tap on item launches ROM
 test('T19: ROM list tap on item launches emulator', async ({ page, request }) => {
-  await setServerState(request, { authed: true, roms: ['Tetris.gb', 'Mario.gb'] });
+  await setServerState(page, { authed: true, roms: ['Tetris.gb', 'Mario.gb'] });
   await loadApp(page);
+  await ensureMainMenu(page);
 
   await menuKey(page, 'Enter'); // open ROM list
   await page.waitForFunction(
@@ -501,8 +473,9 @@ test('T19: ROM list tap on item launches emulator', async ({ page, request }) =>
 
 // T20: Power button during game → in-game pause menu (still running, paused)
 test('T20: power button while running shows in-game pause menu', async ({ page, request }) => {
-  await setServerState(request, { authed: true, roms: ['Tetris.gb'] });
+  await setServerState(page, { authed: true, roms: ['Tetris.gb'] });
   await loadApp(page);
+  await ensureMainMenu(page);
 
   await menuKey(page, 'Enter'); // GAMES
   await page.waitForFunction(
@@ -531,8 +504,9 @@ test('T20: power button while running shows in-game pause menu', async ({ page, 
 
 // T21: Backspace key during game → in-game pause menu
 test('T21: Backspace key while running shows in-game pause menu', async ({ page, request }) => {
-  await setServerState(request, { authed: true, roms: ['Tetris.gb'] });
+  await setServerState(page, { authed: true, roms: ['Tetris.gb'] });
   await loadApp(page);
+  await ensureMainMenu(page);
 
   await menuKey(page, 'Enter'); // GAMES
   await page.waitForFunction(
@@ -560,8 +534,9 @@ test('T21: Backspace key while running shows in-game pause menu', async ({ page,
 
 // T22: Zero ROMs → error screen
 test('T22: empty ROM list shows error screen', async ({ page, request }) => {
-  await setServerState(request, { authed: true, roms: [] });
+  await setServerState(page, { authed: true, roms: [] });
   await loadApp(page);
+  await ensureMainMenu(page);
 
   await menuKey(page, 'Enter'); // PLAY
 
@@ -577,8 +552,9 @@ test('T22: empty ROM list shows error screen', async ({ page, request }) => {
 
 // T23: Error screen Escape → back to main menu
 test('T23: error screen Escape returns to main menu', async ({ page, request }) => {
-  await setServerState(request, { authed: true, roms: [] });
+  await setServerState(page, { authed: true, roms: [] });
   await loadApp(page);
+  await ensureMainMenu(page);
 
   await menuKey(page, 'Enter'); // PLAY → error screen
   await page.waitForFunction(
@@ -642,7 +618,7 @@ async function cycleLogin(page) {
 
 // T24: two full login→play→back→logout cycles verifying d-pad works after each B press
 test('T24: two full login→play→back→logout cycles without freeze', async ({ page, request }) => {
-  await setServerState(request, { authed: false, roms: ['Tetris.gb', 'Mario.gb'] });
+  await setServerState(page, { authed: false, roms: ['Tetris.gb', 'Mario.gb'] });
   await loadApp(page);
 
   // Cycle 1
@@ -672,7 +648,7 @@ test('T24: two full login→play→back→logout cycles without freeze', async (
 // verifies that activeMenu is correctly set and navigable after each transition,
 // which is the invariant that would have caught the real-world freeze.
 test('T25: two login→play→back→logout cycles — menu stays navigable throughout', async ({ page, request }) => {
-  await setServerState(request, { authed: false, roms: ['Tetris.gb', 'Mario.gb'] });
+  await setServerState(page, { authed: false, roms: ['Tetris.gb', 'Mario.gb'] });
   await loadApp(page);
 
   async function waitForItems(value) {
@@ -745,8 +721,9 @@ test('T25: two login→play→back→logout cycles — menu stays navigable thro
 
 // ── Mobile pointer-event tests ────────────────────────────────────────────────
 //
-// These simulate the actual mobile touch path: pointerdown + pointerup on
-// d-pad/action buttons, and touchend on canvas for menu item taps.
+// These simulate the actual mobile touch path: pointerdown/move/up on the
+// nipplejs D-pad zone, pointerdown/up on action buttons, and touchend on canvas
+// for menu item taps.
 // This is distinct from menuKey() which calls handleInput() directly.
 
 /** Simulate a button tap via pointerdown + pointerup on a [data-btn] element. */
@@ -757,6 +734,128 @@ async function tapButton(page, selector) {
     el.dispatchEvent(new PointerEvent('pointerdown', { bubbles: true, cancelable: true }));
     el.dispatchEvent(new PointerEvent('pointerup',   { bubbles: true, cancelable: true }));
   }, selector);
+}
+
+/** Simulate a nipplejs D-pad drag in the requested direction. */
+async function dpadGesture(page, direction, endType = 'pointerup') {
+  await page.evaluate(([dir, end]) => {
+    const zone = document.getElementById('dpadZone');
+    if (!zone) throw new Error('dpadGesture: no #dpadZone');
+
+    const rect = zone.getBoundingClientRect();
+    const centerX = rect.left + rect.width / 2;
+    const centerY = rect.top + rect.height / 2;
+    const distance = 58;
+    const offsets = {
+      up: [0, -distance],
+      down: [0, distance],
+      left: [-distance, 0],
+      right: [distance, 0],
+    };
+    const [dx, dy] = offsets[dir];
+    const pointerId = 17;
+
+    const fire = (target, type, x, y, buttons) => {
+      target.dispatchEvent(new PointerEvent(type, {
+        bubbles: true,
+        cancelable: true,
+        pointerId,
+        pointerType: 'touch',
+        isPrimary: true,
+        buttons,
+        clientX: x,
+        clientY: y,
+      }));
+    };
+
+    fire(zone, 'pointerdown', centerX, centerY, 1);
+    fire(document, 'pointermove', centerX + dx, centerY + dy, 1);
+    fire(document, end, centerX + dx, centerY + dy, 0);
+  }, [direction, endType]);
+}
+
+async function startDpadHold(page, direction, pointerId = 19) {
+  await page.evaluate(([dir, pid]) => {
+    const zone = document.getElementById('dpadZone');
+    if (!zone) throw new Error('startDpadHold: no #dpadZone');
+
+    const rect = zone.getBoundingClientRect();
+    const centerX = rect.left + rect.width / 2;
+    const centerY = rect.top + rect.height / 2;
+    const distance = 58;
+    const offsets = {
+      up: [0, -distance],
+      down: [0, distance],
+      left: [-distance, 0],
+      right: [distance, 0],
+    };
+    const [dx, dy] = offsets[dir];
+
+    const fire = (target, type, x, y, buttons) => {
+      target.dispatchEvent(new PointerEvent(type, {
+        bubbles: true,
+        cancelable: true,
+        pointerId: pid,
+        pointerType: 'touch',
+        isPrimary: true,
+        buttons,
+        clientX: x,
+        clientY: y,
+      }));
+    };
+
+    fire(zone, 'pointerdown', centerX, centerY, 1);
+    fire(document, 'pointermove', centerX + dx, centerY + dy, 1);
+  }, [direction, pointerId]);
+}
+
+async function startDpadPress(page, direction, pointerId = 21) {
+  await page.evaluate(([dir, pid]) => {
+    const zone = document.getElementById('dpadZone');
+    if (!zone) throw new Error('startDpadPress: no #dpadZone');
+
+    const rect = zone.getBoundingClientRect();
+    const centerX = rect.left + rect.width / 2;
+    const centerY = rect.top + rect.height / 2;
+    const distance = 58;
+    const offsets = {
+      up: [0, -distance],
+      down: [0, distance],
+      left: [-distance, 0],
+      right: [distance, 0],
+    };
+    const [dx, dy] = offsets[dir];
+
+    zone.dispatchEvent(new PointerEvent('pointerdown', {
+      bubbles: true,
+      cancelable: true,
+      pointerId: pid,
+      pointerType: 'touch',
+      isPrimary: true,
+      buttons: 1,
+      clientX: centerX + dx,
+      clientY: centerY + dy,
+    }));
+  }, [direction, pointerId]);
+}
+
+async function endDpadHold(page, pointerId = 19) {
+  await page.evaluate((pid) => {
+    const zone = document.getElementById('dpadZone');
+    if (!zone) throw new Error('endDpadHold: no #dpadZone');
+
+    const rect = zone.getBoundingClientRect();
+    document.dispatchEvent(new PointerEvent('pointerup', {
+      bubbles: true,
+      cancelable: true,
+      pointerId: pid,
+      pointerType: 'touch',
+      isPrimary: true,
+      buttons: 0,
+      clientX: rect.left + rect.width / 2,
+      clientY: rect.top + rect.height / 2,
+    }));
+  }, pointerId);
 }
 
 /** Simulate a canvas tap at menu canvas-space coordinates (x, y). */
@@ -787,15 +886,37 @@ async function waitForMenuTitle(page, title) {
 }
 
 async function waitForMenuItems(page, value) {
-  await page.waitForFunction(
-    (v) => window.__appState?.activeMenu?._opts?.items?.some(i => i.value === v),
-    value, { timeout: 3000 }
-  );
+  try {
+    await page.waitForFunction(
+      (v) => window.__appState?.activeMenu?._opts?.items?.some(i => i.value === v),
+      value, { timeout: 3000 }
+    );
+  } catch (err) {
+    const state = await page.evaluate(() => ({
+      href: window.location.href,
+      active: window.__appState?.activeMenu?.isActive?.() ?? null,
+      title: window.__appState?.activeMenu?._opts?.title ?? null,
+      items: window.__appState?.activeMenu?._opts?.items?.map(i => i.value) ?? [],
+      user: window.__appState?.user ?? null,
+    })).catch(e => ({ error: String(e) }));
+    throw new Error(`Timed out waiting for menu item "${value}"; state=${JSON.stringify(state)}; cause=${err}`);
+  }
+}
+
+async function ensureMainMenu(page) {
+  const items = await activeMenuItems(page);
+  if (items.includes('login')) {
+    await Promise.all([
+      page.waitForNavigation({ waitUntil: 'networkidle', timeout: 5000 }),
+      tapCanvas(page, 80, 23),
+    ]);
+  }
+  await waitForMenuItems(page, 'games');
 }
 
 // T26: mobile — tap login → main menu via canvas tap
 test('T26: mobile tap on login item navigates to main menu', async ({ page, request }) => {
-  await setServerState(request, { authed: false, roms: ['Tetris.gb'] });
+  await setServerState(page, { authed: false, roms: ['Tetris.gb'] });
   await loadApp(page);
   await waitForMenuItems(page, 'login');
 
@@ -811,22 +932,73 @@ test('T26: mobile tap on login item navigates to main menu', async ({ page, requ
 
 // T27: mobile — d-pad down on main menu moves selection
 test('T27: mobile d-pad down moves main menu selection', async ({ page, request }) => {
-  await setServerState(request, { authed: true, roms: ['Tetris.gb'] });
+  await setServerState(page, { authed: true, roms: ['Tetris.gb'] });
   await loadApp(page);
-  await waitForMenuItems(page, 'games');
+  await ensureMainMenu(page);
 
   expect(await activeMenuSelIdx(page)).toBe(0);
-  await tapButton(page, '[data-btn="3"]'); // Down
+  await dpadGesture(page, 'down');
   expect(await activeMenuSelIdx(page)).toBe(1);
-  await tapButton(page, '[data-btn="2"]'); // Up
+  await dpadGesture(page, 'up');
   expect(await activeMenuSelIdx(page)).toBe(0);
+});
+
+test('T27b: holding mobile d-pad down repeats menu selection', async ({ page, request }) => {
+  await setServerState(page, { authed: true, roms: ['A.gb', 'B.gb', 'C.gb', 'D.gb', 'E.gb', 'F.gb'] });
+  await loadApp(page);
+  await ensureMainMenu(page);
+
+  await tapButton(page, '[data-btn="4"]');
+  await waitForMenuTitle(page, 'SELECT GAME');
+  expect(await activeMenuSelIdx(page)).toBe(0);
+
+  await startDpadHold(page, 'down');
+  try {
+    await expect.poll(() => activeMenuSelIdx(page), { timeout: 1500 }).toBeGreaterThan(1);
+  } finally {
+    await endDpadHold(page);
+  }
+});
+
+test('T27d: holding lower d-pad zone without dragging repeats menu selection', async ({ page, request }) => {
+  await setServerState(page, { authed: true, roms: ['A.gb', 'B.gb', 'C.gb', 'D.gb', 'E.gb', 'F.gb'] });
+  await loadApp(page);
+  await ensureMainMenu(page);
+
+  await tapButton(page, '[data-btn="4"]');
+  await waitForMenuTitle(page, 'SELECT GAME');
+  expect(await activeMenuSelIdx(page)).toBe(0);
+
+  await startDpadPress(page, 'down');
+  try {
+    await expect.poll(() => activeMenuSelIdx(page), { timeout: 1500 }).toBeGreaterThan(1);
+  } finally {
+    await endDpadHold(page, 21);
+  }
+});
+
+test('T27c: holding keyboard ArrowDown repeats menu selection', async ({ page, request }) => {
+  await setServerState(page, { authed: true, roms: ['A.gb', 'B.gb', 'C.gb', 'D.gb', 'E.gb', 'F.gb'] });
+  await loadApp(page);
+  await ensureMainMenu(page);
+
+  await tapButton(page, '[data-btn="4"]');
+  await waitForMenuTitle(page, 'SELECT GAME');
+  expect(await activeMenuSelIdx(page)).toBe(0);
+
+  await page.keyboard.down('ArrowDown');
+  try {
+    await expect.poll(() => activeMenuSelIdx(page), { timeout: 1500 }).toBeGreaterThan(1);
+  } finally {
+    await page.keyboard.up('ArrowDown');
+  }
 });
 
 // T28: mobile — A button on PLAY opens ROM list
 test('T28: mobile A button on PLAY opens ROM list', async ({ page, request }) => {
-  await setServerState(request, { authed: true, roms: ['Tetris.gb', 'Mario.gb'] });
+  await setServerState(page, { authed: true, roms: ['Tetris.gb', 'Mario.gb'] });
   await loadApp(page);
-  await waitForMenuItems(page, 'games');
+  await ensureMainMenu(page);
 
   await tapButton(page, '[data-btn="4"]'); // A
   await waitForMenuTitle(page, 'SELECT GAME');
@@ -834,9 +1006,9 @@ test('T28: mobile A button on PLAY opens ROM list', async ({ page, request }) =>
 
 // T29: mobile — B button on ROM list returns to main menu
 test('T29: mobile B button on ROM list returns to main menu', async ({ page, request }) => {
-  await setServerState(request, { authed: true, roms: ['Tetris.gb', 'Mario.gb'] });
+  await setServerState(page, { authed: true, roms: ['Tetris.gb', 'Mario.gb'] });
   await loadApp(page);
-  await waitForMenuItems(page, 'games');
+  await ensureMainMenu(page);
 
   await tapButton(page, '[data-btn="4"]'); // A → ROM list
   await waitForMenuTitle(page, 'SELECT GAME');
@@ -848,9 +1020,9 @@ test('T29: mobile B button on ROM list returns to main menu', async ({ page, req
 // T30: mobile — d-pad still works on main menu after returning from ROM list via B
 // This is the regression test for the reported freeze.
 test('T30: mobile d-pad navigable on main menu after B back from ROM list', async ({ page, request }) => {
-  await setServerState(request, { authed: true, roms: ['Tetris.gb', 'Mario.gb'] });
+  await setServerState(page, { authed: true, roms: ['Tetris.gb', 'Mario.gb'] });
   await loadApp(page);
-  await waitForMenuItems(page, 'games');
+  await ensureMainMenu(page);
 
   // Go into ROM list and back
   await tapButton(page, '[data-btn="4"]'); // A → ROM list
@@ -860,16 +1032,16 @@ test('T30: mobile d-pad navigable on main menu after B back from ROM list', asyn
 
   // D-pad must still work — this is what froze on mobile
   expect(await activeMenuSelIdx(page)).toBe(0);
-  await tapButton(page, '[data-btn="3"]'); // Down
+  await dpadGesture(page, 'down');
   expect(await activeMenuSelIdx(page)).toBe(1);
-  await tapButton(page, '[data-btn="2"]'); // Up
+  await dpadGesture(page, 'up');
   expect(await activeMenuSelIdx(page)).toBe(0);
 });
 
 // T31: mobile — full cycle: login(tap) → play(A) → ROM list → B → logout(A) → login
 // Two cycles to catch any state accumulation bug.
 test('T31: mobile two full cycles without freeze', async ({ page, request }) => {
-  await setServerState(request, { authed: false, roms: ['Tetris.gb', 'Mario.gb'] });
+  await setServerState(page, { authed: false, roms: ['Tetris.gb', 'Mario.gb'] });
   await loadApp(page);
 
   for (let cycle = 1; cycle <= 2; cycle++) {
@@ -883,9 +1055,9 @@ test('T31: mobile two full cycles without freeze', async ({ page, request }) => 
 
     // D-pad works on main menu
     expect(await activeMenuSelIdx(page)).toBe(0);
-    await tapButton(page, '[data-btn="3"]'); // Down
+    await dpadGesture(page, 'down');
     expect(await activeMenuSelIdx(page)).toBe(1);
-    await tapButton(page, '[data-btn="2"]'); // Up
+    await dpadGesture(page, 'up');
     expect(await activeMenuSelIdx(page)).toBe(0);
 
     // A → ROM list
@@ -893,9 +1065,9 @@ test('T31: mobile two full cycles without freeze', async ({ page, request }) => 
     await waitForMenuTitle(page, 'SELECT GAME');
 
     // D-pad works on ROM list
-    await tapButton(page, '[data-btn="3"]'); // Down
+    await dpadGesture(page, 'down');
     expect(await activeMenuSelIdx(page)).toBe(1);
-    await tapButton(page, '[data-btn="2"]'); // Up
+    await dpadGesture(page, 'up');
     expect(await activeMenuSelIdx(page)).toBe(0);
 
     // B → back to main menu
@@ -904,9 +1076,9 @@ test('T31: mobile two full cycles without freeze', async ({ page, request }) => 
 
     // D-pad still works after returning — the bug
     expect(await activeMenuSelIdx(page)).toBe(0);
-    await tapButton(page, '[data-btn="3"]');
+    await dpadGesture(page, 'down');
     expect(await activeMenuSelIdx(page)).toBe(1); // would be 0 if frozen
-    await tapButton(page, '[data-btn="2"]');
+    await dpadGesture(page, 'up');
     expect(await activeMenuSelIdx(page)).toBe(0);
 
     // Logout
@@ -921,9 +1093,9 @@ test('T31: mobile two full cycles without freeze', async ({ page, request }) => 
 // T32: mobile canvas tap fires both touch AND pointer events (real browser behavior)
 // If pointer events on canvas interfere with sendButton, this catches it.
 test('T32: canvas tap fires touch+pointer — d-pad still works after', async ({ page, request }) => {
-  await setServerState(request, { authed: true, roms: ['Tetris.gb', 'Mario.gb'] });
+  await setServerState(page, { authed: true, roms: ['Tetris.gb', 'Mario.gb'] });
   await loadApp(page);
-  await waitForMenuItems(page, 'games');
+  await ensureMainMenu(page);
 
   // A → ROM list via canvas tap (fires both touch and pointer events like real mobile)
   await page.evaluate(() => {
@@ -951,16 +1123,16 @@ test('T32: canvas tap fires touch+pointer — d-pad still works after', async ({
 
   // D-pad must work
   expect(await activeMenuSelIdx(page)).toBe(0);
-  await tapButton(page, '[data-btn="3"]');
+  await dpadGesture(page, 'down');
   expect(await activeMenuSelIdx(page)).toBe(1);
 });
 
 // T33: regression — touch starts on canvas, ends outside (simulates d-pad tap
 // with finger migrating from canvas area). Must NOT trigger menu tap.
 test('T33: touch ending outside canvas bounds does not trigger menu selection', async ({ page, request }) => {
-  await setServerState(request, { authed: true, roms: ['Tetris.gb', 'Mario.gb'] });
+  await setServerState(page, { authed: true, roms: ['Tetris.gb', 'Mario.gb'] });
   await loadApp(page);
-  await waitForMenuItems(page, 'games');
+  await ensureMainMenu(page);
 
   // Touch starts on canvas (inside), ends at a position outside canvas bounds
   const triggered = await page.evaluate(() => {
@@ -996,22 +1168,22 @@ test('T33: touch ending outside canvas bounds does not trigger menu selection', 
 
 // T34: B button on main menu must not dismiss it (the confirmed freeze bug)
 test('T34: B button on main menu does not hide menu', async ({ page, request }) => {
-  await setServerState(request, { authed: true, roms: ['Tetris.gb'] });
+  await setServerState(page, { authed: true, roms: ['Tetris.gb'] });
   await loadApp(page);
-  await waitForMenuItems(page, 'games');
+  await ensureMainMenu(page);
 
   await tapButton(page, '[data-btn="5"]'); // B on main menu
 
   expect(await hasActiveMenu(page)).toBe(true);
   expect(await activeMenuTitle(page)).toBe('RUSTYBOY');
   // D-pad still works
-  await tapButton(page, '[data-btn="3"]'); // Down
+  await dpadGesture(page, 'down');
   expect(await activeMenuSelIdx(page)).toBe(1);
 });
 
 // T35: B button on login screen does not hide menu
 test('T35: B button on login screen does not hide menu', async ({ page, request }) => {
-  await setServerState(request, { authed: false, roms: [] });
+  await setServerState(page, { authed: false, roms: [] });
   await loadApp(page);
   await waitForMenuItems(page, 'login');
 
@@ -1025,9 +1197,9 @@ test('T35: B button on login screen does not hide menu', async ({ page, request 
 
 /** Helper: launch a game and wait until running. */
 async function launchGame(page, request) {
-  await setServerState(request, { authed: true, roms: ['Tetris.gb'], saveStates: [] });
+  await setServerState(page, { authed: true, roms: ['Tetris.gb'], saveStates: [] });
   await loadApp(page);
-  await waitForMenuItems(page, 'games');
+  await ensureMainMenu(page);
   await menuKey(page, 'Enter'); // GAMES → ROM list
   await page.waitForFunction(
     () => window.__appState?.activeMenu?._opts?.title === 'SELECT GAME',
@@ -1205,7 +1377,7 @@ test('T38: pause menu opens correctly after multiple open/close cycles', async (
 // T40: Select button on LOAD STATE screen deletes the selected save slot
 // After deletion the slot is removed from the list; if list becomes empty, go back.
 test('T40: Select on load state screen deletes selected save slot', async ({ page, request }) => {
-  await setServerState(request, {
+  await setServerState(page, {
     authed: true,
     roms: ['Tetris.gb'],
     saveStates: [
@@ -1214,7 +1386,7 @@ test('T40: Select on load state screen deletes selected save slot', async ({ pag
     ],
   });
   await loadApp(page);
-  await waitForMenuItems(page, 'games');
+  await ensureMainMenu(page);
 
   // Navigate to GAMES (may not be index 0 if CONTINUE is present)
   await page.waitForFunction(
@@ -1270,13 +1442,13 @@ test('T40: Select on load state screen deletes selected save slot', async ({ pag
 test('T43: marquee RAF loop stops after power-button resume on marquee-title game', async ({ page, request }) => {
   // Use a long ROM name that will overflow the 160px header and trigger marquee.
   const longRomName = 'A Very Long Game Title That Will Overflow The Header Area.gb';
-  await setServerState(request, {
+  await setServerState(page, {
     authed: true,
     roms: [longRomName],
     saveStates: [],
   });
   await loadApp(page);
-  await waitForMenuItems(page, 'games');
+  await ensureMainMenu(page);
 
   // Navigate to GAMES → select the long-named ROM
   const mainItems = await activeMenuItems(page);
@@ -1324,7 +1496,7 @@ test('T43: marquee RAF loop stops after power-button resume on marquee-title gam
 
 // T41: Deleting the last save slot on the LOAD STATE screen goes back to pause menu
 test('T41: deleting last save slot returns to pause menu', async ({ page, request }) => {
-  await setServerState(request, {
+  await setServerState(page, {
     authed: true,
     roms: ['Tetris.gb'],
     saveStates: [
@@ -1332,7 +1504,7 @@ test('T41: deleting last save slot returns to pause menu', async ({ page, reques
     ],
   });
   await loadApp(page);
-  await waitForMenuItems(page, 'games');
+  await ensureMainMenu(page);
 
   // Navigate to GAMES
   await page.waitForFunction(


### PR DESCRIPTION
## Summary
- replace the web D-pad button grid with a nipplejs joystick, including diagonal support
- add robust release/reset handling so lost pointer capture and page aborts cannot leave the joystick or emulator stuck
- add Up/Down hold-repeat in menus for both on-screen D-pad and keyboard
- harden the Playwright e2e harness and add regression coverage for joystick release, menu repeat, and mobile traversal

## Tests
- npm run typecheck
- npm run build
- npm test (62 passed)